### PR TITLE
[codex] Compact settings diagnostics

### DIFF
--- a/src/screens/SettingsScreen.tsx
+++ b/src/screens/SettingsScreen.tsx
@@ -73,6 +73,7 @@ export function SettingsScreen({
   const [regenerating, setRegenerating] = useState(false);
   const [codeError, setCodeError] = useState(false);
   const [sensitiveOpen, setSensitiveOpen] = useState(false);
+  const [diagnosticsOpen, setDiagnosticsOpen] = useState(false);
   const [testingPush, setTestingPush] = useState(false);
   const [testPushStatus, setTestPushStatus] = useState<'idle' | 'success' | 'error'>('idle');
 
@@ -278,19 +279,34 @@ export function SettingsScreen({
             icon={<IonIcon icon={informationCircleOutline} />}
             title={t('settingsRecoveryDiagnosticsTitle')}
             detail={t('settingsRecoveryDiagnosticsDetail')}
+            trailing={(
+              <button
+                type="button"
+                className="settings-diagnostics-toggle"
+                aria-expanded={diagnosticsOpen}
+                aria-label={t('settingsRecoveryDiagnosticsTitle')}
+                onClick={() => setDiagnosticsOpen((open) => !open)}
+              >
+                <IonIcon className={diagnosticsOpen ? 'expanded' : undefined} icon={chevronDownOutline} aria-hidden="true" />
+              </button>
+            )}
           >
             <dl className="settings-diagnostics-list">
-              <div><dt>{t('settingsDiagnosticsFamilyId')}</dt><dd>{familyId ?? t('settingsDiagnosticsMissing')}</dd></div>
-              <div><dt>{t('settingsDiagnosticsRole')}</dt><dd>{t(role)}</dd></div>
-              <div><dt>{t('settingsDiagnosticsParticipant')}</dt><dd>{childInstalled ? t('settingsChildInstallStatusLinked') : t('settingsChildInstallStatusPending')}</dd></div>
-              <div><dt>{t('settingsDiagnosticsNotifications')}</dt><dd>{notificationsEnabled ? t('settingsNotificationsStatusEnabled') : t('settingsNotificationsStatusDisabled')}</dd></div>
-              <div><dt>{t('settingsDiagnosticsPushPermission')}</dt><dd>{pushHealth?.permission ?? t('settingsDiagnosticsMissing')}</dd></div>
-              <div><dt>{t('settingsDiagnosticsPushEndpoint')}</dt><dd>{pushHealth?.endpointPresent ? t('yes') : t('no')}</dd></div>
-              <div><dt>{t('settingsDiagnosticsPushSaved')}</dt><dd>{formatDiagnosticDate(pushHealth?.lastSuccessfulSaveAt)}</dd></div>
-              <div><dt>{t('settingsDiagnosticsPushDispatch')}</dt><dd>{pushHealth?.lastDispatchResult ?? t('settingsDiagnosticsMissing')}</dd></div>
-              <div><dt>{t('settingsDiagnosticsPushDispatchAt')}</dt><dd>{formatDiagnosticDate(pushHealth?.lastDispatchAt)}</dd></div>
+              {diagnosticsOpen ? (
+                <>
+                  <div><dt>{t('settingsDiagnosticsFamilyId')}</dt><dd>{familyId ?? t('settingsDiagnosticsMissing')}</dd></div>
+                  <div><dt>{t('settingsDiagnosticsRole')}</dt><dd>{t(role)}</dd></div>
+                  <div><dt>{t('settingsDiagnosticsParticipant')}</dt><dd>{childInstalled ? t('settingsChildInstallStatusLinked') : t('settingsChildInstallStatusPending')}</dd></div>
+                  <div><dt>{t('settingsDiagnosticsNotifications')}</dt><dd>{notificationsEnabled ? t('settingsNotificationsStatusEnabled') : t('settingsNotificationsStatusDisabled')}</dd></div>
+                  <div><dt>{t('settingsDiagnosticsPushPermission')}</dt><dd>{pushHealth?.permission ?? t('settingsDiagnosticsMissing')}</dd></div>
+                  <div><dt>{t('settingsDiagnosticsPushEndpoint')}</dt><dd>{pushHealth?.endpointPresent ? t('yes') : t('no')}</dd></div>
+                  <div><dt>{t('settingsDiagnosticsPushSaved')}</dt><dd>{formatDiagnosticDate(pushHealth?.lastSuccessfulSaveAt)}</dd></div>
+                  <div><dt>{t('settingsDiagnosticsPushDispatch')}</dt><dd>{pushHealth?.lastDispatchResult ?? t('settingsDiagnosticsMissing')}</dd></div>
+                  <div><dt>{t('settingsDiagnosticsPushDispatchAt')}</dt><dd>{formatDiagnosticDate(pushHealth?.lastDispatchAt)}</dd></div>
+                  <div><dt>{t('settingsDiagnosticsServiceWorker')}</dt><dd>{t(serviceWorkerDetailKey)}</dd></div>
+                </>
+              ) : null}
               <div><dt>{t('settingsDiagnosticsAppVersion')}</dt><dd>{import.meta.env.VITE_APP_VERSION}</dd></div>
-              <div><dt>{t('settingsDiagnosticsServiceWorker')}</dt><dd>{t(serviceWorkerDetailKey)}</dd></div>
               <div><dt>{t('settingsDiagnosticsLastSync')}</dt><dd>{formattedLastSync}</dd></div>
             </dl>
           </ListRow>

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -1192,6 +1192,9 @@ ion-input {
 .settings-diagnostics-list div { display: flex; align-items: baseline; justify-content: space-between; gap: 14px; padding-top: 8px; border-top: 1px solid rgba(13,146,125,.12); }
 .settings-diagnostics-list dt { color: var(--muted); font-size: 11px; font-weight: 900; text-transform: uppercase; }
 .settings-diagnostics-list dd { margin: 0; max-width: 58%; overflow-wrap: anywhere; color: var(--navy); font-size: 12px; font-weight: 900; text-align: right; }
+.settings-diagnostics-toggle { width: 34px; height: 34px; display: grid; place-items: center; justify-self: end; padding: 0; border: 0; border-radius: 12px; background: #f2f7f5; color: var(--teal); }
+.settings-diagnostics-toggle ion-icon { font-size: 20px; transition: transform .18s ease; }
+.settings-diagnostics-toggle ion-icon.expanded { transform: rotate(180deg); }
 .settings-contact-button {
   min-height: 54px;
   margin-top: 4px;


### PR DESCRIPTION
## Summary
- Make the settings diagnostics section compact by default.
- Add a chevron toggle to reveal full diagnostic details.
- Keep app version and last sync visible and ordered last.

## Validation
- npm run build