### PR TITLE
[codex] Let parents regenerate child link codes

### DIFF
--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -104,6 +104,54 @@ export const joinFamily = onCall({ region, cors, enforceAppCheck: true }, async 
   return { familyId };
 });
 
+export const regenerateLinkCode = onCall({ region, cors, enforceAppCheck: true }, async (request) => {
+  const uid = requireUid(request.auth);
+  const familyId = String(request.data?.familyId ?? '');
+  const userRef = db.collection('users').doc(uid);
+  const familyRef = db.collection('families').doc(familyId);
+  const [profile, family, links] = await Promise.all([
+    userRef.get(),
+    familyRef.get(),
+    db.collection('linkCodes').where('familyId', '==', familyId).get(),
+  ]);
+
+  if (!profile.exists || profile.data()?.familyId !== familyId || profile.data()?.role !== 'parent') {
+    throw new HttpsError('permission-denied', 'Only the parent can generate a new linking code.');
+  }
+  if (!family.exists || family.data()?.members?.[uid] !== 'parent') {
+    throw new HttpsError('not-found', 'The family could not be found.');
+  }
+
+  const childIds = Object.entries((family.data()?.members ?? {}) as Record<string, string>)
+    .filter(([, role]) => role === 'child')
+    .map(([memberId]) => memberId);
+  const code = createLinkCode();
+  const now = new Date();
+  const expiresAt = new Date(now.getTime() + 24 * 60 * 60 * 1000);
+  const linkRef = db.collection('linkCodes').doc(hashLinkCode(code));
+  const familyUpdate: Record<string, unknown> = { updatedAt: FieldValue.serverTimestamp() };
+  childIds.forEach((childId) => { familyUpdate[`members.${childId}`] = FieldValue.delete(); });
+
+  const batch = db.batch();
+  links.docs.forEach((link) => batch.delete(link.ref));
+  childIds.forEach((childId) => batch.delete(db.collection('users').doc(childId)));
+  batch.update(familyRef, familyUpdate);
+  batch.update(userRef, {
+    linkingCode: code,
+    linkingCodeExpiresAt: expiresAt.toISOString(),
+    updatedAt: FieldValue.serverTimestamp(),
+  });
+  batch.create(linkRef, {
+    familyId,
+    createdBy: uid,
+    expiresAt: expiresAt.toISOString(),
+    consumedAt: null,
+  });
+  await batch.commit();
+
+  return { code, expiresAt: expiresAt.toISOString() };
+});
+
 export const updatePlan = onCall({ region, cors, enforceAppCheck: true }, async (request) => {
   const uid = requireUid(request.auth);
   const familyId = String(request.data?.familyId ?? '');

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -95,7 +95,7 @@ export function App() {
       : tab === 'settings'
         ? <SettingsScreen reset={() => { void reset(); }} t={t} />
         : role === 'parent'
-          ? <ParentDashboard state={state} t={t} />
+          ? <ParentDashboard state={state} regenerateCode={async () => { await repository.regenerateLinkCode(); sync(); }} t={t} />
           : <ChildDashboard state={state} active={repository.activeSession()} start={() => setRoute('camera')} t={t} />;
     content = <div className="app-shell">{screen}<BottomNav tab={tab} role={role} onChange={setTab} t={t} /></div>;
   }

--- a/src/screens/ParentDashboard.tsx
+++ b/src/screens/ParentDashboard.tsx
@@ -1,11 +1,23 @@
+import { useState } from 'react';
 import { adherenceSummary } from '../domain/adherence';
 import type { AppState } from '../domain/models';
 import type { MessageKey } from '../services/i18n';
 import { StatusPill } from '../components/StatusPill';
 
-export function ParentDashboard({ state, t }: { state: AppState; t: (key: MessageKey) => string }) {
+export function ParentDashboard({ state, regenerateCode, t }: { state: AppState; regenerateCode: () => Promise<void>; t: (key: MessageKey) => string }) {
   const summary = adherenceSummary(state.events);
   const attention = state.events.filter((event) => ['uncertain', 'missed', 'expired', 'not_detected'].includes(event.status));
+  const [regenerating, setRegenerating] = useState(false);
+  const [codeError, setCodeError] = useState(false);
+
+  const regenerate = async () => {
+    if (!window.confirm(t('regenerateCodeConfirm'))) return;
+    setCodeError(false);
+    setRegenerating(true);
+    try { await regenerateCode(); }
+    catch { setCodeError(true); }
+    finally { setRegenerating(false); }
+  };
   return (
     <div className="content-screen">
       <header className="screen-header">
@@ -28,6 +40,10 @@ export function ParentDashboard({ state, t }: { state: AppState; t: (key: Messag
           <small>{t('childLinkCode')}</small>
           <strong>{state.family.linkingCode}</strong>
           <span>{t('childLinkCodeHint')}</span>
+          <button className="regenerate-code" disabled={regenerating} onClick={() => { void regenerate(); }}>
+            {regenerating ? t('regeneratingCode') : t('regenerateCode')}
+          </button>
+          {codeError && <span className="form-error">{t('regenerateCodeError')}</span>}
         </section>
       )}
       <div className="section-heading"><h2>{t('attention')}</h2><span>{attention.length}</span></div>

--- a/src/services/contracts.ts
+++ b/src/services/contracts.ts
@@ -8,6 +8,7 @@ export interface AppRepository {
   setLocale(locale: Locale): Promise<void>;
   linkParent(childName: string): Promise<void>;
   linkChild(code: string): Promise<void>;
+  regenerateLinkCode(): Promise<void>;
   savePlan(plan: MonitoringPlan): Promise<void>;
   activeSession(): VerificationEvent | undefined;
   submitCapture(sessionId: string, capturedAt: Date): Promise<VerificationEvent>;

--- a/src/services/demoRepository.test.ts
+++ b/src/services/demoRepository.test.ts
@@ -20,4 +20,14 @@ describe('DemoRepository compatibility', () => {
     const repository = new DemoRepository();
     await expect(repository.linkChild('ZD-0000')).rejects.toThrow('invalid_code');
   });
+
+  test('generates a fresh six-digit child linking code', async () => {
+    const repository = new DemoRepository();
+    const previousCode = repository.snapshot().family.linkingCode;
+
+    await repository.regenerateLinkCode();
+
+    expect(repository.snapshot().family.linkingCode).toMatch(/^ZD-\d{6}$/);
+    expect(repository.snapshot().family.linkingCode).not.toBe(previousCode);
+  });
 });

--- a/src/services/demoRepository.ts
+++ b/src/services/demoRepository.ts
@@ -120,6 +120,11 @@ export class DemoRepository implements AppRepository {
     this.persist();
   }
 
+  async regenerateLinkCode() {
+    this.state.family.linkingCode = `ZD-${Math.floor(100000 + Math.random() * 900000)}`;
+    this.persist();
+  }
+
   async savePlan(plan: MonitoringPlan) {
     this.state.plan = structuredClone(plan);
     this.persist();

--- a/src/services/firebaseRepository.ts
+++ b/src/services/firebaseRepository.ts
@@ -105,6 +105,14 @@ export class FirebaseRepository implements AppRepository {
     await this.attachFamily(result.data.familyId, 'child');
   }
 
+  async regenerateLinkCode() {
+    if (!this.state.family.id || this.state.role !== 'parent') throw new Error('permission_denied');
+    const regenerateLinkCode = httpsCallable<{ familyId: string }, { code: string }>(this.services.functions, 'regenerateLinkCode');
+    const result = await regenerateLinkCode({ familyId: this.state.family.id });
+    this.state.family.linkingCode = result.data.code;
+    this.emit();
+  }
+
   async savePlan(plan: MonitoringPlan) {
     if (!this.state.family.id || this.state.role !== 'parent') throw new Error('permission_denied');
     const updatePlan = httpsCallable<{ familyId: string; plan: MonitoringPlan }, void>(this.services.functions, 'updatePlan');

--- a/src/services/i18n.ts
+++ b/src/services/i18n.ts
@@ -36,6 +36,9 @@ const messages = {
     resetConfirm: 'Reset this account? A parent reset also deletes the current family and its links.',
     unclearResult: 'We could not get a clear result. Better light and a steady photo may help.',
     childLinkCode: 'Child linking code', childLinkCodeHint: 'Enter this code on the child’s phone. It expires after 24 hours.',
+    regenerateCode: 'Generate a new code', regeneratingCode: 'Generating…',
+    regenerateCodeConfirm: 'Generate a new code? The current code and the previously linked child device will stop working. Family history and settings will be kept.',
+    regenerateCodeError: 'The new code could not be generated. Please try again.',
   },
   fr: {
     tagline: 'Le suivi intelligent de votre traitement',
@@ -72,6 +75,9 @@ const messages = {
     resetConfirm: 'Réinitialiser ce compte ? Pour un parent, cela supprime aussi la famille actuelle et ses liaisons.',
     unclearResult: 'Le résultat n’est pas assez clair. Une meilleure lumière et une photo stable peuvent aider.',
     childLinkCode: 'Code de liaison enfant', childLinkCodeHint: 'Saisis ce code sur le téléphone de l’enfant. Il expire après 24 heures.',
+    regenerateCode: 'Générer un nouveau code', regeneratingCode: 'Génération…',
+    regenerateCodeConfirm: 'Générer un nouveau code ? Le code actuel et l’ancien appareil Enfant ne fonctionneront plus. L’historique et les réglages seront conservés.',
+    regenerateCodeError: 'Le nouveau code n’a pas pu être généré. Réessaie.',
   },
 } as const;
 

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -62,6 +62,8 @@ ion-button { --border-radius: 17px; min-height: 52px; font-weight: 800; text-tra
 .code-box { padding: 15px; background: #f1f7f5; border-radius: 17px; display: flex; flex-direction: column; }
 .code-box strong { color: var(--teal); font-size: 25px; letter-spacing: 2px; margin: 3px 0; }
 .code-box span, .code-box small { font-size: 12px; color: var(--muted); }
+.regenerate-code { margin-top: 12px; padding: 10px 12px; border: 1px solid var(--teal); border-radius: 13px; background: transparent; color: var(--teal); font-weight: 900; }
+.regenerate-code:disabled { opacity: .55; }
 .consent-row { display: flex; align-items: flex-start; gap: 12px; color: var(--navy); line-height: 1.4; font-size: 14px; }
 .form-error { color: var(--coral) !important; font-weight: 800; font-size: 13px; }
 


### PR DESCRIPTION
## What changed

- adds a parent-only callable function to generate a fresh 24-hour child linking code
- invalidates all previous codes for the family
- revokes the previously linked child device while preserving the family, plan, checks, and history
- adds a confirmed **Generate a new code** action to the Parent dashboard
- supports the same behavior in local demo mode

## Why

After resetting or replacing the child device, the original single-use code could not be reused. Parents had to delete and recreate the whole family, including re-entering the child name.

## Validation

- frontend: `npm test` (6 tests passed)
- frontend: `npm run build`
- functions: `npm test` (3 tests passed)
- `regenerateLinkCode` deployed successfully to `europe-west1`
