### PR TITLE
Add active participant client state

### DIFF
--- a/src/domain/models.ts
+++ b/src/domain/models.ts
@@ -136,6 +136,26 @@ export interface FamilyState {
   consented: boolean;
 }
 
+export type MembershipRole = 'owner' | 'caregiver' | 'participant' | 'viewer';
+export type MembershipStatus = 'active' | 'suspended';
+
+export interface ParticipantSummary {
+  id: string;
+  displayName: string;
+  selfManaged?: boolean;
+}
+
+export interface MembershipSummary {
+  role: MembershipRole;
+  status: MembershipStatus;
+  label?: 'parent' | 'partner' | 'relative' | 'professional' | 'self' | 'other';
+}
+
+export interface ParticipantAccess {
+  participant: ParticipantSummary;
+  membership: MembershipSummary;
+}
+
 export interface PushSubscriptionHealth {
   permission: NotificationPermission | 'unsupported';
   endpointPresent: boolean;
@@ -171,6 +191,8 @@ export interface AppState {
   pushHealth?: PushSubscriptionHealth;
   preferences?: AppPreferences;
   family: FamilyState;
+  participantAccess?: ParticipantAccess[];
+  activeParticipantId?: string;
   routineAssignments: RoutineAssignment[];
   routinesLoaded?: boolean;
   routinesError?: boolean;

--- a/src/domain/participantAccess.test.ts
+++ b/src/domain/participantAccess.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest';
+import type { ParticipantAccess } from './models';
+import { activeParticipantAccess } from './participantAccess';
+
+const access: ParticipantAccess[] = [
+  {
+    participant: { id: 'alex', displayName: 'Alex' },
+    membership: { role: 'owner', status: 'active' },
+  },
+  {
+    participant: { id: 'sam', displayName: 'Sam' },
+    membership: { role: 'caregiver', status: 'suspended' },
+  },
+];
+
+describe('activeParticipantAccess', () => {
+  it('selects an active participant from several relationships', () => {
+    expect(activeParticipantAccess(access, 'alex')?.participant.displayName).toBe('Alex');
+  });
+
+  it('does not select suspended or unrelated relationships', () => {
+    expect(activeParticipantAccess(access, 'sam')).toBeUndefined();
+    expect(activeParticipantAccess(access, 'unrelated')).toBeUndefined();
+  });
+});
+

--- a/src/domain/participantAccess.ts
+++ b/src/domain/participantAccess.ts
@@ -1,0 +1,9 @@
+import type { ParticipantAccess } from './models';
+
+export const activeParticipantAccess = (
+  access: ParticipantAccess[] | undefined,
+  participantId: string,
+) => access?.find((entry) => (
+  entry.participant.id === participantId && entry.membership.status === 'active'
+));
+

--- a/src/services/appStateDefaults.ts
+++ b/src/services/appStateDefaults.ts
@@ -27,6 +27,7 @@ export const initialRemoteState = (): AppState => {
     role: preferences.role,
     preferences: normalizeAppPreferences(preferences),
     family: { linked: false, childLinked: false, childName: '', linkingCode: '', parentRecoveryCode: '', consented: false },
+    participantAccess: [],
     routineAssignments: [],
     routinesLoaded: false,
     routinesError: false,

--- a/src/services/contracts.ts
+++ b/src/services/contracts.ts
@@ -5,6 +5,7 @@ export interface AppRepository {
   snapshot(): AppState;
   subscribe(listener: () => void): () => void;
   selectRole(role: Role): Promise<void>;
+  selectActiveParticipant?(participantId: string): Promise<void>;
   setLocale(locale: Locale): Promise<void>;
   setPreferences(preferences: Partial<AppPreferences>): Promise<void>;
   linkParent(childName: string): Promise<void>;

--- a/src/services/demoRepository.ts
+++ b/src/services/demoRepository.ts
@@ -9,6 +9,7 @@ import type {
 } from '../domain/models';
 import { createDefaultRoutineAssignment, DEFAULT_ROUTINE_ID, normalizeAppPreferences, primaryRoutineAssignment, type AppPreferences } from '../domain/models';
 import { routineFromCatalog } from '../domain/routineCatalog';
+import { activeParticipantAccess } from '../domain/participantAccess';
 import { isFreshCapture } from '../domain/adherence';
 import { responseWindowExpiresAt } from '../domain/monitoringPlan';
 import type { AppRepository } from './contracts';
@@ -170,6 +171,7 @@ function initialState(): AppState {
       parentRecoveryCode: 'PR-2345-6789-ABCD',
       consented: false,
     },
+    participantAccess: [],
     routineAssignments: [
       defaultAssignment,
       ...(hydrationRoutine ? [{
@@ -230,6 +232,14 @@ export class DemoRepository implements AppRepository {
     this.persist();
   }
 
+  async selectActiveParticipant(participantId: string) {
+    const access = activeParticipantAccess(this.state.participantAccess, participantId);
+    if (!access) throw new Error('participant_access_not_found');
+    this.state.activeParticipantId = participantId;
+    this.state.family.childName = access.participant.displayName;
+    this.persist();
+  }
+
   async setLocale(locale: AppState['locale']) {
     this.state.locale = locale;
     this.persist();
@@ -251,6 +261,11 @@ export class DemoRepository implements AppRepository {
     };
     this.state.routineAssignments = [];
     this.state.events = [];
+    this.state.participantAccess = [{
+      participant: { id: 'demo-participant', displayName: childName },
+      membership: { role: 'owner', status: 'active', label: 'parent' },
+    }];
+    this.state.activeParticipantId = 'demo-participant';
     this.persist();
   }
 
@@ -263,6 +278,11 @@ export class DemoRepository implements AppRepository {
     this.state.family.childLinked = true;
     this.state.family.consented = true;
     this.state.family.parentRecoveryCode = 'PR-EFGH-JKLM-NPQR';
+    this.state.participantAccess ??= [{
+      participant: { id: 'demo-participant', displayName: this.state.family.childName },
+      membership: { role: 'owner', status: 'active', label: 'parent' },
+    }];
+    this.state.activeParticipantId ??= 'demo-participant';
     this.persist();
   }
 
@@ -272,6 +292,11 @@ export class DemoRepository implements AppRepository {
     }
     this.state.family.linked = true;
     this.state.family.childLinked = true;
+    this.state.participantAccess = [{
+      participant: { id: 'demo-participant', displayName: this.state.family.childName },
+      membership: { role: 'participant', status: 'active' },
+    }];
+    this.state.activeParticipantId = 'demo-participant';
     this.persist();
   }
 
@@ -487,6 +512,7 @@ export class DemoRepository implements AppRepository {
     return {
       ...state,
       preferences: normalizeAppPreferences(state.preferences),
+      participantAccess: state.participantAccess ?? [],
       routineAssignments,
       events: state.events.map((event) => ({ ...event, routineId: event.routineId ?? DEFAULT_ROUTINE_ID })),
     };

--- a/src/services/firebaseRepository.ts
+++ b/src/services/firebaseRepository.ts
@@ -28,6 +28,7 @@ import {
 } from '../domain/models';
 import { routineFromCatalog } from '../domain/routineCatalog';
 import { isFreshCapture } from '../domain/adherence';
+import { activeParticipantAccess } from '../domain/participantAccess';
 import { initialRemoteState, PREFERENCES_KEY } from './appStateDefaults';
 import { coalesceInFlight } from './idempotency';
 
@@ -136,6 +137,14 @@ export class FirebaseRepository implements AppRepository {
   async selectRole(role: Role) {
     this.state.role = role;
     this.persistPreferences();
+    this.emit();
+  }
+
+  async selectActiveParticipant(participantId: string) {
+    const access = activeParticipantAccess(this.state.participantAccess, participantId);
+    if (!access) throw new Error('participant_access_not_found');
+    this.state.activeParticipantId = participantId;
+    this.state.family.childName = access.participant.displayName;
     this.emit();
   }
 
@@ -411,6 +420,18 @@ export class FirebaseRepository implements AppRepository {
       childLinked: role === 'child',
       consented: role === 'parent',
     };
+    const membershipRole = role === 'parent' ? 'owner' : 'participant';
+    const existingAccess = this.state.participantAccess?.find((entry) => entry.participant.id === familyId);
+    if (!existingAccess) {
+      this.state.participantAccess = [
+        ...(this.state.participantAccess ?? []),
+        {
+          participant: { id: familyId, displayName: this.state.family.childName },
+          membership: { role: membershipRole, status: 'active' },
+        },
+      ];
+    }
+    this.state.activeParticipantId ??= familyId;
     if (role === 'parent') {
       this.runInBackground('Unable to refresh the parent recovery code', async () => {
         const ensureRecoveryCode = httpsCallable<{ familyId: string }, { recoveryCode: string }>(
@@ -456,6 +477,8 @@ export class FirebaseRepository implements AppRepository {
       const family = snapshot.data() as FamilyDocument;
       const childLinked = Object.values(family.members ?? {}).some((memberRole) => memberRole === 'child');
       this.state.family.childName = family.childName;
+      const participantAccess = this.state.participantAccess?.find((entry) => entry.participant.id === familyId);
+      if (participantAccess) participantAccess.participant.displayName = family.childName;
       this.state.family.childLinked = childLinked || this.state.family.childLinked;
       this.state.family.linkingCode = family.linkingCode ?? this.state.family.linkingCode;
       this.state.family.parentRecoveryCode = family.parentRecoveryCode ?? this.state.family.parentRecoveryCode;


### PR DESCRIPTION
## Summary
- add participant and membership summaries to application state
- support an active participant selection without removing legacy family state
- reject suspended or unrelated participant selections
- migrate persisted demo state and seed compatibility access for current family flows
- keep Firebase and demo repositories aligned

## Validation
- `corepack pnpm exec vitest run src/domain/participantAccess.test.ts`
- `corepack pnpm exec tsc -b --pretty false`
- `git diff --check`

Part of #40.