### PR TITLE
Rehearse caregiver relationship migration

### DIFF
--- a/functions/src/migration-rehearsal.test.ts
+++ b/functions/src/migration-rehearsal.test.ts
@@ -1,6 +1,7 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
 import { DEFAULT_ROUTINE_ID, migrateCheckRoutineId } from './routines.js';
+import { migrateLegacyFamilyRelationships } from './relationships.js';
 
 test('rehearses routine migration against representative legacy checks', () => {
   const legacyChecks = [
@@ -18,4 +19,46 @@ test('rehearses routine migration against representative legacy checks', () => {
 test('rehearsal preserves checks already assigned to another routine', () => {
   const check = { id: 'medication', status: 'detected', routineId: 'medication' };
   assert.deepEqual(migrateCheckRoutineId(check), check);
+});
+
+test('rehearses a family with two caregivers into additive owner memberships', () => {
+  const migrated = migrateLegacyFamilyRelationships('family-alex', {
+    childName: 'Alex',
+    members: {
+      mother: 'parent',
+      father: 'parent',
+      alex: 'child',
+    },
+    createdAt: '2026-06-01T08:00:00.000Z',
+  }, '2026-07-10T12:00:00.000Z');
+
+  assert.equal(migrated.participantId, 'family-alex');
+  assert.equal(migrated.participant.userId, 'alex');
+  assert.deepEqual(migrated.memberships.map(({ uid, role }) => ({ uid, role })), [
+    { uid: 'alex', role: 'participant' },
+    { uid: 'father', role: 'owner' },
+    { uid: 'mother', role: 'owner' },
+  ]);
+  assert.equal(migrated.participantRefs.length, 3);
+  assert.equal(migrated.memberships.filter(({ role }) => role === 'owner').every(({ permissions }) => permissions.manageCaregivers), true);
+});
+
+test('relationship migration is deterministic and does not guess among several participant accounts', () => {
+  const family = {
+    childName: 'Shared profile',
+    members: { owner: 'parent', participantB: 'child', participantA: 'child', invalid: 'viewer' },
+  };
+  const first = migrateLegacyFamilyRelationships('family-shared', family, '2026-07-10T12:00:00.000Z');
+  const rerun = migrateLegacyFamilyRelationships('family-shared', family, '2026-07-10T12:00:00.000Z');
+
+  assert.deepEqual(rerun, first);
+  assert.equal(first.participant.userId, undefined);
+  assert.deepEqual(first.memberships.map(({ uid }) => uid), ['owner', 'participantA', 'participantB']);
+});
+
+test('relationship migration rejects a family without an owner', () => {
+  assert.throws(
+    () => migrateLegacyFamilyRelationships('orphan', { childName: 'Alex', members: { alex: 'child' } }, '2026-07-10T12:00:00.000Z'),
+    /missing_owner/,
+  );
 });

--- a/functions/src/relationships.ts
+++ b/functions/src/relationships.ts
@@ -102,3 +102,72 @@ export const canRemoveMembership = ({
   && target?.status === 'active'
   && !(target.role === 'owner' && activeOwnerCount <= 1);
 
+export interface LegacyFamilyDocument {
+  childName?: unknown;
+  members?: Record<string, unknown>;
+  createdAt?: unknown;
+}
+
+export interface LegacyRelationshipMigration {
+  participantId: string;
+  participant: {
+    displayName: string;
+    userId?: string;
+    status: 'active';
+    sourceFamilyId: string;
+    relationshipModelVersion: 2;
+    createdAt: string;
+    updatedAt: string;
+  };
+  memberships: MembershipDocument[];
+  participantRefs: Array<{
+    uid: string;
+    participantId: string;
+    role: MembershipRole;
+    status: 'active';
+    updatedAt: string;
+  }>;
+}
+
+export const migrateLegacyFamilyRelationships = (
+  familyId: string,
+  family: LegacyFamilyDocument,
+  now: string,
+): LegacyRelationshipMigration => {
+  if (!familyId) throw new Error('invalid_family_id');
+  const displayName = typeof family.childName === 'string' ? family.childName.trim() : '';
+  if (!displayName) throw new Error('invalid_participant_name');
+  const legacyMembers = Object.entries(family.members ?? {})
+    .filter((entry): entry is [string, 'parent' | 'child'] => entry[1] === 'parent' || entry[1] === 'child')
+    .sort(([left], [right]) => left.localeCompare(right));
+  if (!legacyMembers.some(([, role]) => role === 'parent')) throw new Error('missing_owner');
+  const participantUids = legacyMembers.filter(([, role]) => role === 'child').map(([uid]) => uid);
+  const createdAt = typeof family.createdAt === 'string' && Number.isFinite(Date.parse(family.createdAt))
+    ? family.createdAt
+    : now;
+  const memberships = legacyMembers.map(([uid, legacyRole]) => createMembership({
+    uid,
+    role: legacyRole === 'parent' ? 'owner' : 'participant',
+    now: createdAt,
+  }));
+  return {
+    participantId: familyId,
+    participant: {
+      displayName,
+      ...(participantUids.length === 1 ? { userId: participantUids[0] } : {}),
+      status: 'active',
+      sourceFamilyId: familyId,
+      relationshipModelVersion: 2,
+      createdAt,
+      updatedAt: now,
+    },
+    memberships,
+    participantRefs: memberships.map(({ uid, role }) => ({
+      uid,
+      participantId: familyId,
+      role,
+      status: 'active',
+      updatedAt: now,
+    })),
+  };
+};


### PR DESCRIPTION
## Summary
- add a deterministic transformation from legacy family members to participant memberships
- preserve stable aggregate IDs and legacy creation timestamps
- support multiple caregivers without replacement
- avoid guessing a primary participant when legacy data is ambiguous
- reject migration inputs that violate the active-owner invariant

## Validation
- `npm --prefix functions test`
- `git diff --check`

Part of #40.