### PR TITLE
Backfill participant routines and checks

### DIFF
--- a/functions/src/audit.ts
+++ b/functions/src/audit.ts
@@ -12,7 +12,8 @@ export type AuditAction =
   | 'create_participant'
   | 'create_relationship_invitation'
   | 'accept_relationship_invitation'
-  | 'migrate_family_relationships';
+  | 'migrate_family_relationships'
+  | 'migrate_family_content';
 
 type AuditMetadataValue = string | number | boolean | null | undefined;
 

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -15,7 +15,7 @@ import { normalizeReminderRepeatMinutes, shouldSendCheckReminder } from './remin
 import { recordAuditEvent } from './audit.js';
 import { expiredPendingCheckCleanupUpdate, staleCleanupCutoffs } from './cleanup.js';
 import { reportOperationalAlert } from './observability.js';
-import { createMembership, hasParticipantPermission, isCompatibleMembershipMigration, isCompatibleParticipantMigration, isCompatibleParticipantRefMigration, membershipRoles, migrateLegacyFamilyRelationships, type MembershipRole } from './relationships.js';
+import { createMembership, hasParticipantPermission, isCompatibleLegacyContentTarget, isCompatibleMembershipMigration, isCompatibleParticipantMigration, isCompatibleParticipantRefMigration, membershipRoles, migrateLegacyFamilyRelationships, type MembershipRole } from './relationships.js';
 
 const storageBucket = process.env.FIREBASE_STORAGE_BUCKET
   ?? (process.env.GCLOUD_PROJECT ? `${process.env.GCLOUD_PROJECT}.firebasestorage.app` : undefined);
@@ -192,6 +192,36 @@ const ensureFamilyRoutineMigration = async (familyRef: FirebaseFirestore.Documen
     updatedAt: FieldValue.serverTimestamp(),
   });
   return assignmentRef.get();
