### PR TITLE
Add participant relationship model

### DIFF
--- a/functions/src/relationships.test.ts
+++ b/functions/src/relationships.test.ts
@@ -1,0 +1,66 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+  canGrantPermissions,
+  canRemoveMembership,
+  createMembership,
+  defaultPermissionsForRole,
+  hasParticipantPermission,
+  membershipPermissions,
+} from './relationships.js';
+
+test('defines explicit defaults for each membership role', () => {
+  const owner = defaultPermissionsForRole('owner');
+  const caregiver = defaultPermissionsForRole('caregiver');
+  const participant = defaultPermissionsForRole('participant');
+  const viewer = defaultPermissionsForRole('viewer');
+
+  assert.equal(membershipPermissions.every((permission) => owner[permission]), true);
+  assert.equal(caregiver.manageRoutines, true);
+  assert.equal(caregiver.reviewProofs, true);
+  assert.equal(caregiver.manageCaregivers, false);
+  assert.equal(participant.submitChecks, true);
+  assert.equal(participant.reviewProofs, false);
+  assert.deepEqual(Object.entries(viewer).filter(([, enabled]) => enabled).map(([permission]) => permission), ['view']);
+});
+
+test('models self-management as a regular owner membership', () => {
+  const membership = createMembership({
+    uid: 'jordan',
+    role: 'owner',
+    label: 'self',
+    now: '2026-07-10T10:00:00.000Z',
+  });
+
+  assert.equal(membership.uid, 'jordan');
+  assert.equal(membership.label, 'self');
+  assert.equal(hasParticipantPermission(membership, 'manageRoutines'), true);
+  assert.equal(hasParticipantPermission(membership, 'submitChecks'), true);
+});
+
+test('denies permissions to suspended or incomplete memberships', () => {
+  const caregiver = createMembership({ uid: 'caregiver', role: 'caregiver' });
+  assert.equal(hasParticipantPermission(caregiver, 'reviewProofs'), true);
+  assert.equal(hasParticipantPermission({ ...caregiver, status: 'suspended' }, 'reviewProofs'), false);
+  assert.equal(hasParticipantPermission(undefined, 'view'), false);
+});
+
+test('prevents permission escalation when inviting another member', () => {
+  const owner = createMembership({ uid: 'owner', role: 'owner' });
+  const delegatedOwner = createMembership({ uid: 'delegate', role: 'owner' });
+  delegatedOwner.permissions.manageParticipant = false;
+
+  assert.equal(canGrantPermissions(owner, defaultPermissionsForRole('caregiver')), true);
+  assert.equal(canGrantPermissions(delegatedOwner, defaultPermissionsForRole('owner')), false);
+  assert.equal(canGrantPermissions(createMembership({ uid: 'caregiver', role: 'caregiver' }), defaultPermissionsForRole('viewer')), false);
+});
+
+test('protects the last active owner from removal', () => {
+  const owner = createMembership({ uid: 'owner', role: 'owner' });
+  const caregiver = createMembership({ uid: 'caregiver', role: 'caregiver' });
+
+  assert.equal(canRemoveMembership({ actor: owner, target: owner, activeOwnerCount: 1 }), false);
+  assert.equal(canRemoveMembership({ actor: owner, target: owner, activeOwnerCount: 2 }), true);
+  assert.equal(canRemoveMembership({ actor: owner, target: caregiver, activeOwnerCount: 1 }), true);
+  assert.equal(canRemoveMembership({ actor: caregiver, target: owner, activeOwnerCount: 2 }), false);
+});

--- a/functions/src/relationships.ts
+++ b/functions/src/relationships.ts
@@ -1,0 +1,104 @@
+export const membershipRoles = ['owner', 'caregiver', 'participant', 'viewer'] as const;
+export type MembershipRole = typeof membershipRoles[number];
+
+export const membershipPermissions = [
+  'view',
+  'manageRoutines',
+  'requestChecks',
+  'submitChecks',
+  'reviewProofs',
+  'manageCaregivers',
+  'manageParticipant',
+] as const;
+export type MembershipPermission = typeof membershipPermissions[number];
+export type PermissionSet = Record<MembershipPermission, boolean>;
+
+export type MembershipStatus = 'active' | 'suspended';
+export type MembershipLabel = 'parent' | 'partner' | 'relative' | 'professional' | 'self' | 'other';
+
+export interface MembershipDocument {
+  uid: string;
+  role: MembershipRole;
+  label?: MembershipLabel;
+  permissions: PermissionSet;
+  status: MembershipStatus;
+  invitedBy?: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+const noPermissions = (): PermissionSet => ({
+  view: false,
+  manageRoutines: false,
+  requestChecks: false,
+  submitChecks: false,
+  reviewProofs: false,
+  manageCaregivers: false,
+  manageParticipant: false,
+});
+
+export const defaultPermissionsForRole = (role: MembershipRole): PermissionSet => {
+  const permissions = noPermissions();
+  permissions.view = true;
+  if (role === 'viewer') return permissions;
+  permissions.requestChecks = true;
+  if (role === 'participant') {
+    permissions.submitChecks = true;
+    return permissions;
+  }
+  permissions.manageRoutines = true;
+  permissions.reviewProofs = true;
+  if (role === 'owner') {
+    permissions.submitChecks = true;
+    permissions.manageCaregivers = true;
+    permissions.manageParticipant = true;
+  }
+  return permissions;
+};
+
+export const createMembership = ({
+  uid,
+  role,
+  label,
+  invitedBy,
+  now = new Date().toISOString(),
+}: {
+  uid: string;
+  role: MembershipRole;
+  label?: MembershipLabel;
+  invitedBy?: string;
+  now?: string;
+}): MembershipDocument => ({
+  uid,
+  role,
+  ...(label ? { label } : {}),
+  permissions: defaultPermissionsForRole(role),
+  status: 'active',
+  ...(invitedBy ? { invitedBy } : {}),
+  createdAt: now,
+  updatedAt: now,
+});
+
+export const hasParticipantPermission = (
+  membership: Partial<MembershipDocument> | undefined,
+  permission: MembershipPermission,
+) => membership?.status === 'active' && membership.permissions?.[permission] === true;
+
+export const canGrantPermissions = (
+  actor: Partial<MembershipDocument> | undefined,
+  requested: PermissionSet,
+) => hasParticipantPermission(actor, 'manageCaregivers')
+  && membershipPermissions.every((permission) => !requested[permission] || actor?.permissions?.[permission] === true);
+
+export const canRemoveMembership = ({
+  actor,
+  target,
+  activeOwnerCount,
+}: {
+  actor: Partial<MembershipDocument> | undefined;
+  target: Partial<MembershipDocument> | undefined;
+  activeOwnerCount: number;
+}) => hasParticipantPermission(actor, 'manageCaregivers')
+  && target?.status === 'active'
+  && !(target.role === 'owner' && activeOwnerCount <= 1);
+


### PR DESCRIPTION
## Summary
- add explicit caregiver/participant membership roles and permission types
- provide safe role defaults and membership construction
- enforce suspension, permission delegation, and last-owner invariants in reusable helpers
- cover self-management and authorization edge cases with unit tests

## Validation
- `npm --prefix functions test`
- `git diff --check`

Part of #40.