### PR TITLE
Update CI actions to Node 24 runtimes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,15 +17,15 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v4
+      - uses: actions/checkout@v6
+      - uses: pnpm/action-setup@v6
         with:
           version: 11.7.0
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 22
           cache: pnpm
-      - uses: actions/setup-java@v4
+      - uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: 21


### PR DESCRIPTION
## Summary

- update `actions/checkout` to v6
- update `actions/setup-node` to v6
- update `actions/setup-java` to v5
- update `pnpm/action-setup` to v6

## Why

The successful `main` build emitted a GitHub Actions annotation because the previous action majors targeted the deprecated Node.js 20 action runtime. The selected official majors use the supported Node.js 24 runtime while preserving the existing Node 22 project toolchain.

## Validation

- previous full `main` CI passed
- workflow diff check passed
- this PR's GitHub Actions run verifies compatibility of the updated actions
