### PR TITLE
[codex] Activate PWA updates immediately

### DIFF
--- a/src/sw.ts
+++ b/src/sw.ts
@@ -8,6 +8,14 @@ declare let self: ServiceWorkerGlobalScope & {
 cleanupOutdatedCaches();
 precacheAndRoute(self.__WB_MANIFEST);
 
+self.addEventListener('install', () => {
+  void self.skipWaiting();
+});
+
+self.addEventListener('activate', (event: ExtendableEvent) => {
+  event.waitUntil(self.clients.claim());
+});
+
 self.addEventListener('push', (event: PushEvent) => {
   const payload = event.data?.json() as { sessionId?: string; title?: string; body?: string } | undefined;
   event.waitUntil(


### PR DESCRIPTION
## What changed

- activate newly installed service workers immediately
- claim existing PWA windows as soon as the update activates

## Root cause

The installed iPhone PWA could continue running the pre-Web-Push service worker and cached application bundle. Firebase logs confirmed parent requests were received but the child device never called `savePushSubscription`.

## Impact

Installed devices will pick up the notification-enabled application without waiting indefinitely for the old service worker lifecycle to finish.

## Validation

- `npm test` (7 tests)
- `npm run build`
