### PR TITLE
Prevent setup alerts when switching profiles

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zadiag-pwa",
   "private": true,
-  "version": "0.5.91",
+  "version": "0.5.92",
   "type": "module",
   "packageManager": "pnpm@11.7.0",
   "engines": {

--- a/src/App.test.ts
+++ b/src/App.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { DEFAULT_ROUTINE_ID, type AppState, type VerificationEvent } from './domain/models';
-import { appBadgeCountForState, documentLanguageForLocale, isParticipantInvitationCode, participantIdForNotificationLaunch, resetNoticeMessageKey } from './App';
+import { appBadgeCountForState, documentLanguageForLocale, isParticipantInvitationCode, participantIdForNotificationLaunch, resetNoticeMessageKey, setupCompletionTransition } from './App';
 
 const activePendingEvent = (expiresAt: string): VerificationEvent => ({
   id: 'check-1',
@@ -83,5 +83,34 @@ describe('participantIdForNotificationLaunch', () => {
       { ...state, role: 'child' },
       { kind: 'review', participantId: 'alex' },
     )).toBeUndefined();
+  });
+});
+
+describe('setupCompletionTransition', () => {
+  const completeParentState = {
+    role: 'parent' as const,
+    notificationsEnabled: true,
+    family: { linked: true, childLinked: true, childName: 'Maya', linkingCode: '', parentRecoveryCode: '', consented: true },
+    routineAssignments: [{ routineId: 'routine' }] as AppState['routineAssignments'],
+    routinesLoaded: true,
+  };
+
+  it('ignores the temporary empty routine state while switching followed profiles', () => {
+    const loading = setupCompletionTransition(true, {
+      ...completeParentState,
+      routineAssignments: [],
+      routinesLoaded: false,
+    });
+    const loaded = setupCompletionTransition(loading.complete, completeParentState);
+
+    expect(loading).toEqual({ complete: true });
+    expect(loaded).toEqual({ complete: true });
+  });
+
+  it('still announces a real first routine completion', () => {
+    expect(setupCompletionTransition(false, completeParentState)).toEqual({
+      complete: true,
+      noticeKey: 'parentSetupComplete',
+    });
   });
 });

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -63,6 +63,22 @@ export const isParticipantInvitationCode = (code: string) => /^ZI-\d{6}$/.test(c
 
 export const documentLanguageForLocale = (locale: Locale) => documentLanguage(locale);
 
+export const setupCompletionTransition = (
+  previous: boolean | undefined,
+  state: Pick<AppState, 'role' | 'family' | 'notificationsEnabled' | 'routineAssignments' | 'routinesLoaded'>,
+): { complete: boolean | undefined; noticeKey?: MessageKey } => {
+  if (!state.role || (state.role === 'parent' && state.routinesLoaded === false)) return { complete: previous };
+  const complete = state.role === 'parent'
+    ? state.family.linked && state.family.childLinked && state.routineAssignments.length > 0
+    : state.family.linked && state.notificationsEnabled;
+  return {
+    complete,
+    ...(previous === false && complete
+      ? { noticeKey: state.role === 'parent' ? 'parentSetupComplete' : 'participantSetupComplete' }
+      : {}),
+  };
+};
+
 export const participantIdForNotificationLaunch = (
   state: AppState,
   intent = notificationLaunchIntent(),
@@ -127,14 +143,10 @@ export function App() {
 
   useEffect(() => {
     if (!ready || !state.role) return;
-    const setupComplete = state.role === 'parent'
-      ? state.family.linked && state.family.childLinked && state.routineAssignments.length > 0
-      : state.family.linked && state.notificationsEnabled;
-    if (setupCompleteRef.current === false && setupComplete) {
-      setSetupNoticeKey(state.role === 'parent' ? 'parentSetupComplete' : 'participantSetupComplete');
-    }
-    setupCompleteRef.current = setupComplete;
-  }, [ready, state.family.childLinked, state.family.linked, state.notificationsEnabled, state.role, state.routineAssignments.length]);
+    const transition = setupCompletionTransition(setupCompleteRef.current, state);
+    if (transition.noticeKey) setSetupNoticeKey(transition.noticeKey);
+    setupCompleteRef.current = transition.complete;
+  }, [ready, state.family.childLinked, state.family.linked, state.notificationsEnabled, state.role, state.routineAssignments.length, state.routinesLoaded]);
 
   useEffect(() => {
     if (!ready || !firebaseEnabled || !state.family.id || !state.role) return;


### PR DESCRIPTION
## Summary
- preserve completed onboarding while a followed profile is loading its routines
- prevent profile switches from replaying the setup-complete snackbar
- keep the confirmation for a genuinely created first routine
- add regression coverage for both transitions

## Validation
- `corepack pnpm check`
- `git diff --check`