### PR TITLE
Add participant relationship client actions

### DIFF
--- a/src/services/contracts.ts
+++ b/src/services/contracts.ts
@@ -1,4 +1,4 @@
-import type { AnalysisResult, AppPreferences, AppState, Locale, MonitoringPlan, Role, RoutineValidationMode, VerificationEvent } from '../domain/models';
+import type { AnalysisResult, AppPreferences, AppState, Locale, MembershipRole, MonitoringPlan, Role, RoutineValidationMode, VerificationEvent } from '../domain/models';
 
 export interface AppRepository {
   initialize(): Promise<void>;
@@ -6,6 +6,9 @@ export interface AppRepository {
   subscribe(listener: () => void): () => void;
   selectRole(role: Role): Promise<void>;
   selectActiveParticipant?(participantId: string): Promise<void>;
+  createParticipant?(displayName: string, selfManaged?: boolean): Promise<string>;
+  inviteParticipantMember?(participantId: string, role: Exclude<MembershipRole, 'owner'>): Promise<{ code: string; expiresAt: string }>;
+  acceptParticipantInvitation?(code: string): Promise<string>;
   setLocale(locale: Locale): Promise<void>;
   setPreferences(preferences: Partial<AppPreferences>): Promise<void>;
   linkParent(childName: string): Promise<void>;

--- a/src/services/demoRepository.test.ts
+++ b/src/services/demoRepository.test.ts
@@ -156,4 +156,19 @@ describe('DemoRepository compatibility', () => {
     expect(first.events.every((event) => event.routineId === DEFAULT_ROUTINE_ID)).toBe(true);
     expect(second.routineAssignments).toEqual(first.routineAssignments);
   });
+
+  test('creates and accepts additional participant relationships', async () => {
+    const repository = new DemoRepository();
+    await repository.selectRole('parent');
+    const selfManagedId = await repository.createParticipant('Jordan', true);
+
+    expect(repository.snapshot().participantAccess).toContainEqual({
+      participant: { id: selfManagedId, displayName: 'Jordan', selfManaged: true },
+      membership: { role: 'owner', status: 'active', label: 'self' },
+    });
+    await expect(repository.inviteParticipantMember(selfManagedId, 'caregiver')).resolves.toMatchObject({ code: 'ZI-123456' });
+    await expect(repository.acceptParticipantInvitation('invalid')).rejects.toThrow('invalid_code');
+    await expect(repository.acceptParticipantInvitation('ZI-123456')).resolves.toBe('demo-invited');
+    expect(repository.snapshot().activeParticipantId).toBe('demo-invited');
+  });
 });

--- a/src/services/demoRepository.ts
+++ b/src/services/demoRepository.ts
@@ -240,6 +240,46 @@ export class DemoRepository implements AppRepository {
     this.persist();
   }
 
+  async createParticipant(displayName: string, selfManaged = false) {
+    const participantId = `demo-${Date.now()}`;
+    this.state.participantAccess = [
+      ...(this.state.participantAccess ?? []),
+      {
+        participant: { id: participantId, displayName: displayName.trim(), selfManaged },
+        membership: { role: 'owner', status: 'active', ...(selfManaged ? { label: 'self' as const } : {}) },
+      },
+    ];
+    this.state.activeParticipantId = participantId;
+    this.state.family.childName = displayName.trim();
+    this.persist();
+    return participantId;
+  }
+
+  async inviteParticipantMember(participantId: string, role: 'caregiver' | 'participant' | 'viewer') {
+    if (!activeParticipantAccess(this.state.participantAccess, participantId) || role === 'viewer' && this.state.role === 'child') {
+      throw new Error('permission_denied');
+    }
+    return { code: 'ZI-123456', expiresAt: new Date(Date.now() + 86_400_000).toISOString() };
+  }
+
+  async acceptParticipantInvitation(code: string) {
+    if (code.trim().toUpperCase() !== 'ZI-123456') throw new Error('invalid_code');
+    const participantId = 'demo-invited';
+    if (!this.state.participantAccess?.some((entry) => entry.participant.id === participantId)) {
+      this.state.participantAccess = [
+        ...(this.state.participantAccess ?? []),
+        {
+          participant: { id: participantId, displayName: 'Invited participant' },
+          membership: { role: 'caregiver', status: 'active' },
+        },
+      ];
+    }
+    this.state.activeParticipantId = participantId;
+    this.state.family.childName = 'Invited participant';
+    this.persist();
+    return participantId;
+  }
+
   async setLocale(locale: AppState['locale']) {
     this.state.locale = locale;
     this.persist();

--- a/src/services/firebaseRepository.ts
+++ b/src/services/firebaseRepository.ts
@@ -160,6 +160,45 @@ export class FirebaseRepository implements AppRepository {
     }
   }
 
+  async createParticipant(displayName: string, selfManaged = false) {
+    const normalizedName = displayName.trim();
+    const result = await coalesceInFlight(this.inFlightCallables, `createParticipant:${normalizedName}:${selfManaged}`, async () => {
+      const createParticipant = httpsCallable<
+        { displayName: string; selfManaged: boolean },
+        { participantId: string }
+      >(this.services.functions, 'createParticipant');
+      return createParticipant({ displayName: normalizedName, selfManaged });
+    });
+    await this.loadParticipantAccess();
+    const access = activeParticipantAccess(this.state.participantAccess, result.data.participantId);
+    if (access) await this.attachParticipant(result.data.participantId, access.membership.role);
+    return result.data.participantId;
+  }
+
+  async inviteParticipantMember(participantId: string, role: Exclude<MembershipRole, 'owner'>) {
+    const createInvitation = httpsCallable<
+      { participantId: string; role: Exclude<MembershipRole, 'owner'> },
+      { code: string; expiresAt: string }
+    >(this.services.functions, 'createRelationshipInvitation');
+    const result = await createInvitation({ participantId, role });
+    return result.data;
+  }
+
+  async acceptParticipantInvitation(code: string) {
+    const normalizedCode = code.trim().toUpperCase();
+    const result = await coalesceInFlight(this.inFlightCallables, `acceptParticipantInvitation:${normalizedCode}`, async () => {
+      const acceptInvitation = httpsCallable<{ code: string }, { participantId: string }>(
+        this.services.functions,
+        'acceptRelationshipInvitation',
+      );
+      return acceptInvitation({ code: normalizedCode });
+    });
+    await this.loadParticipantAccess();
+    const access = activeParticipantAccess(this.state.participantAccess, result.data.participantId);
+    if (access) await this.attachParticipant(result.data.participantId, access.membership.role);
+    return result.data.participantId;
+  }
+
   async setLocale(locale: Locale) {
     this.state.locale = locale;
     this.persistPreferences();


### PR DESCRIPTION
## Summary
- expose client repository actions to create followed people
- support first-class self-managed participants
- generate scoped caregiver, participant, or viewer invitations
- accept relationship invitations and refresh participant access immediately
- provide matching demo behavior and coverage

## Validation
- `./node_modules/.bin/tsc -b --pretty false`
- `./node_modules/.bin/vitest run src/services/demoRepository.test.ts`
- `git diff --check`

Part of #40.