### PR TITLE
Add active check reminder resend

### DIFF
--- a/src/components/ui.tsx
+++ b/src/components/ui.tsx
@@ -154,11 +154,13 @@ export function EmptyState({
   title,
   detail,
   className,
+  children,
 }: {
   icon: IconSlot;
   title: ReactNode;
   detail?: ReactNode;
   className?: string;
+  children?: ReactNode;
 }) {
   return (
     <Card className={joinClassNames('parent-empty-history-card', className)}>
@@ -166,6 +168,7 @@ export function EmptyState({
       <div>
         <h2>{title}</h2>
         {detail !== undefined ? <p>{detail}</p> : null}
+        {children}
       </div>
     </Card>
   );

--- a/src/screens/ParentDashboard.test.tsx
+++ b/src/screens/ParentDashboard.test.tsx
@@ -120,6 +120,39 @@ describe('ParentDashboard', () => {
     expect(container.textContent).toContain('Waiting for participant proof');
   });
 
+  it('lets the responsible person resend active pending checks from current checks', async () => {
+    const assignment = createDefaultRoutineAssignment();
+    const requestCheck = vi.fn().mockResolvedValue(undefined);
+    const state: AppState = {
+      role: 'parent',
+      locale: 'en',
+      notificationsEnabled: true,
+      family: { linked: true, childLinked: true, childName: 'Maya', linkingCode: '', parentRecoveryCode: '', consented: true },
+      routineAssignments: [assignment],
+      events: [{
+        id: 'pending',
+        routineId: assignment.routineId,
+        sessionId: 'one',
+        requestedAt: new Date().toISOString(),
+        expiresAt: new Date(Date.now() + 20 * 60_000).toISOString(),
+        status: 'pending',
+      }],
+    };
+
+    act(() => root.render(<ParentDashboard state={state} regenerateCode={vi.fn()} requestCheck={requestCheck} t={(key) => translate('en', key)} />));
+
+    const resend = Array.from(container.querySelectorAll('button')).find((button) => button.getAttribute('aria-label') === 'Resend reminder');
+    expect(resend).toBeTruthy();
+
+    await act(async () => {
+      resend?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+      await Promise.resolve();
+    });
+
+    expect(requestCheck).toHaveBeenCalledWith(assignment.routineId);
+    expect(container.textContent).toContain('The check is ready on the participant’s phone.');
+  });
+
   it('shows expired pending checks as missed in recent history', () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date('2026-07-07T08:04:00.000Z'));

--- a/src/screens/ParentDashboard.tsx
+++ b/src/screens/ParentDashboard.tsx
@@ -33,6 +33,8 @@ export function ParentDashboard({
   const [proofErrors, setProofErrors] = useState<Record<string, boolean>>({});
   const [reviewingId, setReviewingId] = useState<string>();
   const [reviewErrorId, setReviewErrorId] = useState<string>();
+  const [requestingActiveReminder, setRequestingActiveReminder] = useState(false);
+  const [activeReminderStatus, setActiveReminderStatus] = useState<'sent' | 'error'>();
   const [enlargedProofUrl, setEnlargedProofUrl] = useState<string>();
   const swipeStartRef = useRef<{ eventId: string; x: number; y: number } | undefined>(undefined);
   const now = Date.now();
@@ -50,7 +52,7 @@ export function ParentDashboard({
     : !state.routineAssignments.length
       ? { icon: 'add' as const, title: t('responsibleEmptyNoRoutineTitle'), hint: t('responsibleEmptyNoRoutineHint') }
       : activePendingEvents.length
-        ? { icon: 'time' as const, title: t('responsibleEmptyWaitingProofTitle'), hint: t('responsibleEmptyWaitingProofHint') }
+        ? { icon: 'send' as const, title: t('responsibleEmptyWaitingProofTitle'), hint: t('responsibleEmptyWaitingProofHint') }
         : !state.events.length
           ? { icon: 'notifications' as const, title: t('responsibleEmptyNoCheckTitle'), hint: t('responsibleEmptyNoCheckHint') }
           : undefined;
@@ -112,6 +114,21 @@ export function ParentDashboard({
       setReviewingId(undefined);
     }
   };
+  const resendActiveReminders = async () => {
+    if (!requestCheck || requestingActiveReminder) return;
+    setRequestingActiveReminder(true);
+    setActiveReminderStatus(undefined);
+    try {
+      const routineIds = Array.from(new Set(activePendingEvents.map((event) => event.routineId)));
+      await Promise.all(routineIds.map((routineId) => requestCheck(routineId)));
+      setActiveReminderStatus('sent');
+    } catch (error) {
+      console.error(error);
+      setActiveReminderStatus('error');
+    } finally {
+      setRequestingActiveReminder(false);
+    }
+  };
   const beginSwipe = (eventId: string, x: number, y: number, target: EventTarget) => {
     if (reviewingId === eventId || (target as HTMLElement).closest('button')) return;
     swipeStartRef.current = { eventId, x, y };
@@ -156,7 +173,24 @@ export function ParentDashboard({
                 icon={responsibleEmptyState.icon}
                 title={responsibleEmptyState.title}
                 detail={responsibleEmptyState.hint}
-              />
+              >
+                {requestCheck && activePendingEvents.length ? (
+                  <div className="responsible-state-actions">
+                    <button
+                      type="button"
+                      className="responsible-reminder-button"
+                      aria-label={t('requestCheckAgain')}
+                      disabled={requestingActiveReminder}
+                      onClick={() => { void resendActiveReminders(); }}
+                    >
+                      <AppIcon name="send" />
+                      {requestingActiveReminder ? t('requestingCheck') : t('requestCheckAgain')}
+                    </button>
+                    {activeReminderStatus === 'sent' ? <span className="request-feedback success">{t('requestCheckSent')}</span> : null}
+                    {activeReminderStatus === 'error' ? <span className="request-feedback error">{t('requestCheckError')}</span> : null}
+                  </div>
+                ) : null}
+              </EmptyState>
             ) : null}
 
             {!state.family.childLinked && state.family.linkingCode ? (

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -566,14 +566,21 @@ ion-input {
 .responsible-state-card {
   display: grid;
   grid-template-columns: 42px minmax(0, 1fr);
-  align-items: center;
+  align-items: start;
   gap: 12px;
   margin-top: 0;
   padding: var(--row-padding-y) var(--row-padding-x);
   border-radius: 20px;
 }
+.responsible-state-card > .settings-row-icon { align-self: start; }
 .responsible-state-card h2 { margin: 0; color: var(--navy); font-size: 16px; }
 .responsible-state-card p { margin: 4px 0 0; color: var(--muted); font-size: 12px; line-height: 1.35; }
+.responsible-state-actions { display: flex; flex-wrap: wrap; align-items: center; gap: 8px; margin-top: 10px; }
+.responsible-reminder-button { min-height: 34px; display: inline-flex; flex: 0 0 auto; align-items: center; justify-content: center; gap: 6px; padding: 7px 11px; border: 0; border-radius: 12px; background: var(--navy); color: white; font-size: 11px; font-weight: 850; line-height: 1; white-space: nowrap; }
+.responsible-reminder-button .app-icon { font-size: 17px; }
+.responsible-reminder-button:active { transform: scale(.985); filter: brightness(.97); }
+.responsible-reminder-button:disabled { opacity: .55; }
+.responsible-state-actions .request-feedback { margin: 0; font-size: 11px; line-height: 1.25; }
 .status-pill { display: inline-flex; flex: 0 0 auto; align-items: center; justify-content: center; white-space: nowrap; padding: 7px 10px; border-radius: 99px; background: #eef2f4; color: var(--navy); font-weight: 900; font-size: 11px; text-transform: capitalize; }
 .status-detected { background: var(--mint); color: var(--teal); }
 .status-uncertain { background: #fff0d9; color: #b87218; }


### PR DESCRIPTION
## Summary
- Align the active-check empty-state icon to the top and switch it to the send icon.
- Add a compact resend reminder action when active pending checks exist.
- Allow `EmptyState` to render optional actions and cover the active resend flow in tests.

## Validation
- `npm test -- ParentDashboard.test.tsx`
- `npm run build`