### PR TITLE
Expose relationship actions in production

### DIFF
--- a/src/services/repositoryFactory.test.ts
+++ b/src/services/repositoryFactory.test.ts
@@ -38,6 +38,13 @@ class FakeFirebaseRepository implements AppRepository {
   }
 
   async selectRole(role: Role) { this.state = { ...this.state, role }; }
+  async selectActiveParticipant(participantId: string) { this.state.activeParticipantId = participantId; }
+  async createParticipant() { return 'participant-1'; }
+  async inviteParticipantMember() { return { code: 'ZI-123456', expiresAt: '2026-07-12T00:00:00.000Z' }; }
+  async acceptParticipantInvitation() { return 'participant-1'; }
+  async leaveParticipant() {}
+  async createRelationshipRecovery() { return { recoveryCode: 'PR-2345-6789-ABCD', expiresAt: '2026-10-01T00:00:00.000Z' }; }
+  async recoverRelationship() { return { participantId: 'participant-1' }; }
   async setLocale(locale: Locale) { this.state = { ...this.state, locale }; }
   async linkParent() {}
   async recoverParent() {}
@@ -85,5 +92,7 @@ describe('repository factory', () => {
     expect(firebaseRepositoryLoaded).toBe(true);
     expect(repository.snapshot()).toMatchObject({ role: 'parent', family: { linked: true, childName: 'Maya' } });
     expect(listener).toHaveBeenCalled();
+    await expect(repository.inviteParticipantMember?.('participant-1', 'caregiver')).resolves.toMatchObject({ code: 'ZI-123456' });
+    await expect(repository.createRelationshipRecovery?.('participant-1')).resolves.toMatchObject({ recoveryCode: 'PR-2345-6789-ABCD' });
   });
 });

--- a/src/services/repositoryFactory.ts
+++ b/src/services/repositoryFactory.ts
@@ -1,6 +1,6 @@
 import type { AppRepository } from './contracts';
 import { DemoRepository } from './demoRepository';
-import { type AppPreferences, type Locale, type MonitoringPlan, type Role, type RoutineValidationMode } from '../domain/models';
+import { type AppPreferences, type Locale, type MembershipRole, type MonitoringPlan, type Role, type RoutineValidationMode } from '../domain/models';
 import { firebaseEnabled } from './firebaseConfig';
 import { isLocalDemoEnvironment } from './browserEnvironment';
 import { initialRemoteState } from './appStateDefaults';
@@ -29,6 +29,48 @@ class LazyFirebaseRepository implements AppRepository {
 
   async selectRole(role: Role) {
     return (await this.load()).selectRole(role);
+  }
+
+  async selectActiveParticipant(participantId: string) {
+    const repository = await this.load();
+    if (!repository.selectActiveParticipant) throw new Error('participant_selection_unavailable');
+    return repository.selectActiveParticipant(participantId);
+  }
+
+  async createParticipant(displayName: string, selfManaged?: boolean) {
+    const repository = await this.load();
+    if (!repository.createParticipant) throw new Error('participant_creation_unavailable');
+    return repository.createParticipant(displayName, selfManaged);
+  }
+
+  async inviteParticipantMember(participantId: string, role: Exclude<MembershipRole, 'owner'>) {
+    const repository = await this.load();
+    if (!repository.inviteParticipantMember) throw new Error('participant_invitation_unavailable');
+    return repository.inviteParticipantMember(participantId, role);
+  }
+
+  async acceptParticipantInvitation(code: string) {
+    const repository = await this.load();
+    if (!repository.acceptParticipantInvitation) throw new Error('participant_invitation_unavailable');
+    return repository.acceptParticipantInvitation(code);
+  }
+
+  async leaveParticipant(participantId: string) {
+    const repository = await this.load();
+    if (!repository.leaveParticipant) throw new Error('participant_leave_unavailable');
+    return repository.leaveParticipant(participantId);
+  }
+
+  async createRelationshipRecovery(participantId: string) {
+    const repository = await this.load();
+    if (!repository.createRelationshipRecovery) throw new Error('relationship_recovery_unavailable');
+    return repository.createRelationshipRecovery(participantId);
+  }
+
+  async recoverRelationship(code: string) {
+    const repository = await this.load();
+    if (!repository.recoverRelationship) throw new Error('relationship_recovery_unavailable');
+    return repository.recoverRelationship(code);
   }
 
   async setLocale(locale: Locale) {


### PR DESCRIPTION
## Summary
- forward participant selection, creation, invitation, joining, leaving, and recovery through the lazy Firebase repository
- make the relationship management sections visible in production Settings
- cover invitation and recovery forwarding in the repository factory test

## Validation
- `./node_modules/.bin/vitest run src/services/repositoryFactory.test.ts src/components/RelationshipManager.test.tsx`
- `./node_modules/.bin/tsc -b --pretty false`
- `./node_modules/.bin/vite build`
- `git diff --check`