### PR TITLE
Expose the README quick start

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,21 +51,21 @@ device and does not diagnose, prescribe, or replace professional care.
 [Product brief](docs/product-brief.md) ·
 [Security](SECURITY.md)
 
-<details>
-<summary><strong>Build and run locally</strong></summary>
-
-### Quick start
-
-Requirements: Node.js 22+ and pnpm 11.7+.
+## Quick start
 
 ```sh
-corepack enable
 corepack pnpm install
 corepack pnpm dev
 ```
 
-No Firebase setup is required to explore the product: Zadiag automatically uses
-its local demo mode when public Firebase variables are absent.
+Open the local URL and start exploring. No Firebase configuration is required:
+Zadiag automatically runs in private demo mode.
+
+<details>
+<summary><strong>Developer details</strong></summary>
+
+Requirements: Node.js 22+, pnpm 11.7+, and Java 21 for the complete validation
+suite.
 
 ### Verify before delivery
 


### PR DESCRIPTION
## Summary

- make the two-command Quick Start visible in the README
- state clearly that Firebase configuration is not required for exploration
- keep prerequisites and delivery checks inside the collapsed developer section

## Why

The streamlined README hid the startup path inside technical details. A visible, zero-configuration Quick Start makes the project immediately approachable without reintroducing setup noise.

## Validation

- README is the only changed file
- `git diff --check`
