### PR TITLE
Automate dependency security and immutable releases

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,52 @@
+version: 2
+
+updates:
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: "05:20"
+    open-pull-requests-limit: 5
+    groups:
+      routine-updates:
+        patterns:
+          - "*"
+        update-types:
+          - minor
+          - patch
+      security-updates:
+        applies-to: security-updates
+        patterns:
+          - "*"
+
+  - package-ecosystem: npm
+    directory: /functions
+    schedule:
+      interval: weekly
+      day: monday
+      time: "05:30"
+    open-pull-requests-limit: 5
+    groups:
+      routine-updates:
+        patterns:
+          - "*"
+        update-types:
+          - minor
+          - patch
+      security-updates:
+        applies-to: security-updates
+        patterns:
+          - "*"
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: "05:40"
+    open-pull-requests-limit: 3
+    groups:
+      routine-actions:
+        patterns:
+          - "*"

--- a/.github/workflows/force-version-bump.yml
+++ b/.github/workflows/force-version-bump.yml
@@ -1,4 +1,4 @@
-name: 🏷️ Force app version bump
+name: Publish version-only release
 
 on:
   workflow_dispatch:
@@ -21,17 +21,22 @@ on:
 permissions:
   contents: write
 
+concurrency:
+  group: version-only-release
+  cancel-in-progress: false
+
 jobs:
   bump-version:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 22
 
@@ -51,8 +56,12 @@ jobs:
             const pkg = JSON.parse(fs.readFileSync('package.json', 'utf8'));
             const versionType = process.env.VERSION_TYPE;
             const customVersion = process.env.CUSTOM_VERSION;
-            const parts = String(pkg.version || '0.0.0').split('.').map((v) => Number(v) || 0);
-            let [major, minor, patch] = parts;
+            const current = String(pkg.version || '0.0.0');
+            const parts = current.split('.').map(Number);
+            if (parts.length !== 3 || parts.some((part) => !Number.isInteger(part) || part < 0)) {
+              throw new Error('Invalid current version: ' + current);
+            }
+            const [major, minor, patch] = parts;
             let next = '';
             if (versionType === 'custom') {
               if (!customVersion) throw new Error('custom_version is required when version_type=custom');
@@ -67,6 +76,11 @@ jobs:
               throw new Error('Unsupported version type');
             }
             if (!/^\\d+\\.\\d+\\.\\d+$/.test(next)) throw new Error('Invalid version format: ' + next);
+            const nextParts = next.split('.').map(Number);
+            const isNewer = nextParts.some((part, index) =>
+              part > parts[index] && nextParts.slice(0, index).every((value, previous) => value === parts[previous])
+            );
+            if (!isNewer) throw new Error('New version must be greater than ' + current);
             pkg.version = next;
             fs.writeFileSync('package.json', JSON.stringify(pkg, null, 2) + '\\n');
             process.stdout.write(next);
@@ -74,29 +88,35 @@ jobs:
           echo "version=$NEW_VERSION" >> "$GITHUB_OUTPUT"
           echo "Target version: $NEW_VERSION"
 
-      - name: Commit and push version bump
-        run: |
-          git add package.json
-          git commit -m "chore(version): bump to ${{ steps.bump.outputs.version }} [skip ci]"
-          git push
-
-      - name: Create or update Git tag
+      - name: Refuse an existing tag or release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           TAG="v${{ steps.bump.outputs.version }}"
-          git tag -f -a "$TAG" -m "Release ${{ steps.bump.outputs.version }}"
-          git push origin "$TAG" --force
+          if git ls-remote --exit-code --tags origin "refs/tags/$TAG" >/dev/null 2>&1; then
+            echo "::error::Tag $TAG already exists and will not be overwritten."
+            exit 1
+          fi
+          if gh release view "$TAG" >/dev/null 2>&1; then
+            echo "::error::Release $TAG already exists and will not be overwritten."
+            exit 1
+          fi
 
-      - name: Create or update GitHub Release
+      - name: Commit, tag, and push atomically
+        run: |
+          TAG="v${{ steps.bump.outputs.version }}"
+          git add package.json
+          git commit -m "chore(version): bump to ${{ steps.bump.outputs.version }} [skip ci]"
+          git tag -a "$TAG" -m "Release ${{ steps.bump.outputs.version }}"
+          git push --atomic origin HEAD:main "$TAG"
+
+      - name: Create GitHub Release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           TAG="v${{ steps.bump.outputs.version }}"
           TITLE="Release ${{ steps.bump.outputs.version }}"
