### PR TITLE
[codex] Use Ionicons for add icons

### DIFF
--- a/src/screens/InstallScreen.tsx
+++ b/src/screens/InstallScreen.tsx
@@ -1,3 +1,5 @@
+import { IonIcon } from '@ionic/react';
+import { addOutline } from 'ionicons/icons';
 import type { Locale } from '../domain/models';
 import type { MessageKey } from '../services/i18n';
 import { SetupProgress } from '../components/SetupProgress';
@@ -40,7 +42,7 @@ export function InstallScreen({
         <div className="instruction-row">
           <span className="instruction-number">2</span>
           <div><strong>{t('setupInstallHomeTitle')}</strong><p>{t('setupInstallHomeBody')}</p></div>
-          <span className="instruction-symbol" aria-hidden="true">＋</span>
+          <span className="instruction-symbol" aria-hidden="true"><IonIcon icon={addOutline} /></span>
         </div>
         <div className="instruction-row">
           <span className="instruction-number">3</span>

--- a/src/screens/RoutineEditScreen.tsx
+++ b/src/screens/RoutineEditScreen.tsx
@@ -1,3 +1,5 @@
+import { IonIcon } from '@ionic/react';
+import { addOutline } from 'ionicons/icons';
 import { useEffect, useMemo, useState } from 'react';
 import type { MonitoringPlan, RoutineValidationMode, ScheduleGroup } from '../domain/models';
 import type { MessageKey } from '../services/i18n';
@@ -311,13 +313,13 @@ export function RoutineEditScreen({
             ))}
           </div>
           <button type="button" className="plan-add-button schedule-add-window" disabled={totalWindowCount >= MAX_TIME_WINDOWS} onClick={() => addWindow(group.id)}>
-            <span className="schedule-add-symbol" aria-hidden="true">+</span>{t('addTimeSlot')}
+            <IonIcon icon={addOutline} aria-hidden="true" />{t('addTimeSlot')}
           </button>
         </section>
       ))}
 
       <button type="button" className="plan-add-button schedule-add-group" disabled={groups.length >= MAX_SCHEDULE_GROUPS || totalWindowCount >= MAX_TIME_WINDOWS} onClick={addGroup}>
-        <span className="schedule-add-symbol" aria-hidden="true">+</span>{t('addScheduleGroup')}
+        <IonIcon icon={addOutline} aria-hidden="true" />{t('addScheduleGroup')}
       </button>
 
       {error && <p className="form-error">{error}</p>}

--- a/src/screens/RoutinesScreen.tsx
+++ b/src/screens/RoutinesScreen.tsx
@@ -1,3 +1,5 @@
+import { IonIcon } from '@ionic/react';
+import { addOutline } from 'ionicons/icons';
 import { lazy, Suspense, useEffect, useState } from 'react';
 import type { AppState, MonitoringPlan, RoutineAssignment, RoutineValidationMode, ScheduleGroup, VerificationEvent } from '../domain/models';
 import { groupsFromLegacyPlan, nextPlannedWindow, summarizeWeekdaysShort } from '../domain/monitoringPlan';
@@ -202,7 +204,11 @@ export function RoutinesScreen({
     <div className="content-screen routines-screen">
       <header className="screen-header participant-header">
         <div><h1>{t('myRoutines')}</h1><p>{t('routinesHint')}</p></div>
-        {onAssignRoutine && <button type="button" className="add-routine-button" aria-label={t('addRoutine')} aria-expanded={catalogOpen} onClick={() => setCatalogOpen((open) => !open)}>＋</button>}
+        {onAssignRoutine && (
+          <button type="button" className="add-routine-button" aria-label={t('addRoutine')} aria-expanded={catalogOpen} onClick={() => setCatalogOpen((open) => !open)}>
+            <IonIcon icon={addOutline} aria-hidden="true" />
+          </button>
+        )}
       </header>
       {catalogOpen && (
         <section className="card routine-catalog-card" aria-labelledby="routine-catalog-title">

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -646,6 +646,7 @@ ion-input {
 .more-button, .add-routine-button, .detail-back { border: 0; background: transparent; color: var(--navy); font-weight: 900; }
 .more-button { padding: 7px; letter-spacing: 2px; }
 .add-routine-button { width: 42px; height: 42px; display: grid; place-items: center; border-radius: 50%; background: var(--navy); color: white; font-size: 25px; }
+.add-routine-button ion-icon { font-size: 24px; }
 
 .today-section { margin-top: 16px; }
 .content-screen > .today-section { margin-top: 0; }
@@ -1837,14 +1838,10 @@ ion-input {
     color-mix(in srgb, var(--plan-action) 13%, white)
   );
 }
-.schedule-add-window .schedule-add-symbol {
-  width: 18px;
-  height: 18px;
-  font-size: 15px;
-}
+.schedule-add-window ion-icon { font-size: 18px; }
 .schedule-add-group {
   width: 100%;
-  min-height: 54px;
+  min-height: 46px;
   justify-content: center;
   margin: 4px 0 0;
   border: 0;
@@ -1852,21 +1849,9 @@ ion-input {
   background: var(--navy);
   color: white;
   box-shadow: 0 14px 28px rgba(16, 42, 67, .16), inset 0 1px rgba(255,255,255,.2);
-  font-size: 14px;
+  font-size: 13px;
 }
-.schedule-add-group .schedule-add-symbol { background: white; color: var(--navy); }
-.schedule-add-symbol {
-  width: 22px;
-  height: 22px;
-  display: grid;
-  place-items: center;
-  border-radius: 50%;
-  background: var(--plan-action, #8b5cf6);
-  color: white;
-  font-size: 19px;
-  font-weight: 900;
-  line-height: 1;
-}
+.schedule-add-group ion-icon { font-size: 20px; }
 
 .plan-window-list { display: grid; gap: 1px; }
 .plan-window-card { display: grid; grid-template-columns: 28px minmax(0, 1fr) 26px; align-items: center; gap: 7px; padding: 5px 0; border-top: 1px solid var(--line); background: transparent; }


### PR DESCRIPTION
## Summary
- Replace text-based plus signs with Ionicons add icons.
- Keep the add period button full-width while reducing its height.
- Remove obsolete composite plus styling.

## Validation
- npm run build