### PR TITLE
Clarify primary caregiver label

### DIFF
--- a/src/services/i18n.ts
+++ b/src/services/i18n.ts
@@ -333,7 +333,7 @@ const messages = {
     disclaimer: 'Aide à l’observance uniquement. Zadiag ne remplace pas les conseils de votre professionnel de santé.',
     parent: 'Responsable', child: 'Participant', continueAs: 'Continuer en tant que', followedPerson: 'Personne suivie',
     relationshipManagerTitle: 'Personnes suivies', relationshipManagerHint: 'Gérez les personnes associées à ce compte.',
-    relationshipRoleOwner: 'Propriétaire', relationshipRoleCaregiver: 'Responsable', relationshipRoleParticipant: 'Participant', relationshipRoleViewer: 'Observateur',
+    relationshipRoleOwner: 'Responsable principal', relationshipRoleCaregiver: 'Responsable', relationshipRoleParticipant: 'Participant', relationshipRoleViewer: 'Observateur',
     relationshipSelfManaged: 'Auto-suivi', relationshipCreateTitle: 'Ajouter une personne suivie', relationshipNameLabel: 'Nom',
     relationshipSelfManagedLabel: 'Cette personne, c’est moi', relationshipCreateAction: 'Créer', relationshipWorking: 'Traitement…',
     relationshipInviteTitle: 'Inviter une personne', relationshipInviteRole: 'Rôle de l’invitation', relationshipInviteAction: 'Générer l’invitation',


### PR DESCRIPTION
## Summary
- replace the French technical label `Propriétaire` with `Responsable principal`
- keep the underlying owner role and permissions unchanged

## Validation
- `./node_modules/.bin/vitest run src/components/RelationshipManager.test.tsx`
- `./node_modules/.bin/tsc -b --pretty false`
- `git diff --check`