+};
+
+const copyLegacyParticipantSubcollection = async (
+  familyId: string,
+  source: FirebaseFirestore.CollectionReference,
+  target: FirebaseFirestore.CollectionReference,
+) => {
+  const sourceSnapshot = await source.get();
+  const chunkSize = 150;
+  for (let offset = 0; offset < sourceSnapshot.docs.length; offset += chunkSize) {
+    const sourceDocuments = sourceSnapshot.docs.slice(offset, offset + chunkSize);
+    await db.runTransaction(async (transaction) => {
+      const targetRefs = sourceDocuments.map((document) => target.doc(document.id));
+      const targetSnapshots = await transaction.getAll(...targetRefs);
+      sourceDocuments.forEach((sourceDocument, index) => {
+        const targetSnapshot = targetSnapshots[index];
+        if (!isCompatibleLegacyContentTarget(targetSnapshot.data(), familyId, sourceDocument.ref.path)) {
+          throw new HttpsError('already-exists', `Conflicting migrated content at ${targetRefs[index].path}.`);
+        }
+        if (!targetSnapshot.exists) {
+          transaction.create(targetRefs[index], {
+            ...sourceDocument.data(),
+            relationshipSourceFamilyId: familyId,
+            relationshipSourcePath: sourceDocument.ref.path,
+          });
+        }
+      });
+    });
+  }
+  return sourceSnapshot.size;
 };
 
 const recordRecoveryAttempt = async (uid: string) => {
@@ -630,6 +660,59 @@ export const migrateFamilyRelationships = onCall({ region, cors, enforceAppCheck
     participantId: familyId,
   });
   return { participantId: familyId };
+});
+
+export const migrateFamilyContent = onCall({ region, cors, enforceAppCheck: true }, async (request) => {
+  const uid = requireUid(request.auth);
+  const familyId = String(request.data?.familyId ?? '');
+  if (!familyId) throw new HttpsError('invalid-argument', 'Family ID is required.');
+  const familyRef = db.collection('families').doc(familyId);
+  const participantRef = db.collection('participants').doc(familyId);
+  const [family, participant, profile] = await Promise.all([
+    familyRef.get(),
+    participantRef.get(),
+    db.collection('users').doc(uid).get(),
+  ]);
+  if (
+    !family.exists
+    || !participant.exists
+    || !profile.exists
+    || profile.data()?.familyId !== familyId
+    || family.data()?.members?.[uid] !== 'parent'
+    || participant.data()?.sourceFamilyId !== familyId
+  ) {
+    throw new HttpsError('permission-denied', 'Only a linked owner can migrate family content.');
+  }
+  const [routineAssignments, checks, pushSubscriptions] = await Promise.all([
+    copyLegacyParticipantSubcollection(
+      familyId,
+      familyRef.collection('routineAssignments'),
+      participantRef.collection('routineAssignments'),
+    ),
+    copyLegacyParticipantSubcollection(
+      familyId,
+      familyRef.collection('checks'),
+      participantRef.collection('checks'),
+    ),
+    copyLegacyParticipantSubcollection(
+      familyId,
+      familyRef.collection('pushSubscriptions'),
+      participantRef.collection('pushSubscriptions'),
+    ),
+  ]);
+  const migratedAt = new Date().toISOString();
+  await Promise.all([
+    familyRef.set({ relationshipContentMigrationVersion: 1, relationshipContentMigratedAt: migratedAt }, { merge: true }),
+    participantRef.set({ contentMigrationVersion: 1, contentMigratedAt: migratedAt }, { merge: true }),
+  ]);
+  await recordAuditEvent(db, {
+    action: 'migrate_family_content',
+    actorUid: uid,
+    familyId,
+    participantId: familyId,
+    metadata: { routineAssignments, checks, pushSubscriptions },
+  });
+  return { participantId: familyId, routineAssignments, checks, pushSubscriptions };
 });
 
 export const recoverParent = onCall({ region, cors, enforceAppCheck: true }, async (request) => {

--- a/functions/src/migration-rehearsal.test.ts
+++ b/functions/src/migration-rehearsal.test.ts
@@ -1,7 +1,7 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
 import { DEFAULT_ROUTINE_ID, migrateCheckRoutineId } from './routines.js';
-import { isCompatibleMembershipMigration, isCompatibleParticipantMigration, isCompatibleParticipantRefMigration, migrateLegacyFamilyRelationships } from './relationships.js';
+import { isCompatibleLegacyContentTarget, isCompatibleMembershipMigration, isCompatibleParticipantMigration, isCompatibleParticipantRefMigration, migrateLegacyFamilyRelationships } from './relationships.js';
 
 test('rehearses routine migration against representative legacy checks', () => {
   const legacyChecks = [
@@ -75,4 +75,18 @@ test('relationship migration accepts reruns but detects conflicting target data'
   assert.equal(isCompatibleMembershipMigration({ ...migrated.memberships[0], role: 'viewer' }, migrated.memberships[0]), false);
   assert.equal(isCompatibleParticipantRefMigration(migrated.participantRefs[0], migrated.participantRefs[0]), true);
   assert.equal(isCompatibleParticipantRefMigration({ ...migrated.participantRefs[0], participantId: 'another-participant' }, migrated.participantRefs[0]), false);
+});
+
+test('content migration accepts its own copies but rejects colliding participant data', () => {
+  const sourcePath = 'families/family-alex/checks/check-1';
+  assert.equal(isCompatibleLegacyContentTarget(undefined, 'family-alex', sourcePath), true);
+  assert.equal(isCompatibleLegacyContentTarget({
+    relationshipSourceFamilyId: 'family-alex',
+    relationshipSourcePath: sourcePath,
+  }, 'family-alex', sourcePath), true);
+  assert.equal(isCompatibleLegacyContentTarget({ status: 'pending' }, 'family-alex', sourcePath), false);
+  assert.equal(isCompatibleLegacyContentTarget({
+    relationshipSourceFamilyId: 'another-family',
+    relationshipSourcePath: sourcePath,
+  }, 'family-alex', sourcePath), false);
 });

--- a/functions/src/relationships.ts
+++ b/functions/src/relationships.ts
@@ -199,3 +199,12 @@ export const isCompatibleParticipantRefMigration = (
   && existing.role === expected.role
   && existing.status === 'active'
 );
+
+export const isCompatibleLegacyContentTarget = (
+  existing: Record<string, unknown> | undefined,
+  familyId: string,
+  sourcePath: string,
+) => !existing || (
+  existing.relationshipSourceFamilyId === familyId
+  && existing.relationshipSourcePath === sourcePath
+);

--- a/src/services/firebaseRepository.ts
+++ b/src/services/firebaseRepository.ts
@@ -562,6 +562,22 @@ export class FirebaseRepository implements AppRepository {
       const migrateRoutines = httpsCallable<{ familyId: string }, void>(this.services.functions, 'migrateFamilyRoutines');
       await migrateRoutines({ familyId });
     });
+    if (role === 'parent') {
+      this.runInBackground('Unable to migrate family relationships and content', async () => {
+        const migrateRelationships = httpsCallable<{ familyId: string }, { participantId: string }>(
+          this.services.functions,
+          'migrateFamilyRelationships',
+        );
+        const migrateContent = httpsCallable<{ familyId: string }, { participantId: string }>(
+          this.services.functions,
+          'migrateFamilyContent',
+        );
+        await migrateRelationships({ familyId });
+        await migrateContent({ familyId });
+        await this.loadParticipantAccess();
+        this.emit();
+      });
+    }
     const familyRef = doc(this.services.db, 'families', familyId);
     if ((role === 'child' || role === 'parent') && this.user) {
       this.remoteSubscriptions.push(onSnapshot(doc(familyRef, 'pushSubscriptions', this.user.uid), (snapshot) => {


### PR DESCRIPTION
## Summary
- copy legacy routine assignments, checks, and push subscriptions into participant aggregates
- process content in bounded transactions with stable document IDs
- make partial or complete reruns safe
- reject collisions with unrelated target data
- preserve legacy proof paths and source metadata
- trigger relationship and content migration for legacy owners during attachment

## Validation
- `npm --prefix functions test`
- `./node_modules/.bin/tsc -b --pretty false`
- `git diff --check`

Part of #40.