### PR TITLE
Reorder settings refresh action

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zadiag-pwa",
   "private": true,
-  "version": "0.4.42",
+  "version": "0.4.43",
   "type": "module",
   "packageManager": "pnpm@11.7.0",
   "engines": {

--- a/src/screens/SettingsScreen.tsx
+++ b/src/screens/SettingsScreen.tsx
@@ -400,6 +400,26 @@ export function SettingsScreen({
             </dl>
           </ListRow>
           <ListRow
+            icon={<SvgIcon icon={informationCircleOutline} />}
+            title={t('settingsUpdateTitle')}
+            detail={updateDetail}
+            trailing={(
+              <div className="settings-row-control">
+                {updateInfo.badgeLabel ? <span className={`settings-update-badge ${updateSeverity}`}>{updateInfo.badgeLabel}</span> : null}
+                <button
+                  type="button"
+                  className={`settings-inline-action settings-inline-action-contained settings-update-action ${updateSeverity}`}
+                  disabled={updatingApp}
+                  onClick={() => { void forceUpdate(); }}
+                >
+                  {updatingApp ? t('settingsUpdateChecking') : updateInfo.available ? t('settingsUpdateAction') : t('settingsUpdateCheckAction')}
+                </button>
+              </div>
+            )}
+          >
+            {updateError ? <small className="settings-action-error">{t('settingsUpdateError')}</small> : null}
+          </ListRow>
+          <ListRow
             icon={<SvgIcon icon={mailOutline} />}
             title={t('settingsDebugMailTitle')}
             detail={t('settingsDebugMailDetail')}
@@ -429,26 +449,6 @@ export function SettingsScreen({
             {testPushStatus === 'success' ? <small>{t('settingsTestNotificationSuccess')}</small> : null}
             {testPushStatus === 'error' ? <small className="settings-action-error">{t('settingsTestNotificationError')}</small> : null}
             {testPushStatus === 'enableError' ? <small className="settings-action-error">{t('settingsEnableNotificationsError')}</small> : null}
-          </ListRow>
-          <ListRow
-            icon={<SvgIcon icon={informationCircleOutline} />}
-            title={t('settingsUpdateTitle')}
-            detail={updateDetail}
-            trailing={(
-              <div className="settings-row-control">
-                {updateInfo.badgeLabel ? <span className={`settings-update-badge ${updateSeverity}`}>{updateInfo.badgeLabel}</span> : null}
-                <button
-                  type="button"
-                  className={`settings-inline-action settings-inline-action-contained settings-update-action ${updateSeverity}`}
-                  disabled={updatingApp}
-                  onClick={() => { void forceUpdate(); }}
-                >
-                  {updatingApp ? t('settingsUpdateChecking') : updateInfo.available ? t('settingsUpdateAction') : t('settingsUpdateCheckAction')}
-                </button>
-              </div>
-            )}
-          >
-            {updateError ? <small className="settings-action-error">{t('settingsUpdateError')}</small> : null}
           </ListRow>
         </div>
       </section>


### PR DESCRIPTION
## Summary
- move the app refresh/update row directly before Send a report
- keep notification testing below the diagnostic report action
- include version `0.4.43` in the delivery

## Validation
- `./node_modules/.bin/vitest run src/screens/SettingsScreen.test.tsx`
- `./node_modules/.bin/tsc -b --pretty false`
- `git diff --check`