### PR TITLE
Align routine add buttons right

### DIFF
--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -946,7 +946,7 @@ button {
 @media (max-width: 430px) {
   .routine-catalog-card { height: min(72dvh, 620px); min-height: min(440px, 66dvh); }
   .routine-catalog-item { grid-template-columns: 36px minmax(0, 1fr); align-items: start; }
-  .routine-catalog-add { grid-column: 2; justify-self: start; }
+  .routine-catalog-add { grid-column: 2; justify-self: end; }
 }
 .routines-empty-card { display: grid; gap: 6px; padding: var(--block-padding-lg); text-align: center; }
 .routines-empty-card h2 { font-size: 18px; }


### PR DESCRIPTION
## Summary
- keep mobile routine actions on their dedicated row
- align Add and Added buttons to the right

## Validation
- `./node_modules/.bin/vitest run src/screens/RoutinesScreen.test.tsx`
- `git diff --check`