### PR TITLE
[codex] Harden check submission and child revocation

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -10,11 +10,6 @@ service cloud.firestore {
         && get(/databases/$(database)/documents/families/$(familyId)).data.members[request.auth.uid] in ['parent', 'child'];
     }
 
-    function childMember(familyId) {
-      return signedIn()
-        && get(/databases/$(database)/documents/families/$(familyId)).data.members[request.auth.uid] == 'child';
-    }
-
     match /users/{userId} {
       allow read: if signedIn() && request.auth.uid == userId;
       allow write: if false;
@@ -26,11 +21,7 @@ service cloud.firestore {
 
       match /checks/{checkId} {
         allow read: if familyMember(familyId);
-        allow create, delete: if false;
-        allow update: if childMember(familyId)
-          && resource.data.status == 'pending'
-          && request.resource.data.status == 'analyzing'
-          && request.resource.data.diff(resource.data).affectedKeys().hasOnly(['status', 'capturedAt']);
+        allow create, update, delete: if false;
       }
     }
 

--- a/functions/src/helpers.test.ts
+++ b/functions/src/helpers.test.ts
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
-import { assertChildName, createLinkCode, hashLinkCode, normalizeLinkCode } from './helpers.js';
+import { assertChildName, createLinkCode, hashLinkCode, isFreshCheckSubmission, normalizeLinkCode } from './helpers.js';
 
 test('normalizes and hashes codes consistently', () => {
   assert.equal(normalizeLinkCode(' zd-123456 '), 'ZD-123456');
@@ -14,4 +14,19 @@ test('creates a non-ambiguous code shape', () => {
 test('validates child names', () => {
   assert.equal(assertChildName(' Maya '), 'Maya');
   assert.throws(() => assertChildName(''));
+});
+
+test('accepts only fresh pending check submissions', () => {
+  const now = Date.parse('2026-07-02T08:00:00.000Z');
+  const pending = {
+    status: 'pending',
+    requestedAt: '2026-07-02T07:55:00.000Z',
+    expiresAt: '2026-07-02T08:05:00.000Z',
+  };
+  assert.equal(isFreshCheckSubmission(pending, '2026-07-02T07:59:59.000Z', now), true);
+  assert.equal(isFreshCheckSubmission({ ...pending, status: 'detected' }, '2026-07-02T07:59:59.000Z', now), false);
+  assert.equal(isFreshCheckSubmission({ ...pending, status: 'analyzing', capturedAt: '2026-07-02T07:59:00.000Z' }, '2026-07-02T07:59:00.000Z', now), true);
+  assert.equal(isFreshCheckSubmission({ ...pending, expiresAt: '2026-07-02T07:59:00.000Z' }, '2026-07-02T07:58:00.000Z', now), false);
+  assert.equal(isFreshCheckSubmission(pending, '2026-07-02T08:01:00.000Z', now), false);
+  assert.equal(isFreshCheckSubmission({ ...pending, capturedAt: '2026-07-02T07:58:00.000Z' }, '2026-07-02T07:59:00.000Z', now), false);
 });

--- a/functions/src/helpers.ts
+++ b/functions/src/helpers.ts
@@ -15,3 +15,22 @@ export const assertChildName = (value: unknown) => {
   if (childName.length < 1 || childName.length > 40) throw new Error('invalid_child_name');
   return childName;
 };
+
+export const isFreshCheckSubmission = (
+  check: { status?: unknown; requestedAt?: unknown; expiresAt?: unknown; capturedAt?: unknown },
+  capturedAt: unknown,
+  now = Date.now(),
+) => {
+  const requestedAtMs = Date.parse(String(check.requestedAt ?? ''));
+  const expiresAtMs = Date.parse(String(check.expiresAt ?? ''));
+  const capturedAtMs = Date.parse(String(capturedAt ?? ''));
+  const isNewSubmission = check.status === 'pending' && !check.capturedAt;
+  const isLegacySubmission = check.status === 'analyzing' && String(check.capturedAt) === String(capturedAt);
+  return (isNewSubmission || isLegacySubmission)
+    && Number.isFinite(requestedAtMs)
+    && Number.isFinite(expiresAtMs)
+    && Number.isFinite(capturedAtMs)
+    && capturedAtMs >= requestedAtMs
+    && capturedAtMs <= now + 30_000
+    && now <= expiresAtMs;
+};

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -3,7 +3,7 @@ import { FieldValue, getFirestore } from 'firebase-admin/firestore';
 import { HttpsError, onCall } from 'firebase-functions/v2/https';
 import { defineSecret } from 'firebase-functions/params';
 import webpush, { type PushSubscription } from 'web-push';
-import { assertChildName, createLinkCode, createRecoveryCode, hashLinkCode, normalizeLinkCode } from './helpers.js';
+import { assertChildName, createLinkCode, createRecoveryCode, hashLinkCode, isFreshCheckSubmission, normalizeLinkCode } from './helpers.js';
 
 initializeApp();
 const db = getFirestore();
@@ -201,6 +201,7 @@ export const regenerateLinkCode = onCall({ region, cors, enforceAppCheck: true }
   const batch = db.batch();
   links.docs.forEach((link) => batch.delete(link.ref));
   childIds.forEach((childId) => batch.delete(db.collection('users').doc(childId)));
+  childIds.forEach((childId) => batch.delete(familyRef.collection('pushSubscriptions').doc(childId)));
   batch.update(familyRef, familyUpdate);
   batch.update(userRef, {
     linkingCode: code,
@@ -321,25 +322,28 @@ export const analyzeCheck = onCall({ region, cors, enforceAppCheck: true }, asyn
   const uid = requireUid(request.auth);
   const familyId = String(request.data?.familyId ?? '');
   const checkId = String(request.data?.checkId ?? '');
+  const capturedAt = String(request.data?.capturedAt ?? '');
   const profile = await db.collection('users').doc(uid).get();
   if (!profile.exists || profile.data()?.familyId !== familyId || profile.data()?.role !== 'child') {
     throw new HttpsError('permission-denied', 'Only the linked child can submit this check.');
   }
   const checkRef = db.collection('families').doc(familyId).collection('checks').doc(checkId);
-  const check = await checkRef.get();
-  if (!check.exists || check.data()?.status !== 'analyzing') {
-    throw new HttpsError('failed-precondition', 'This check cannot be analyzed.');
-  }
   const result = { status: 'detected', confidence: 0.94, imageQuality: 0.91 };
-  const batch = db.batch();
-  batch.update(checkRef, result);
-  batch.update(db.collection('families').doc(familyId), {
-    activeCheckId: FieldValue.delete(),
-    activeCheckExpiresAt: FieldValue.delete(),
-    updatedAt: FieldValue.serverTimestamp(),
+  const response = await db.runTransaction(async (transaction) => {
+    const check = await transaction.get(checkRef);
+    const checkData = check.data();
+    if (!check.exists || !checkData || !isFreshCheckSubmission(checkData, capturedAt)) {
+      throw new HttpsError('failed-precondition', 'This check is expired, completed, or invalid.');
+    }
+    transaction.update(checkRef, { ...result, capturedAt });
+    transaction.update(db.collection('families').doc(familyId), {
+      activeCheckId: FieldValue.delete(),
+      activeCheckExpiresAt: FieldValue.delete(),
+      updatedAt: FieldValue.serverTimestamp(),
+    });
+    return { id: check.id, ...checkData, capturedAt, ...result };
   });
-  await batch.commit();
-  return { id: check.id, ...check.data(), ...result };
+  return response;
 });
 
 export const deleteAccountData = onCall({ region, cors, enforceAppCheck: true }, async (request) => {
@@ -353,6 +357,7 @@ export const deleteAccountData = onCall({ region, cors, enforceAppCheck: true },
   if (role === 'child') {
     await Promise.all([
       familyRef.update({ [`members.${uid}`]: FieldValue.delete(), updatedAt: FieldValue.serverTimestamp() }),
+      familyRef.collection('pushSubscriptions').doc(uid).delete(),
       userRef.delete(),
     ]);
     return;

--- a/rules-tests/firestore.rules.test.ts
+++ b/rules-tests/firestore.rules.test.ts
@@ -56,9 +56,9 @@ describe('family isolation', () => {
 });
 
 describe('check submission', () => {
-  test('allows the child to atomically move a pending check to analyzing', async () => {
+  test('denies direct child check submissions so the server validates expiry', async () => {
     const childDb = environment.authenticatedContext('child').firestore();
-    await assertSucceeds(updateDoc(doc(childDb, 'families/family-1/checks/check-1'), {
+    await assertFails(updateDoc(doc(childDb, 'families/family-1/checks/check-1'), {
       status: 'analyzing',
       capturedAt: new Date().toISOString(),
     }));

--- a/src/services/firebaseRepository.ts
+++ b/src/services/firebaseRepository.ts
@@ -6,7 +6,6 @@ import {
   onSnapshot,
   orderBy,
   query,
-  runTransaction,
   type DocumentData,
   type Unsubscribe,
 } from 'firebase/firestore';
@@ -165,14 +164,12 @@ export class FirebaseRepository implements AppRepository {
     const familyId = this.state.family.id;
     const event = this.state.events.find((item) => item.sessionId === sessionId);
     if (!familyId || !event || !isFreshCapture(event, capturedAt)) throw new Error('invalid_or_replayed_capture');
-    const eventRef = doc(this.services.db, 'families', familyId, 'checks', event.id);
-    await runTransaction(this.services.db, async (transaction) => {
-      const snapshot = await transaction.get(eventRef);
-      if (!snapshot.exists() || snapshot.data().status !== 'pending') throw new Error('invalid_or_replayed_capture');
-      transaction.update(eventRef, { status: 'analyzing', capturedAt: capturedAt.toISOString() });
-    });
-    const analyzeCheck = httpsCallable<{ familyId: string; checkId: string }, VerificationEvent>(this.services.functions, 'analyzeCheck');
-    const result = await analyzeCheck({ familyId, checkId: event.id });
+    const analyzeCheck = httpsCallable<{
+      familyId: string;
+      checkId: string;
+      capturedAt: string;
+    }, VerificationEvent>(this.services.functions, 'analyzeCheck');
+    const result = await analyzeCheck({ familyId, checkId: event.id, capturedAt: capturedAt.toISOString() });
     return result.data;
   }
 


### PR DESCRIPTION
## What changed

- move check completion into the authenticated Cloud Function transaction
- validate pending state, request time, expiry, capture time and replay status on the server
- deny all direct client writes to check documents
- delete stale Web Push subscriptions when a child is revoked or resets the account
- keep temporary compatibility with the previous installed PWA during rollout

## Why

The previous client transitioned checks to `analyzing` directly in Firestore. A modified client could bypass local expiry checks, and revoked child devices could retain a Push subscription after their membership was removed.

## Validation

- app tests: 8 passed
- Functions tests: 4 passed, including fresh/expired/replayed submissions
- Firestore emulator tests: 5 passed
- production build passed
- compatible backend functions deployed before the frontend rollout
