### PR TITLE
[codex] Show time in check history

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -91,7 +91,7 @@ export function App() {
   } else {
     const role = state.role ?? 'child';
     const screen = tab === 'history'
-      ? <HistoryScreen events={state.events} t={t} />
+      ? <HistoryScreen events={state.events} locale={state.locale} t={t} />
       : tab === 'settings'
         ? <SettingsScreen reset={() => { void reset(); }} t={t} />
         : role === 'parent'

--- a/src/screens/HistoryScreen.tsx
+++ b/src/screens/HistoryScreen.tsx
@@ -1,9 +1,13 @@
-import type { VerificationEvent } from '../domain/models';
+import type { Locale, VerificationEvent } from '../domain/models';
 import type { MessageKey } from '../services/i18n';
 import { StatusPill } from '../components/StatusPill';
 
-export function HistoryScreen({ events, t }: { events: VerificationEvent[]; t: (key: MessageKey) => string }) {
+export function HistoryScreen({ events, locale, t }: { events: VerificationEvent[]; locale: Locale; t: (key: MessageKey) => string }) {
   const closed = events.filter((event) => event.status !== 'pending' && event.status !== 'analyzing');
+  const formatDateTime = (value: string) => new Intl.DateTimeFormat(locale === 'fr' ? 'fr-FR' : 'en-US', {
+    dateStyle: 'short',
+    timeStyle: 'short',
+  }).format(new Date(value));
   return (
     <div className="content-screen">
       <header className="screen-header"><div><small>{t('progress')}</small><h1>{t('history')}</h1><p>{t('historyHint')}</p></div></header>
@@ -11,7 +15,7 @@ export function HistoryScreen({ events, t }: { events: VerificationEvent[]; t: (
         {closed.map((event) => (
           <section className="card history-row" key={event.id}>
             <div className="history-icon">◎</div>
-            <div><strong>{new Date(event.requestedAt).toLocaleDateString()}</strong><small>{event.imageQuality ? `${t('imageQuality')} ${Math.round(event.imageQuality * 100)}%` : ''}</small></div>
+            <div><strong>{formatDateTime(event.requestedAt)}</strong><small>{event.imageQuality ? `${t('imageQuality')} ${Math.round(event.imageQuality * 100)}%` : ''}</small></div>
             <StatusPill status={event.status} t={t} />
           </section>
         ))}


### PR DESCRIPTION
## What changed

- displays both date and local time for every completed check in History
- formats timestamps using the language selected in Zadiag (`fr-FR` or `en-US`)

## Why

The date alone was not precise enough to distinguish multiple checks completed on the same day.

## Validation

- `npm test` (7 tests passed)
- `npm run build`
