### PR TITLE
Persist dashboard summary range

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,6 +7,7 @@ import { translate, type MessageKey } from './services/i18n';
 import { BottomNav, type Tab } from './components/BottomNav';
 import { SplashScreen } from './components/SplashScreen';
 import { Snackbar } from './components/Snackbar';
+import type { SummaryRange } from './components/AdherenceSummaryCard';
 import { PushSetupError, WebPushGateway } from './services/webPush';
 import { firebaseEnabled } from './services/firebaseConfig';
 import { browserRouteContext, isLocalDemoEnvironment, routineCentricUiEnabled } from './services/browserEnvironment';
@@ -70,6 +71,7 @@ export function App() {
   const [savingRoutineId, setSavingRoutineId] = useState<string>();
   const [selectedSessionId, setSelectedSessionId] = useState<string>();
   const [lastSyncAt, setLastSyncAt] = useState<string>();
+  const [dashboardSummaryRange, setDashboardSummaryRange] = useState<SummaryRange>('day');
   const [serviceWorkerStatus, setServiceWorkerStatus] = useState<'unsupported' | 'registered' | 'notRegistered'>(
     () => ('serviceWorker' in navigator ? 'notRegistered' : 'unsupported'),
   );
@@ -406,9 +408,19 @@ export function App() {
               getProofImageUrl={(eventId) => repository.getProofImageUrl(eventId)}
               reviewCheck={async (eventId, decision) => { await repository.reviewCheck(eventId, decision); sync(); }}
               requestCheck={async (routineId) => { await repository.requestCheckNow(routineId); sync(); }}
+              summaryRange={dashboardSummaryRange}
+              onSummaryRangeChange={setDashboardSummaryRange}
               t={t}
             />
-          : <ChildDashboard state={state} active={repository.activeSession()} start={startCapture} retake={retryCapture} t={t} />;
+          : <ChildDashboard
+              state={state}
+              active={repository.activeSession()}
+              start={startCapture}
+              retake={retryCapture}
+              summaryRange={dashboardSummaryRange}
+              onSummaryRangeChange={setDashboardSummaryRange}
+              t={t}
+            />;
     content = <div className="app-shell">{screen}<BottomNav tab={tab} role={role} routineCentricEnabled={routineCentricUiEnabled} onChange={setTab} t={t} /></div>;
   }
 

--- a/src/screens/ChildDashboard.tsx
+++ b/src/screens/ChildDashboard.tsx
@@ -23,15 +23,21 @@ export function ChildDashboard({
   active,
   start,
   retake,
+  summaryRange: controlledSummaryRange,
+  onSummaryRangeChange,
   t,
 }: {
   state: AppState;
   active?: VerificationEvent;
   start: (event: VerificationEvent) => void;
   retake?: (event: VerificationEvent) => void;
+  summaryRange?: SummaryRange;
+  onSummaryRangeChange?: (range: SummaryRange) => void;
   t: (key: MessageKey) => string;
 }) {
-  const [summaryRange, setSummaryRange] = useState<SummaryRange>('day');
+  const [localSummaryRange, setLocalSummaryRange] = useState<SummaryRange>('day');
+  const summaryRange = controlledSummaryRange ?? localSummaryRange;
+  const setSummaryRange = onSummaryRangeChange ?? setLocalSummaryRange;
   const now = Date.now();
   const participantInitial = state.family.childName.trim().charAt(0).toUpperCase() || '?';
   const today = state.events.filter((event) => isToday(event.requestedAt));

--- a/src/screens/ParentDashboard.tsx
+++ b/src/screens/ParentDashboard.tsx
@@ -16,6 +16,8 @@ export function ParentDashboard({
   getProofImageUrl,
   reviewCheck,
   requestCheck,
+  summaryRange: controlledSummaryRange,
+  onSummaryRangeChange,
   t,
 }: {
   state: AppState;
@@ -24,11 +26,13 @@ export function ParentDashboard({
   getProofImageUrl?: (eventId: string) => Promise<string>;
   reviewCheck?: (eventId: string, decision: 'detected' | 'not_detected') => Promise<void>;
   requestCheck?: (routineId: string) => Promise<void>;
+  summaryRange?: SummaryRange;
+  onSummaryRangeChange?: (range: SummaryRange) => void;
   t: (key: MessageKey) => string;
 }) {
   const [regenerating, setRegenerating] = useState(false);
   const [codeError, setCodeError] = useState(false);
-  const [summaryRange, setSummaryRange] = useState<SummaryRange>('day');
+  const [localSummaryRange, setLocalSummaryRange] = useState<SummaryRange>('day');
   const [proofUrls, setProofUrls] = useState<Record<string, string>>({});
   const [proofErrors, setProofErrors] = useState<Record<string, boolean>>({});
   const [reviewingId, setReviewingId] = useState<string>();
@@ -37,6 +41,8 @@ export function ParentDashboard({
   const [activeReminderStatus, setActiveReminderStatus] = useState<'sent' | 'error'>();
   const [enlargedProofUrl, setEnlargedProofUrl] = useState<string>();
   const swipeStartRef = useRef<{ eventId: string; x: number; y: number } | undefined>(undefined);
+  const summaryRange = controlledSummaryRange ?? localSummaryRange;
+  const setSummaryRange = onSummaryRangeChange ?? setLocalSummaryRange;
   const now = Date.now();
   const displayEvents = useMemo(() => withResolvedEventStatuses(state.events, now), [now, state.events]);
   const rangedEvents = filterEventsBySummaryRange(displayEvents, summaryRange, now);


### PR DESCRIPTION
## Summary

Keep the dashboard summary range selected when the user leaves Home and comes back. The range state now lives in `App`, while the parent and participant dashboards still keep local fallback state for isolated renders and tests.

## Root Cause

`ParentDashboard` and `ChildDashboard` stored the summary range locally. Switching away from Home unmounted the dashboard, so returning recreated it with the default `day` range.

## Validation

- `npm run test -- ParentDashboard ChildDashboard App`
- `npm run build`