### PR TITLE
Centralize translations and locale handling

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,7 +2,8 @@ import { lazy, Suspense, useEffect, useMemo, useState, type ComponentType } from
 import { normalizeAppPreferences, type Locale, type Role, type VerificationEvent } from './domain/models';
 import { routeForState, type AppRoute } from './domain/appRouting';
 import { createRepository } from './services/repositoryFactory';
-import { translate, type MessageKey } from './services/i18n';
+import { createTranslator, type MessageKey } from './services/i18n';
+import { documentLanguage } from './services/locale';
 import { BottomNav, type Tab } from './components/BottomNav';
 import { SplashScreen } from './components/SplashScreen';
 import { Snackbar } from './components/Snackbar';
@@ -57,7 +58,7 @@ export const resetNoticeMessageKey = (role: Role | undefined): MessageKey =>
 
 export const isParticipantInvitationCode = (code: string) => /^ZI-\d{6}$/.test(code.trim().toUpperCase());
 
-export const documentLanguageForLocale = (locale: Locale) => locale === 'fr' ? 'fr' : 'en';
+export const documentLanguageForLocale = (locale: Locale) => documentLanguage(locale);
 
 export function App() {
   const repository = useMemo(createRepository, []);
@@ -80,7 +81,7 @@ export function App() {
     () => ('serviceWorker' in navigator ? 'notRegistered' : 'unsupported'),
   );
   const useLocalDemo = isLocalDemoEnvironment();
-  const t = (key: MessageKey) => translate(state.locale, key);
+  const t = createTranslator(state.locale);
   const preferences = normalizeAppPreferences(state.preferences);
   const appRootClassName = 'app-root';
   const {

--- a/src/components/RelationshipManager.tsx
+++ b/src/components/RelationshipManager.tsx
@@ -1,7 +1,7 @@
 import { useState, type FormEvent } from 'react';
 import { settingsOutline } from 'ionicons/icons';
 import type { MembershipRole, ParticipantAccess, ParticipantMember } from '../domain/models';
-import type { MessageKey } from '../services/i18n';
+import { formatMessage, type MessageKey } from '../services/i18n';
 import { ProfileContextCard } from './ProfileContextCard';
 
 type InviteRole = Exclude<MembershipRole, 'owner'>;
@@ -211,7 +211,7 @@ export function RelationshipManager({ access, activeParticipantId, onSelect, onC
             <h3>{t('relationshipDeleteProfileTitle')}</h3>
             <p>{t('relationshipDeleteProfileHint')}</p>
             <button type="button" aria-busy={busy === 'delete'} disabled={Boolean(busy)} onClick={() => {
-              const confirmation = t('relationshipDeleteProfileConfirm').replace('{name}', selectedAccess?.participant.displayName ?? '');
+              const confirmation = formatMessage(t('relationshipDeleteProfileConfirm'), { name: selectedAccess?.participant.displayName ?? '' });
               if (!window.confirm(confirmation)) return;
               void run('delete', async () => {
                 await onDeleteParticipant(selectedParticipantId);

--- a/src/components/RoutineHistoryPanel.tsx
+++ b/src/components/RoutineHistoryPanel.tsx
@@ -8,6 +8,7 @@ import { canRetakeCapture, stalePendingCheckReason, withResolvedEventStatuses } 
 import { coalesceActivePendingEventsByRoutine } from '../domain/dashboardChecks';
 import { EmptyState, ListRow } from './ui';
 import { readUiStorageJson, writeUiStorageString } from '../services/uiStorage';
+import { languageTag } from '../services/locale';
 
 const eventTimestamp = (event: VerificationEvent) =>
   Date.parse(event.capturedAt ?? event.requestedAt);
@@ -69,7 +70,7 @@ export function RoutineHistoryPanel({
   const [excludedRoutineIds, setExcludedRoutineIds] = useState<string[]>(() => readStoredFilters(titleId).routineIds);
   const [requestingEventId, setRequestingEventId] = useState<string>();
   const [hiddenRequestEventIds, setHiddenRequestEventIds] = useState<Record<string, string>>({});
-  const formatterLocale = locale === 'fr' ? 'fr-FR' : 'en-US';
+  const formatterLocale = languageTag(locale);
   const now = Date.now();
   const dateTimeFormatter = useMemo(() => new Intl.DateTimeFormat(formatterLocale, {
     dateStyle: 'short',

--- a/src/domain/models.ts
+++ b/src/domain/models.ts
@@ -1,3 +1,5 @@
+import { translationsForRoutine } from './routineTranslations';
+
 export type Role = 'parent' | 'child';
 export type Locale = 'en' | 'fr';
 export type VerificationStatus =
@@ -261,25 +263,7 @@ export const defaultRoutine: Routine = {
     { id: 'photo', icon: '📷', title: 'Take a clear photo', description: 'Use good light and keep your mouth centered.' },
     { id: 'send', icon: '📤', title: 'Send your proof', description: 'Submit it so the responsible person can review it.' },
   ],
-  translations: {
-    fr: {
-      name: 'Élastiques orthodontiques',
-      description: 'Contrôles quotidiens du port des élastiques orthodontiques.',
-      instructions: 'Porte tes élastiques selon les consignes de ton praticien et envoie une photo claire pour chaque contrôle.',
-      proofExample: 'Photo de la bouche avec les élastiques visibles, en bonne lumière.',
-      analysis: {
-        expectedEvidence: 'Une vue claire de la bouche montrant si les élastiques orthodontiques sont portés.',
-        detectedCriteria: 'les élastiques orthodontiques sont clairement visibles sur les dents ou l’appareil.',
-        notDetectedCriteria: 'la bouche ou les dents sont visibles et les élastiques orthodontiques sont clairement absents.',
-        uncertaintyCriteria: 'la bouche n’est pas assez visible, l’image est floue ou sombre, ou il est impossible de savoir si les élastiques sont présents.',
-      },
-      instructionSteps: [
-        { id: 'wear', icon: '🦷', title: 'Mets tes élastiques', description: 'Suis les consignes de ton praticien.' },
-        { id: 'photo', icon: '📷', title: 'Prends une photo', description: 'Cadre bien ta bouche avec une lumière claire.' },
-        { id: 'send', icon: '📤', title: 'Envoie ta preuve', description: 'Le responsable pourra ensuite la vérifier.' },
-      ],
-    },
-  },
+  translations: translationsForRoutine(DEFAULT_ROUTINE_ID),
 };
 
 export const createDefaultRoutineAssignment = (assignedAt = new Date().toISOString()): RoutineAssignment => ({

--- a/src/domain/routineCatalog.ts
+++ b/src/domain/routineCatalog.ts
@@ -1,5 +1,6 @@
 import { defaultRoutine, type Locale, type Routine } from './models';
 import { presentRoutine } from './routinePresentation';
+import { translationsForRoutine } from './routineTranslations';
 
 // Built-in routines shipped with the app. Shared/custom routines live in the
 // marketplace layer and are snapshotted into RoutineAssignment when assigned.
@@ -28,25 +29,7 @@ export const availableRoutines: Routine[] = [
       { id: 'track', icon: '▣', title: 'Show hydration', description: 'A photo of you drinking water is enough. A bottle, glass, or tracker also works.' },
       { id: 'send', icon: '➤', title: 'Send your proof', description: 'Submit it so the responsible person can review it.' },
     ],
-    translations: {
-      fr: {
-        name: 'Hydratation',
-        description: 'Contrôle quotidien de l’hydratation.',
-        instructions: 'Quand c’est demandé, envoie une photo où tu bois de l’eau ou une preuve claire d’hydratation.',
-        proofExample: 'Photo du participant qui boit de l’eau, verre, bouteille ou suivi d’hydratation visible.',
-        analysis: {
-          expectedEvidence: 'Une photo montrant le participant en train de boire de l’eau suffit. Accepte aussi un verre d’eau, une bouteille d’eau, un suivi d’hydratation ou un autre signe clair de consommation d’eau.',
-          detectedCriteria: 'la photo montre clairement le participant en train de boire de l’eau, ou une autre preuve claire de consommation d’eau.',
-          notDetectedCriteria: 'l’image est claire mais ne montre pas le participant en train de boire, ni eau, ni bouteille, ni verre, ni suivi, ni preuve d’hydratation.',
-          uncertaintyCriteria: 'l’action ou la preuve est ambiguë, coupée, trop sombre, floue ou pourrait ne pas être liée à l’hydratation.',
-        },
-        instructionSteps: [
-          { id: 'prepare', icon: '💧', title: 'Garde de l’eau à portée', description: 'Rends l’hydratation simple pendant la journée.' },
-          { id: 'track', icon: '▣', title: 'Montre l’hydratation', description: 'Une photo où tu bois de l’eau suffit. Une bouteille, un verre ou un suivi fonctionne aussi.' },
-          { id: 'send', icon: '➤', title: 'Envoie ta preuve', description: 'Le responsable pourra ensuite la vérifier.' },
-        ],
-      },
-    },
+    translations: translationsForRoutine('daily-hydration'),
   },
   {
     id: 'medication',
@@ -71,25 +54,7 @@ export const availableRoutines: Routine[] = [
       { id: 'photo', icon: '▣', title: 'Take a clear photo', description: 'Show the expected proof clearly.' },
       { id: 'send', icon: '➤', title: 'Send your proof', description: 'Submit it so the responsible person can review it.' },
     ],
-    translations: {
-      fr: {
-        name: 'Médicament',
-        description: 'Rappel de prise de médicament.',
-        instructions: 'Prends le médicament selon la prescription et envoie une preuve quand elle est demandée.',
-        proofExample: 'Photo de la boîte, du pilulier ou de la dose préparée selon la prescription.',
-        analysis: {
-          expectedEvidence: 'Une preuve claire de prise de médicament, comme la boîte, le pilulier, la dose prescrite ou une autre preuve attendue.',
-          detectedCriteria: 'la photo montre clairement une preuve liée au médicament et cohérente avec la prise ou la préparation de la dose.',
-          notDetectedCriteria: 'l’image est claire mais ne contient ni médicament, ni boîte, ni pilulier, ni dose, ni preuve liée au médicament.',
-          uncertaintyCriteria: 'la preuve est ambiguë, l’objet ou l’étiquette n’est pas clair, ou la qualité empêche une décision fiable.',
-        },
-        instructionSteps: [
-          { id: 'check', icon: '✚', title: 'Vérifie la dose', description: 'Suis la dose et l’horaire prescrits.' },
-          { id: 'photo', icon: '▣', title: 'Prends une photo claire', description: 'Montre clairement la preuve attendue.' },
-          { id: 'send', icon: '➤', title: 'Envoie ta preuve', description: 'Le responsable pourra ensuite la vérifier.' },
-        ],
-      },
-    },
+    translations: translationsForRoutine('medication'),
   },
   {
     id: 'mobility-exercise',
@@ -114,25 +79,7 @@ export const availableRoutines: Routine[] = [
       { id: 'complete', icon: '✓', title: 'Complete the exercise', description: 'Do the routine as agreed with your responsible person.' },
       { id: 'send', icon: '➤', title: 'Send your proof', description: 'Submit it so the responsible person can review it.' },
     ],
-    translations: {
-      fr: {
-        name: 'Exercice',
-        description: 'Contrôle quotidien d’exercice ou de mobilité.',
-        instructions: 'Réalise l’exercice prévu et envoie une preuve quand elle est demandée.',
-        proofExample: 'Photo montrant la position, le matériel ou la preuve d’activité prévue pour la routine.',
-        analysis: {
-          expectedEvidence: 'Une preuve claire que l’exercice ou la routine de mobilité prévue a été réalisée, comme le participant en position, du matériel d’exercice ou une preuve d’activité terminée.',
-          detectedCriteria: 'la photo montre clairement une preuve d’exercice ou de mobilité correspondant à la routine.',
-          notDetectedCriteria: 'l’image est claire mais ne montre ni exercice, ni mobilité, ni matériel, ni position, ni preuve d’activité terminée.',
-          uncertaintyCriteria: 'la scène est ambiguë, trop coupée, trop sombre, floue ou ne montre pas assez de contexte pour vérifier l’exercice.',
-        },
-        instructionSteps: [
-          { id: 'prepare', icon: '✦', title: 'Prépare la séance', description: 'Choisis un espace adapté et suis le plan.' },
-          { id: 'complete', icon: '✓', title: 'Fais l’exercice', description: 'Réalise la routine convenue avec ton responsable.' },
-          { id: 'send', icon: '➤', title: 'Envoie ta preuve', description: 'Le responsable pourra ensuite la vérifier.' },
-        ],
-      },
-    },
+    translations: translationsForRoutine('mobility-exercise'),
   },
 ];
 

--- a/src/domain/routineTranslations.test.ts
+++ b/src/domain/routineTranslations.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest';
+import { availableRoutines } from './routineCatalog';
+import { builtinRoutineTranslations } from './routineTranslations';
+
+describe('built-in routine translations', () => {
+  it('has one centralized translation entry for every built-in routine', () => {
+    expect(Object.keys(builtinRoutineTranslations).sort()).toEqual(
+      availableRoutines.map((routine) => routine.id).sort(),
+    );
+  });
+
+  it('attaches the central entry instead of duplicating localized content', () => {
+    for (const routine of availableRoutines) {
+      expect(routine.translations).toBe(builtinRoutineTranslations[routine.id]);
+      expect(routine.translations?.fr?.name).toBeTruthy();
+    }
+  });
+});

--- a/src/domain/routineTranslations.ts
+++ b/src/domain/routineTranslations.ts
@@ -1,0 +1,86 @@
+import type { Locale, RoutineLocalizedContent } from './models';
+
+type BuiltinRoutineTranslations = Partial<Record<Locale, RoutineLocalizedContent>>;
+
+// All localized content for built-in routines lives here. Routine definitions
+// remain the locale-neutral source for scheduling, validation and persistence.
+export const builtinRoutineTranslations: Record<string, BuiltinRoutineTranslations> = {
+  'orthodontic-elastics': {
+    fr: {
+      name: 'Élastiques orthodontiques',
+      description: 'Contrôles quotidiens du port des élastiques orthodontiques.',
+      instructions: 'Porte tes élastiques selon les consignes de ton praticien et envoie une photo claire pour chaque contrôle.',
+      proofExample: 'Photo de la bouche avec les élastiques visibles, en bonne lumière.',
+      analysis: {
+        expectedEvidence: 'Une vue claire de la bouche montrant si les élastiques orthodontiques sont portés.',
+        detectedCriteria: 'les élastiques orthodontiques sont clairement visibles sur les dents ou l’appareil.',
+        notDetectedCriteria: 'la bouche ou les dents sont visibles et les élastiques orthodontiques sont clairement absents.',
+        uncertaintyCriteria: 'la bouche n’est pas assez visible, l’image est floue ou sombre, ou il est impossible de savoir si les élastiques sont présents.',
+      },
+      instructionSteps: [
+        { id: 'wear', icon: '🦷', title: 'Mets tes élastiques', description: 'Suis les consignes de ton praticien.' },
+        { id: 'photo', icon: '📷', title: 'Prends une photo', description: 'Cadre bien ta bouche avec une lumière claire.' },
+        { id: 'send', icon: '📤', title: 'Envoie ta preuve', description: 'Le responsable pourra ensuite la vérifier.' },
+      ],
+    },
+  },
+  'daily-hydration': {
+    fr: {
+      name: 'Hydratation',
+      description: 'Contrôle quotidien de l’hydratation.',
+      instructions: 'Quand c’est demandé, envoie une photo où tu bois de l’eau ou une preuve claire d’hydratation.',
+      proofExample: 'Photo du participant qui boit de l’eau, verre, bouteille ou suivi d’hydratation visible.',
+      analysis: {
+        expectedEvidence: 'Une photo montrant le participant en train de boire de l’eau suffit. Accepte aussi un verre d’eau, une bouteille d’eau, un suivi d’hydratation ou un autre signe clair de consommation d’eau.',
+        detectedCriteria: 'la photo montre clairement le participant en train de boire de l’eau, ou une autre preuve claire de consommation d’eau.',
+        notDetectedCriteria: 'l’image est claire mais ne montre pas le participant en train de boire, ni eau, ni bouteille, ni verre, ni suivi, ni preuve d’hydratation.',
+        uncertaintyCriteria: 'l’action ou la preuve est ambiguë, coupée, trop sombre, floue ou pourrait ne pas être liée à l’hydratation.',
+      },
+      instructionSteps: [
+        { id: 'prepare', icon: '💧', title: 'Garde de l’eau à portée', description: 'Rends l’hydratation simple pendant la journée.' },
+        { id: 'track', icon: '▣', title: 'Montre l’hydratation', description: 'Une photo où tu bois de l’eau suffit. Une bouteille, un verre ou un suivi fonctionne aussi.' },
+        { id: 'send', icon: '➤', title: 'Envoie ta preuve', description: 'Le responsable pourra ensuite la vérifier.' },
+      ],
+    },
+  },
+  medication: {
+    fr: {
+      name: 'Médicament',
+      description: 'Rappel de prise de médicament.',
+      instructions: 'Prends le médicament selon la prescription et envoie une preuve quand elle est demandée.',
+      proofExample: 'Photo de la boîte, du pilulier ou de la dose préparée selon la prescription.',
+      analysis: {
+        expectedEvidence: 'Une preuve claire de prise de médicament, comme la boîte, le pilulier, la dose prescrite ou une autre preuve attendue.',
+        detectedCriteria: 'la photo montre clairement une preuve liée au médicament et cohérente avec la prise ou la préparation de la dose.',
+        notDetectedCriteria: 'l’image est claire mais ne contient ni médicament, ni boîte, ni pilulier, ni dose, ni preuve liée au médicament.',
+        uncertaintyCriteria: 'la preuve est ambiguë, l’objet ou l’étiquette n’est pas clair, ou la qualité empêche une décision fiable.',
+      },
+      instructionSteps: [
+        { id: 'check', icon: '✚', title: 'Vérifie la dose', description: 'Suis la dose et l’horaire prescrits.' },
+        { id: 'photo', icon: '▣', title: 'Prends une photo claire', description: 'Montre clairement la preuve attendue.' },
+        { id: 'send', icon: '➤', title: 'Envoie ta preuve', description: 'Le responsable pourra ensuite la vérifier.' },
+      ],
+    },
+  },
+  'mobility-exercise': {
+    fr: {
+      name: 'Exercice',
+      description: 'Contrôle quotidien d’exercice ou de mobilité.',
+      instructions: 'Réalise l’exercice prévu et envoie une preuve quand elle est demandée.',
+      proofExample: 'Photo montrant la position, le matériel ou la preuve d’activité prévue pour la routine.',
+      analysis: {
+        expectedEvidence: 'Une preuve claire que l’exercice ou la routine de mobilité prévue a été réalisée, comme le participant en position, du matériel d’exercice ou une preuve d’activité terminée.',
+        detectedCriteria: 'la photo montre clairement une preuve d’exercice ou de mobilité correspondant à la routine.',
+        notDetectedCriteria: 'l’image est claire mais ne montre ni exercice, ni mobilité, ni matériel, ni position, ni preuve d’activité terminée.',
+        uncertaintyCriteria: 'la scène est ambiguë, trop coupée, trop sombre, floue ou ne montre pas assez de contexte pour vérifier l’exercice.',
+      },
+      instructionSteps: [
+        { id: 'prepare', icon: '✦', title: 'Prépare la séance', description: 'Choisis un espace adapté et suis le plan.' },
+        { id: 'complete', icon: '✓', title: 'Fais l’exercice', description: 'Réalise la routine convenue avec ton responsable.' },
+        { id: 'send', icon: '➤', title: 'Envoie ta preuve', description: 'Le responsable pourra ensuite la vérifier.' },
+      ],
+    },
+  },
+};
+
+export const translationsForRoutine = (routineId: string) => builtinRoutineTranslations[routineId];

--- a/src/screens/ChildDashboard.tsx
+++ b/src/screens/ChildDashboard.tsx
@@ -1,6 +1,7 @@
 import { useMemo, useState } from 'react';
 import type { AppState, VerificationEvent } from '../domain/models';
-import type { MessageKey } from '../services/i18n';
+import { formatMessage, type MessageKey } from '../services/i18n';
+import { languageTag } from '../services/locale';
 import { Disclaimer } from '../components/Disclaimer';
 import { StatusPill } from '../components/StatusPill';
 import { AppIcon, routineIconName } from '../components/Icon';
@@ -67,10 +68,10 @@ export function ChildDashboard({
     () => filterEventsBySummaryRange(historyEvents, summaryRange, now),
     [historyEvents, now, summaryRange],
   );
-  const formatTime = (value: string) => new Intl.DateTimeFormat(state.locale === 'fr' ? 'fr-FR' : 'en-US', {
+  const formatTime = (value: string) => new Intl.DateTimeFormat(languageTag(state.locale), {
     timeStyle: 'short',
   }).format(new Date(value));
-  const locale = state.locale === 'fr' ? 'fr-FR' : 'en-US';
+  const locale = languageTag(state.locale);
   const presentations = new Map(state.routineAssignments.map((assignment) => [assignment.routineId, presentRoutine(assignment.routine, state.locale)]));
   const presentationFor = (event: VerificationEvent) => {
     return presentations.get(event.routineId) ?? { name: t('routine'), icon: undefined, style: {} };
@@ -98,7 +99,7 @@ export function ChildDashboard({
   const emptyTodayTitle = hasAttentionToday ? t('keepGoing') : t('niceWork');
   const emptyTodayHint = hasAttentionToday ? t('missedTodayHint') : t('nextCheckHint');
   const missedTodayLabel = missedTodayCount > 0
-    ? t(missedTodayCount === 1 ? 'missedTodayCountOne' : 'missedTodayCountMany').replace('{count}', String(missedTodayCount))
+    ? formatMessage(t(missedTodayCount === 1 ? 'missedTodayCountOne' : 'missedTodayCountMany'), { count: missedTodayCount })
     : undefined;
   const upcomingChecks = useMemo(() => upcomingRoutineChecks(state.routineAssignments, nowDate)
     .map((item) => ({
@@ -226,7 +227,7 @@ export function ChildDashboard({
   return (
     <div className="content-screen child-home">
       <header className="screen-header participant-header">
-        <div><h1>{t('activity')}</h1><p>{t('participantTodaySubtitle').replace('{name}', state.family.childName)}</p></div>
+        <div><h1>{t('activity')}</h1><p>{formatMessage(t('participantTodaySubtitle'), { name: state.family.childName })}</p></div>
         <div className="avatar" aria-hidden="true">{participantInitial}</div>
       </header>
       {pendingSection}

--- a/src/screens/HistoryScreen.tsx
+++ b/src/screens/HistoryScreen.tsx
@@ -3,10 +3,11 @@ import type { MessageKey } from '../services/i18n';
 import { StatusPill } from '../components/StatusPill';
 import { withResolvedEventStatuses } from '../domain/adherence';
 import { ListRow } from '../components/ui';
+import { languageTag } from '../services/locale';
 
 export function HistoryScreen({ events, locale, t }: { events: VerificationEvent[]; locale: Locale; t: (key: MessageKey) => string }) {
   const closed = withResolvedEventStatuses(events).filter((event) => event.status !== 'pending' && event.status !== 'analyzing');
-  const formatDateTime = (value: string) => new Intl.DateTimeFormat(locale === 'fr' ? 'fr-FR' : 'en-US', {
+  const formatDateTime = (value: string) => new Intl.DateTimeFormat(languageTag(locale), {
     dateStyle: 'short',
     timeStyle: 'short',
   }).format(new Date(value));

--- a/src/screens/ParentDashboard.test.tsx
+++ b/src/screens/ParentDashboard.test.tsx
@@ -105,7 +105,8 @@ describe('ParentDashboard', () => {
       ],
     };
 
-    act(() => root.render(<ParentDashboard state={state} regenerateCode={vi.fn()} t={(key) => translate('en', key)} />));
+    // This scenario may cross midnight, so include both calendar days.
+    act(() => root.render(<ParentDashboard state={state} regenerateCode={vi.fn()} summaryRange="twoDays" t={(key) => translate('en', key)} />));
 
     expect(Array.from(container.querySelectorAll('.filter-chips button')).some((button) => button.textContent === 'All')).toBe(false);
     expect(container.querySelectorAll('.parent-history-row')).toHaveLength(2);
@@ -136,7 +137,7 @@ describe('ParentDashboard', () => {
     expect(container.querySelectorAll('.parent-history-row')).toHaveLength(0);
 
     act(() => root.render(<div />));
-    act(() => root.render(<ParentDashboard state={state} regenerateCode={vi.fn()} t={(key) => translate('en', key)} />));
+    act(() => root.render(<ParentDashboard state={state} regenerateCode={vi.fn()} summaryRange="twoDays" t={(key) => translate('en', key)} />));
 
     const restoredHydrationButton = Array.from(container.querySelectorAll('.filter-chips button')).find((button) => button.textContent === 'Hydration');
     const restoredMissedButton = Array.from(container.querySelectorAll('.filter-chips button')).find((button) => button.textContent === 'Missed');

--- a/src/screens/ParentDashboard.tsx
+++ b/src/screens/ParentDashboard.tsx
@@ -12,6 +12,7 @@ import { EmptyState } from '../components/ui';
 import { activePendingEvents as activePendingChecks, upcomingRoutineChecks } from '../domain/dashboardChecks';
 import { ParticipantSelector } from '../components/ParticipantSelector';
 import { useModalFocus } from '../hooks/useModalFocus';
+import { languageTag } from '../services/locale';
 
 export function ParentDashboard({
   state,
@@ -58,7 +59,7 @@ export function ParentDashboard({
     .filter((event) => event.status === 'uncertain' && !['approved', 'rejected'].includes(event.reviewStatus ?? ''))
     .sort((a, b) => Date.parse(b.capturedAt ?? b.requestedAt) - Date.parse(a.capturedAt ?? a.requestedAt)),
   [state.events]);
-  const locale = state.locale === 'fr' ? 'fr-FR' : 'en-US';
+  const locale = languageTag(state.locale);
   const nowDate = useMemo(() => new Date(now), [now]);
   const dateTimeFormatter = useMemo(() => new Intl.DateTimeFormat(locale, {
     dateStyle: 'short',

--- a/src/screens/RoutineDetailScreen.tsx
+++ b/src/screens/RoutineDetailScreen.tsx
@@ -10,6 +10,7 @@ import { dayPeriodLabelKey } from '../domain/taskTimeLabel';
 import { RoutineEditScreen } from './RoutineEditScreen';
 import { SvgIcon } from '../components/SvgIcon';
 import { ActionButton } from '../components/ui';
+import { languageTag } from '../services/locale';
 import { useModalFocus } from '../hooks/useModalFocus';
 
 type DetailTab = 'details' | 'tracking' | 'plan';
@@ -171,7 +172,7 @@ export function RoutineDetailScreen({ assignment, state, back, start, getProofIm
   const rawEvents = state.events.filter((event) => event.routineId === assignment.routineId);
   const events = withResolvedEventStatuses(rawEvents, now);
   const summary = adherenceSummary(events);
-  const locale = state.locale === 'fr' ? 'fr-FR' : 'en-US';
+  const locale = languageTag(state.locale);
   const visual = presentRoutine(assignment.routine, state.locale);
   const next = rawEvents.find((event) => event.status === 'pending' && Date.parse(event.expiresAt) > now);
   const formatDateTime = (value: string) => new Intl.DateTimeFormat(locale, { dateStyle: 'short', timeStyle: 'short' }).format(new Date(value));

--- a/src/screens/RoutinesScreen.tsx
+++ b/src/screens/RoutinesScreen.tsx
@@ -2,7 +2,8 @@ import { lazy, Suspense, useEffect, useMemo, useState } from 'react';
 import { addCircleOutline } from 'ionicons/icons';
 import type { AppState, MonitoringPlan, RoutineAssignment, RoutineCategory, RoutineValidationMode, ScheduleGroup, VerificationEvent } from '../domain/models';
 import { groupsFromLegacyPlan, nextPlannedWindow, summarizeWeekdaysShort } from '../domain/monitoringPlan';
-import type { MessageKey } from '../services/i18n';
+import { formatMessage, type MessageKey } from '../services/i18n';
+import { languageTag } from '../services/locale';
 import { AppIcon, routineIconName } from '../components/Icon';
 import { ProfileContextCard } from '../components/ProfileContextCard';
 import { presentRoutine } from '../domain/routinePresentation';
@@ -259,10 +260,11 @@ export function RoutinesScreen({
     }
     const routineEvents = state.events.filter((event) => event.routineId === assignment.routineId);
     const activeChecks = routineEvents.filter((event) => event.status === 'pending' && Date.parse(event.expiresAt) > Date.now()).length;
-    const confirmation = t('confirmDeleteRoutine')
-      .replace('{routine}', routineName)
-      .replace('{checks}', String(routineEvents.length))
-      .replace('{activeChecks}', String(activeChecks));
+    const confirmation = formatMessage(t('confirmDeleteRoutine'), {
+      routine: routineName,
+      checks: routineEvents.length,
+      activeChecks,
+    });
     if (!window.confirm(confirmation)) return;
     setDeletingRoutineId(assignment.routineId);
     setDeleteErrorRoutineId(undefined);
@@ -361,7 +363,7 @@ export function RoutinesScreen({
             const next = activePendingByRoutineId.get(assignment.routineId);
             const rate = completionRatesByRoutineId.get(assignment.routineId) ?? 0;
             const visual = presentRoutine(assignment.routine, state.locale);
-            const locale = state.locale === 'fr' ? 'fr-FR' : 'en-US';
+            const locale = languageTag(state.locale);
             const planned = next ? undefined : nextPlannedWindow(assignment.plan, nowDate);
             const nextLabel = next
               ? `${t('before')} ${formatRoutineTime(new Date(next.expiresAt), locale)}`
@@ -436,7 +438,7 @@ export function RoutinesScreen({
                         <button
                           type="button"
                           className="routine-list-delete-button"
-                          aria-label={t('deleteRoutine').replace('{routine}', visual.name)}
+                          aria-label={formatMessage(t('deleteRoutine'), { routine: visual.name })}
                           disabled={deletingRoutineId === assignment.routineId || deletingLastRoutine}
                           onClick={() => { void deleteRoutine(assignment, visual.name); }}
                         >
@@ -453,7 +455,7 @@ export function RoutinesScreen({
                         {requestStatus === 'error' && (
                           <p role="status" aria-live="polite" className="request-feedback error">
                             {retryBlocked
-                              ? `${t('requestCheckError')} ${t('retryInSeconds').replace('{seconds}', String(retryInSeconds))}`
+                              ? `${t('requestCheckError')} ${formatMessage(t('retryInSeconds'), { seconds: retryInSeconds })}`
                               : t('requestCheckError')}
                           </p>
                         )}

--- a/src/screens/SettingsScreen.tsx
+++ b/src/screens/SettingsScreen.tsx
@@ -9,13 +9,14 @@ import {
   trashOutline,
 } from 'ionicons/icons';
 import type { AppPreferences, Locale, MembershipRole, ParticipantAccess, ParticipantMember, PushSubscriptionHealth, Role, VerificationEvent } from '../domain/models';
-import type { MessageKey } from '../services/i18n';
+import { formatMessage, type MessageKey } from '../services/i18n';
 import { buildDiagnosticsEmailBody, createCorrelationId } from '../services/appLogs';
 import type { AppUpdateInfo } from '../services/appUpdate';
 import { Disclaimer } from '../components/Disclaimer';
 import { ActionButton, ListRow, SegmentedControl } from '../components/ui';
 import { SvgIcon } from '../components/SvgIcon';
 import { RelationshipManager } from '../components/RelationshipManager';
+import { languageTag } from '../services/locale';
 
 const SUPPORT_EMAIL = 'contact@3dime.com';
 
@@ -213,7 +214,7 @@ export function SettingsScreen({
     : 'anytime';
   const reminderRepeatLabel = preferences.reminderRepeatMinutes === 0
     ? t('settingsReminderRepeatDetailOff')
-    : t('settingsReminderRepeatDetail').replace('{minutes}', String(preferences.reminderRepeatMinutes));
+    : formatMessage(t('settingsReminderRepeatDetail'), { minutes: preferences.reminderRepeatMinutes });
   const updateSeverity = updateInfo.available ? updateInfo.severity : 'none';
   const updateDetail = updateInfo.available
     ? updateInfo.severity === 'major'
@@ -230,7 +231,7 @@ export function SettingsScreen({
       ? 'settingsServiceWorkerUnsupported'
       : 'settingsServiceWorkerMissing';
   const formattedLastSync = lastSyncAt
-    ? new Intl.DateTimeFormat(locale === 'fr' ? 'fr-FR' : 'en-US', {
+    ? new Intl.DateTimeFormat(languageTag(locale), {
       day: '2-digit',
       month: '2-digit',
       hour: '2-digit',
@@ -241,7 +242,7 @@ export function SettingsScreen({
     if (!value) return t('settingsDiagnosticsMissing');
     const date = new Date(value);
     if (Number.isNaN(date.getTime())) return value;
-    return new Intl.DateTimeFormat(locale === 'fr' ? 'fr-FR' : 'en-US', {
+    return new Intl.DateTimeFormat(languageTag(locale), {
       day: '2-digit',
       month: '2-digit',
       hour: '2-digit',

--- a/src/services/appLogs.ts
+++ b/src/services/appLogs.ts
@@ -1,5 +1,6 @@
 import type { Locale, PushSubscriptionHealth, Role, VerificationEvent } from '../domain/models';
 import { firebaseConfig, firebaseEnabled } from './firebaseConfig';
+import { translate } from './i18n';
 
 type LogLevel = 'log' | 'info' | 'warn' | 'error' | 'debug';
 
@@ -221,9 +222,9 @@ export const buildDiagnosticsEmailBody = (input: DiagnosticsInput): string => {
     : ['No logs recorded yet.'];
 
   return [
-    'Bonjour équipe 3Dime,',
+    translate(input.locale, 'diagnosticsEmailGreeting'),
     '',
-    'Voici un rapport de debug généré depuis Zadiag.',
+    translate(input.locale, 'diagnosticsEmailIntro'),
     '',
     '--- CORRELATION ---',
     ...correlationLines,

--- a/src/services/appStateDefaults.ts
+++ b/src/services/appStateDefaults.ts
@@ -5,10 +5,11 @@ import {
   type Locale,
   type Role,
 } from '../domain/models';
+import { resolveLocale } from './locale';
 
 export const PREFERENCES_KEY = 'zadiag.preferences.v1';
 
-export const browserLocale = (): Locale => navigator.language?.startsWith('fr') ? 'fr' : 'en';
+export const browserLocale = (): Locale => resolveLocale(navigator.language);
 
 export const readStoredPreferences = () => {
   try {

--- a/src/services/i18n.test.ts
+++ b/src/services/i18n.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest';
+import { createTranslator, messageCatalogs, translate } from './i18n';
+import { supportedLocales } from './locale';
+
+describe('i18n', () => {
+  it('interpolates parameters through the translation API', () => {
+    expect(translate('en', 'relationshipSelectedProfileActionsTitle', { name: 'Mina' })).toBe('Actions for Mina');
+    expect(translate('fr', 'retryInSeconds', { seconds: 12 })).toBe('Réessai dans 12s.');
+  });
+
+  it('keeps an unknown placeholder visible', () => {
+    expect(translate('en', 'deleteRoutine', {})).toBe('Delete {routine}');
+  });
+
+  it('creates a locale-bound translator', () => {
+    expect(createTranslator('fr')('settingsLanguageTitle')).toBe('Langue');
+  });
+
+  it('keeps every locale complete and placeholders aligned', () => {
+    const englishKeys = Object.keys(messageCatalogs.en).sort();
+    const placeholders = (message: string) =>
+      Array.from(message.matchAll(/\{([^{}]+)\}/g), (match) => match[1]).sort();
+
+    for (const locale of supportedLocales) {
+      expect(Object.keys(messageCatalogs[locale]).sort()).toEqual(englishKeys);
+      for (const key of englishKeys) {
+        const messageKey = key as keyof typeof messageCatalogs.en;
+        expect(placeholders(messageCatalogs[locale][messageKey]), `${locale}.${key}`).toEqual(
+          placeholders(messageCatalogs.en[messageKey]),
+        );
+      }
+    }
+  });
+});

--- a/src/services/i18n.ts
+++ b/src/services/i18n.ts
@@ -154,6 +154,8 @@ const messages = {
     settingsNotificationsDetailDisabled: 'Enable reminders to receive checks',
     settingsDebugMailTitle: 'Send report',
     settingsDebugMailDetail: 'Include device, app and recent logs.',
+    diagnosticsEmailGreeting: 'Hello 3Dime team,',
+    diagnosticsEmailIntro: 'Here is a debug report generated from Zadiag.',
     settingsDebugMailSend: 'Send',
     settingsDebugMailError: 'Unable to open your email app. Please try again.',
     settingsTestNotificationTitle: 'Test notification',
@@ -468,6 +470,8 @@ const messages = {
     settingsNotificationsDetailDisabled: 'Active les rappels pour recevoir les contrôles',
     settingsDebugMailTitle: 'Envoyer un rapport',
     settingsDebugMailDetail: 'Inclut appareil, app et logs récents.',
+    diagnosticsEmailGreeting: 'Bonjour équipe 3Dime,',
+    diagnosticsEmailIntro: 'Voici un rapport de debug généré depuis Zadiag.',
     settingsDebugMailSend: 'Envoyer',
     settingsDebugMailError: 'Impossible d’ouvrir l’app email. Réessaie.',
     settingsTestNotificationTitle: 'Notification test',
@@ -632,4 +636,18 @@ const messages = {
 } as const;
 
 export type MessageKey = keyof typeof messages.en;
-export const translate = (locale: Locale, key: MessageKey) => messages[locale][key];
+export const messageCatalogs = messages;
+export type MessageParams = Readonly<Record<string, string | number>>;
+export type Translator = (key: MessageKey, params?: MessageParams) => string;
+
+export const formatMessage = (message: string, params?: MessageParams) => {
+  if (!params) return message;
+  return message.replace(/\{([^{}]+)\}/g, (placeholder, name: string) =>
+    Object.hasOwn(params, name) ? String(params[name]) : placeholder);
+};
+
+export const translate = (locale: Locale, key: MessageKey, params?: MessageParams) =>
+  formatMessage(messages[locale][key], params);
+
+export const createTranslator = (locale: Locale): Translator =>
+  (key, params) => translate(locale, key, params);

--- a/src/services/locale.ts
+++ b/src/services/locale.ts
@@ -1,0 +1,14 @@
+import type { Locale } from '../domain/models';
+
+export const supportedLocales = ['en', 'fr'] as const satisfies readonly Locale[];
+
+export const localeConfig: Record<Locale, { languageTag: string; documentLanguage: string; label: string }> = {
+  en: { languageTag: 'en-US', documentLanguage: 'en', label: 'English' },
+  fr: { languageTag: 'fr-FR', documentLanguage: 'fr', label: 'Français' },
+};
+
+export const languageTag = (locale: Locale) => localeConfig[locale].languageTag;
+export const documentLanguage = (locale: Locale) => localeConfig[locale].documentLanguage;
+
+export const resolveLocale = (language?: string): Locale =>
+  language?.toLowerCase().startsWith('fr') ? 'fr' : 'en';


### PR DESCRIPTION
## What changed

- centralize supported locale metadata and regional formatting
- centralize message interpolation for translated placeholders
- move built-in routine translations into one dedicated registry
- localize diagnostic email copy through the shared message catalog
- add coverage for catalog completeness, placeholder parity, and routine translation uniqueness

## Why

Language-specific values and formatting logic were spread across screens and routine definitions. This made translations easier to duplicate, omit, or update inconsistently.

## Impact

Adding or changing a language now has a clear set of central sources and automated checks. Existing English and French UI behavior remains intact.

## Validation

- `npm test` — 167 tests passed
- `npm run build`
- `git diff --check`