-          if gh release view "$TAG" >/dev/null 2>&1; then
-            gh release edit "$TAG" --title "$TITLE" --notes "Manual release for $TAG" --latest
-          else
-            gh release create "$TAG" --title "$TITLE" --notes "Manual release for $TAG" --latest
-          fi
+          gh release create "$TAG" --verify-tag --title "$TITLE" --notes "Version-only release for $TAG" --latest
 
       - name: Summary
         run: |

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,0 +1,29 @@
+name: Dependency security
+
+on:
+  schedule:
+    - cron: "17 5 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: dependency-security
+  cancel-in-progress: true
+
+jobs:
+  audit:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v6
+      - uses: pnpm/action-setup@v6
+        with:
+          version: 11.7.0
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          cache: pnpm
+      - name: Audit production dependencies
+        run: pnpm check:security

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -34,3 +34,10 @@ and ways to bypass retention or deletion controls.
 
 General product suggestions and non-sensitive defects belong in the regular
 issue tracker. Never test against another person's account or data.
+
+## Automated dependency controls
+
+GitHub audits production dependencies every week and Dependabot monitors the web
+application, Functions, and workflow actions. Routine minor and patch updates are
+grouped to keep each maintenance change coherent. Security findings still require
+impact review, relevant tests, and the normal delivery checks before merging.

--- a/docs/deployment-workflow.md
+++ b/docs/deployment-workflow.md
@@ -42,7 +42,15 @@ Before opening the delivery pull request:
 
 The merge into `main` creates the single production deployment. There is no automatic follow-up version commit.
 
-Use the manual **Force app version bump** GitHub workflow only when a version-only release is intentionally required. Because it writes to `main`, it creates its own production deployment.
+Use the manual **Publish version-only release** GitHub workflow only when a version-only release is intentionally required. Because it writes to `main`, it creates its own production deployment.
+
+The workflow accepts only a version greater than the current application version. It refuses an existing tag or release, then pushes the version commit and annotated tag atomically. GitHub release immutability is enabled for the repository and applies to future releases. Published version tags and releases are never moved or edited; use a new version to correct a release.
+
+## Dependency security
+
+Production dependency audits run every Monday and can also be started manually through the **Dependency security** workflow. Dependabot checks the web app, Functions, and GitHub Actions weekly. Minor and patch updates are grouped by deployment unit so routine maintenance remains reviewable without producing a stream of tiny pull requests.
+
+Treat an audit or Dependabot alert as a signal to inspect the affected dependency and its reachable use before upgrading. Keep the remediation in one validated batch and run `pnpm check` (`pnpm check:full` when Firestore rules are involved) before merging it.
 
 ## Expected deployment count
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zadiag-pwa",
   "private": true,
-  "version": "0.5.80",
+  "version": "0.5.81",
   "type": "module",
   "packageManager": "pnpm@11.7.0",
   "engines": {
@@ -15,7 +15,7 @@
     "check:design": "node scripts/check-design.mjs",
     "check": "npm run check:architecture && npm run check:design && npm run test && npm run build && npm run check:bundle && npm --prefix functions test",
     "check:full": "npm run check && npm run test:rules",
-    "check:security": "pnpm audit --prod --audit-level high && npm --prefix functions audit --omit=dev --audit-level=high",
+    "check:security": "corepack pnpm audit --prod --audit-level high && npm --prefix functions audit --omit=dev --audit-level=high",
     "icons": "node scripts/generate-icons.mjs",
     "preview": "vite preview --host 0.0.0.0",
     "test": "vitest run",


### PR DESCRIPTION
## Summary

- schedule weekly production dependency audits and keep a manual trigger
- group routine Dependabot updates for the web app, Functions, and GitHub Actions
- reject reused or downgraded versions and push version commits with annotated tags atomically
- create releases without force-updating tags or editing existing releases
- document the dependency and release guardrails and bump the app to 0.5.81

## Why

The security audit existed but was not automated, and the manual version workflow could rewrite published tags and releases. This makes dependency monitoring continuous while keeping maintenance changes coherent, and gives future releases immutable identities.

## Validation

- `corepack pnpm check:security` — no known production vulnerabilities
- `corepack pnpm check` — architecture, design, 182 frontend tests, production build, bundle budget, and 59 Functions tests passed
- YAML parsing for all changed workflow and Dependabot files
- GitHub Dependabot alerts/security updates verified enabled and unpaused
- GitHub release immutability enabled for future releases
