### PR TITLE
Make routine catalog fully scrollable

### DIFF
--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -905,12 +905,34 @@ button {
 }
 
 .routine-list { min-width: 0; gap: 8px; }
-.routine-catalog-card { display: grid; gap: 10px; margin-bottom: 13px; padding: var(--block-padding); overflow: hidden; }
+.routine-catalog-card {
+  display: grid;
+  grid-template-rows: auto minmax(0, 1fr) auto;
+  gap: 10px;
+  height: min(68dvh, 620px);
+  min-height: min(420px, 62dvh);
+  margin-bottom: 13px;
+  padding: var(--block-padding);
+  overflow: hidden;
+}
 .routine-catalog-heading { display: flex; align-items: flex-start; justify-content: space-between; gap: 12px; }
 .routine-catalog-heading small { color: var(--muted); font-size: 10px; font-weight: 900; letter-spacing: .08em; text-transform: uppercase; }
 .routine-catalog-heading h2 { margin-top: 2px; font-size: 18px; }
 .routine-catalog-close { width: 34px; height: 34px; display: grid; place-items: center; border: 0; border-radius: 12px; background: #f1f3f2; color: #91a0a7; font-size: 24px; line-height: 1; font-weight: 850; }
-.routine-catalog-list { display: grid; gap: 0; }
+.routine-catalog-list {
+  min-height: 0;
+  display: grid;
+  align-content: start;
+  gap: 0;
+  overflow-x: hidden;
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  touch-action: pan-y;
+  -webkit-overflow-scrolling: touch;
+  scrollbar-gutter: stable;
+}
+.routine-catalog-list::-webkit-scrollbar { width: 5px; }
+.routine-catalog-list::-webkit-scrollbar-thumb { border-radius: 99px; background: rgba(16,42,67,.18); }
 .routine-catalog-item { display: grid; grid-template-columns: 42px minmax(0, 1fr) auto; align-items: center; gap: 12px; min-height: 64px; padding: var(--row-padding-y) 0; border: 0; border-top: 1px solid rgba(16,42,67,.07); border-radius: 0; background: transparent; }
 .routine-catalog-item-content { min-width: 0; display: grid; gap: 4px; }
 .routine-catalog-meta { display: flex; flex-wrap: wrap; gap: 5px; }
@@ -921,6 +943,11 @@ button {
 .routine-catalog-proof b { color: var(--navy); font-weight: 900; }
 .routine-catalog-add { min-height: 40px; padding: 8px 14px; border: 0; border-radius: 12px; background: var(--routine-accent, var(--teal)); color: white; font-size: 12px; font-weight: 850; white-space: nowrap; }
 .routine-catalog-add:disabled { background: #e8eeee; color: #7d8a92; }
+@media (max-width: 430px) {
+  .routine-catalog-card { height: min(72dvh, 620px); min-height: min(440px, 66dvh); }
+  .routine-catalog-item { grid-template-columns: 36px minmax(0, 1fr); align-items: start; }
+  .routine-catalog-add { grid-column: 2; justify-self: start; }
+}
 .routines-empty-card { display: grid; gap: 6px; padding: var(--block-padding-lg); text-align: center; }
 .routines-empty-card h2 { font-size: 18px; }
 .routines-empty-card p { max-width: 28ch; margin: 0 auto; font-size: 13px; }


### PR DESCRIPTION
## Summary
- size the routine picker against the available viewport height
- give the catalog list an independent touch-friendly scroll area
- prevent routine details from being clipped
- stack the add action below content on narrow iPhone screens

## Validation
- `./node_modules/.bin/vitest run src/screens/RoutinesScreen.test.tsx`
- `./node_modules/.bin/tsc -b --pretty false`
- `./node_modules/.bin/vite build`
- `git diff --check`