### PR TITLE
Secure participant relationship reads

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -10,9 +10,24 @@ service cloud.firestore {
         && get(/databases/$(database)/documents/families/$(familyId)).data.members[request.auth.uid] in ['parent', 'child'];
     }
 
+    function participantMembership(participantId) {
+      return get(/databases/$(database)/documents/participants/$(participantId)/memberships/$(request.auth.uid));
+    }
+
+    function canViewParticipant(participantId) {
+      return signedIn()
+        && participantMembership(participantId).data.status == 'active'
+        && participantMembership(participantId).data.permissions.view == true;
+    }
+
     match /users/{userId} {
       allow read: if signedIn() && (request.auth.uid == userId || isChildInFamily(userId));
       allow write: if false;
+
+      match /participantRefs/{participantId} {
+        allow read: if signedIn() && request.auth.uid == userId;
+        allow write: if false;
+      }
     }
 
     function isChildInFamily(userId) {
@@ -40,11 +55,44 @@ service cloud.firestore {
       }
     }
 
+    match /participants/{participantId} {
+      allow read: if canViewParticipant(participantId);
+      allow write: if false;
+
+      match /memberships/{userId} {
+        allow read: if canViewParticipant(participantId);
+        allow write: if false;
+      }
+
+      match /checks/{checkId} {
+        allow read: if canViewParticipant(participantId);
+        allow write: if false;
+      }
+
+      match /routineAssignments/{assignmentId} {
+        allow read: if canViewParticipant(participantId);
+        allow write: if false;
+      }
+
+      match /pushSubscriptions/{subscriptionId} {
+        allow read: if canViewParticipant(participantId);
+        allow write: if false;
+      }
+    }
+
     match /linkCodes/{codeHash} {
       allow read, write: if false;
     }
 
     match /parentRecoveryCodes/{codeHash} {
+      allow read, write: if false;
+    }
+
+    match /relationshipInvitations/{codeHash} {
+      allow read, write: if false;
+    }
+
+    match /relationshipRecoveryCodes/{codeHash} {
       allow read, write: if false;
     }
 

--- a/rules-tests/firestore.rules.test.ts
+++ b/rules-tests/firestore.rules.test.ts
@@ -41,6 +41,65 @@ beforeEach(async () => {
     });
     await setDoc(doc(db, 'users/parent'), { familyId: 'family-1', role: 'parent' });
     await setDoc(doc(db, 'linkCodes/private-hash'), { familyId: 'family-1' });
+    await setDoc(doc(db, 'participants/participant-1'), { displayName: 'Maya', status: 'active' });
+    await setDoc(doc(db, 'participants/participant-1/memberships/parent'), {
+      uid: 'parent', role: 'owner', status: 'active', permissions: { view: true },
+    });
+    await setDoc(doc(db, 'participants/participant-1/memberships/coparent'), {
+      uid: 'coparent', role: 'caregiver', status: 'active', permissions: { view: true },
+    });
+    await setDoc(doc(db, 'participants/participant-1/memberships/suspended'), {
+      uid: 'suspended', role: 'caregiver', status: 'suspended', permissions: { view: true },
+    });
+    await setDoc(doc(db, 'participants/participant-1/checks/check-1'), { status: 'pending' });
+    await setDoc(doc(db, 'participants/participant-1/routineAssignments/routine-1'), { status: 'active' });
+    await setDoc(doc(db, 'users/parent/participantRefs/participant-1'), {
+      participantId: 'participant-1', role: 'owner', status: 'active',
+    });
+    await setDoc(doc(db, 'participants/self-managed'), { displayName: 'Jordan', status: 'active', userId: 'jordan' });
+    await setDoc(doc(db, 'participants/self-managed/memberships/jordan'), {
+      uid: 'jordan', role: 'owner', label: 'self', status: 'active', permissions: { view: true },
+    });
+    await setDoc(doc(db, 'relationshipInvitations/private-invitation'), { participantId: 'participant-1' });
+  });
+});
+
+describe('participant relationship isolation', () => {
+  test('allows two active caregivers to read the same participant data', async () => {
+    for (const uid of ['parent', 'coparent']) {
+      const memberDb = environment.authenticatedContext(uid).firestore();
+      await assertSucceeds(getDoc(doc(memberDb, 'participants/participant-1')));
+      await assertSucceeds(getDocs(collection(memberDb, 'participants/participant-1/memberships')));
+      await assertSucceeds(getDoc(doc(memberDb, 'participants/participant-1/checks/check-1')));
+      await assertSucceeds(getDoc(doc(memberDb, 'participants/participant-1/routineAssignments/routine-1')));
+    }
+  });
+
+  test('allows a self-managed owner to read their participant', async () => {
+    const selfDb = environment.authenticatedContext('jordan').firestore();
+    await assertSucceeds(getDoc(doc(selfDb, 'participants/self-managed')));
+  });
+
+  test('denies unrelated and suspended users', async () => {
+    for (const uid of ['outsider', 'suspended']) {
+      const deniedDb = environment.authenticatedContext(uid).firestore();
+      await assertFails(getDoc(doc(deniedDb, 'participants/participant-1')));
+      await assertFails(getDocs(collection(deniedDb, 'participants/participant-1/checks')));
+    }
+  });
+
+  test('allows only the account owner to read participant indexes', async () => {
+    const parentDb = environment.authenticatedContext('parent').firestore();
+    const coparentDb = environment.authenticatedContext('coparent').firestore();
+    await assertSucceeds(getDoc(doc(parentDb, 'users/parent/participantRefs/participant-1')));
+    await assertFails(getDoc(doc(coparentDb, 'users/parent/participantRefs/participant-1')));
+  });
+
+  test('denies all direct relationship writes and invitation reads', async () => {
+    const parentDb = environment.authenticatedContext('parent').firestore();
+    await assertFails(updateDoc(doc(parentDb, 'participants/participant-1'), { displayName: 'Changed' }));
+    await assertFails(updateDoc(doc(parentDb, 'participants/participant-1/memberships/coparent'), { role: 'owner' }));
+    await assertFails(getDoc(doc(parentDb, 'relationshipInvitations/private-invitation')));
   });
 });
 


### PR DESCRIPTION
## Summary
- authorize participant reads through active canonical memberships with explicit view permission
- allow users to read only their own participant indexes
- expose membership lists to authorized participant members for management screens
- keep all relationship and invitation writes server-only
- test two caregivers, self-management, suspended users, outsiders, and direct-write denial

## Validation
- `corepack pnpm test:rules` (Firestore emulator on temporary port 8081 because local port 8080 was occupied)
- `git diff --check`

Part of #40.