### PR TITLE
[codex] Keep bottom navigation fixed on iPhone

### DIFF
--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -23,14 +23,12 @@ body { margin: 0; background: var(--cream); color: var(--navy); }
 button, input { font: inherit; }
 ion-app {
   background: var(--cream);
-  overflow-y: auto;
-  overscroll-behavior-y: contain;
-  touch-action: pan-y;
-  -webkit-overflow-scrolling: touch;
+  overflow: hidden;
 }
 ion-button { --border-radius: 17px; min-height: 52px; font-weight: 800; text-transform: none; letter-spacing: 0; }
 
 .page, .content-screen { min-height: 100dvh; max-width: 640px; margin: 0 auto; padding: calc(20px + env(safe-area-inset-top)) 22px calc(100px + env(safe-area-inset-bottom)); background: var(--cream); }
+.page { height: 100dvh; overflow-y: auto; overscroll-behavior-y: contain; touch-action: pan-y; -webkit-overflow-scrolling: touch; }
 .page h1, .screen-header h1 { margin: 5px 0 8px; font-size: clamp(29px, 8vw, 38px); line-height: 1.08; font-weight: 900; color: var(--navy); }
 .page h2, .content-screen h2 { margin: 0; font-size: 20px; font-weight: 900; }
 .page p, .content-screen p { color: var(--muted); line-height: 1.5; }
@@ -67,7 +65,8 @@ ion-button { --border-radius: 17px; min-height: 52px; font-weight: 800; text-tra
 .consent-row { display: flex; align-items: flex-start; gap: 12px; color: var(--navy); line-height: 1.4; font-size: 14px; }
 .form-error { color: var(--coral) !important; font-weight: 800; font-size: 13px; }
 
-.app-shell { min-height: 100dvh; background: var(--cream); }
+.app-shell { position: relative; height: 100dvh; overflow: hidden; background: var(--cream); }
+.app-shell > .content-screen { height: 100%; min-height: 0; overflow-y: auto; overscroll-behavior-y: contain; touch-action: pan-y; -webkit-overflow-scrolling: touch; }
 .screen-header { display: flex; align-items: center; justify-content: space-between; margin-bottom: 22px; }
 .screen-header small { color: var(--muted); }
 .screen-header p { margin: 0; }
@@ -103,7 +102,7 @@ ion-button { --border-radius: 17px; min-height: 52px; font-weight: 800; text-tra
 .week-card { margin-top: 16px; }
 .week-card progress { width: 100%; height: 14px; accent-color: var(--teal); }
 .history-list { display: grid; gap: 0; }
-.bottom-nav { position: fixed; z-index: 10; bottom: 0; left: 0; right: 0; max-width: 640px; margin: auto; display: flex; justify-content: space-around; padding: 9px 12px calc(8px + env(safe-area-inset-bottom)); background: rgba(255,255,255,.96); border-top: 1px solid var(--line); backdrop-filter: blur(16px); }
+.bottom-nav { position: absolute; z-index: 10; bottom: 0; left: 0; right: 0; max-width: 640px; margin: auto; display: flex; justify-content: space-around; padding: 9px 12px calc(8px + env(safe-area-inset-bottom)); background: rgba(255,255,255,.96); border-top: 1px solid var(--line); backdrop-filter: blur(16px); }
 .bottom-nav button { flex: 1; border: 0; background: transparent; color: #78858d; display: flex; flex-direction: column; align-items: center; gap: 3px; font-size: 10px; font-weight: 800; }
 .bottom-nav button span { font-size: 21px; }
 .bottom-nav button.active { color: var(--teal); }


### PR DESCRIPTION
## What changed

- moves vertical scrolling from `ion-app` to the active screen content
- keeps the bottom navigation outside the scroll container
- anchors navigation to the app viewport while preserving iOS safe-area padding
- keeps standalone welcome and linking screens independently scrollable

## Root cause

Making `ion-app` scrollable fixed long pages, but on iOS it also made the fixed bottom navigation move with that scrolling surface.

## Validation

- `npm test` (5 tests passed)
- `npm run build`
