### PR TITLE
Fix timezone-dependent child dashboard test

### DIFF
--- a/src/screens/ChildDashboard.test.tsx
+++ b/src/screens/ChildDashboard.test.tsx
@@ -197,7 +197,7 @@ describe('participant Today screen', () => {
     yesterday.setDate(yesterday.getDate() - 1);
     const submittedToday = {
       ...event('submitted-today', 'detected', yesterday.toISOString(), atToday(12)),
-      capturedAt: atToday(14),
+      capturedAt: atToday(10),
     };
     const state: AppState = {
       role: 'child',


### PR DESCRIPTION
## Summary
- make the child dashboard history fixture independent from the runner timezone
- keep the captured check before the frozen current time in UTC and Europe/Paris

## Validation
- TZ=UTC ./node_modules/.bin/vitest run src/screens/ChildDashboard.test.tsx
- TZ=Europe/Paris ./node_modules/.bin/vitest run src/screens/ChildDashboard.test.tsx
- npm run check (passed as part of npm run check:full)

Note: the Firestore emulator portion could not start locally because port 8080 is occupied by an unrelated service; Firestore rules are unchanged.