### PR TITLE
Improve notification icon and clear viewed badges

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zadiag-pwa",
   "private": true,
-  "version": "0.7.0",
+  "version": "0.7.1",
   "type": "module",
   "packageManager": "pnpm@11.7.0",
   "engines": {

--- a/src/components/NotificationCenter.test.tsx
+++ b/src/components/NotificationCenter.test.tsx
@@ -11,7 +11,7 @@ describe('NotificationCenter', () => {
     vi.restoreAllMocks();
   });
 
-  it('persists read state per profile after opening the relevant event', () => {
+  it('clears the unread badge when the notification center is opened', () => {
     const container = document.createElement('div');
     document.body.appendChild(container);
     const root = createRoot(container);
@@ -42,12 +42,12 @@ describe('NotificationCenter', () => {
     expect(trigger?.textContent).toBe('1');
     act(() => trigger?.click());
     expect(container.textContent).toContain('Check ready');
+    expect(container.querySelector('.notification-center-trigger')?.textContent).toBe('');
+    expect(localStorage.getItem('zadiag.notificationCenter.read.child.maya')).toBe('["check_ready:ready"]');
     const notification = container.querySelector<HTMLButtonElement>('.notification-center-list > button');
     act(() => notification?.click());
 
     expect(onOpenEvent).toHaveBeenCalledWith(ready);
-    expect(container.querySelector('.notification-center-trigger')?.textContent).toBe('');
-    expect(localStorage.getItem('zadiag.notificationCenter.read.child.maya')).toBe('["check_ready:ready"]');
 
     act(() => root.unmount());
     container.remove();

--- a/src/components/NotificationCenter.tsx
+++ b/src/components/NotificationCenter.tsx
@@ -15,6 +15,14 @@ const titleKeys: Record<AppNotificationKind, MessageKey> = {
   review: 'notificationCenterReview',
 };
 
+const readNotificationIds = (storageKey: string, notificationIds: string[]) => {
+  const stored = readUiStorageJson<string[]>(storageKey, [], (value) => (
+    Array.isArray(value) ? value.filter((item): item is string => typeof item === 'string') : []
+  ));
+  const currentIds = new Set(notificationIds);
+  return stored.filter((id) => currentIds.has(id));
+};
+
 export function NotificationCenter({
   role,
   events,
@@ -33,11 +41,14 @@ export function NotificationCenter({
   t: (key: MessageKey) => string;
 }) {
   const [open, setOpen] = useState(false);
-  const [readIds, setReadIds] = useState<string[]>([]);
   const notifications = notificationsForEvents(role, events);
   const notificationIds = notifications.map((notification) => notification.id);
   const notificationIdSignature = notificationIds.join('|');
   const storageKey = `zadiag.notificationCenter.read.${role}.${contextId}`;
+  const [readState, setReadState] = useState(() => ({
+    storageKey,
+    ids: readNotificationIds(storageKey, notificationIds),
+  }));
   const dialogRef = useModalFocus<HTMLDivElement>(open, () => setOpen(false));
   const routineNames = useMemo(() => new Map(assignments.map((assignment) => [
     assignment.routineId,
@@ -49,20 +60,22 @@ export function NotificationCenter({
   }), [locale]);
 
   useEffect(() => {
-    const stored = readUiStorageJson<string[]>(storageKey, [], (value) => (
-      Array.isArray(value) ? value.filter((item): item is string => typeof item === 'string') : []
-    ));
-    const currentIds = new Set(notificationIds);
-    const validIds = stored.filter((id) => currentIds.has(id));
-    setReadIds(validIds);
-    if (validIds.length !== stored.length) writeUiStorageString(storageKey, JSON.stringify(validIds));
+    const validIds = readNotificationIds(storageKey, notificationIds);
+    setReadState({ storageKey, ids: validIds });
   }, [notificationIdSignature, storageKey]);
 
+  const readIds = readState.storageKey === storageKey
+    ? readState.ids
+    : readNotificationIds(storageKey, notificationIds);
   const readSet = new Set(readIds);
   const unreadCount = notifications.filter((notification) => !readSet.has(notification.id)).length;
   const saveReadIds = (ids: string[]) => {
-    setReadIds(ids);
+    setReadState({ storageKey, ids });
     writeUiStorageString(storageKey, JSON.stringify(ids));
+  };
+  const openCenter = () => {
+    if (unreadCount) saveReadIds(notificationIds);
+    setOpen(true);
   };
   const openNotification = (notificationId: string, event: VerificationEvent) => {
     if (!readSet.has(notificationId)) saveReadIds([...readIds, notificationId]);
@@ -76,7 +89,7 @@ export function NotificationCenter({
         type="button"
         className="notification-center-trigger"
         aria-label={unreadCount ? `${t('notificationCenterTitle')} · ${unreadCount}` : t('notificationCenterTitle')}
-        onClick={() => setOpen(true)}
+        onClick={openCenter}
       >
         <AppIcon name="notifications" />
         {unreadCount ? <span>{unreadCount > 99 ? '99+' : unreadCount}</span> : null}

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -430,8 +430,8 @@ button:disabled { cursor: not-allowed; }
 .page-context-heading { min-width: 0; align-self: center; }
 .page-context-heading h1 { margin-top: 0; }
 .notification-center { flex: 0 0 auto; }
-.notification-center-trigger { position: relative; width: 42px; height: 42px; display: grid; place-items: center; border: 1px solid var(--color-border); border-radius: 14px; background: var(--color-surface-solid); color: var(--color-text); box-shadow: var(--shadow-sm); }
-.notification-center-trigger .app-icon { font-size: 21px; }
+.notification-center-trigger { position: relative; width: 42px; height: 42px; display: grid; place-items: center; border: 1px solid var(--color-border); border-radius: 14px; background: var(--color-surface-solid); color: var(--color-text-strong); box-shadow: var(--shadow-sm); }
+.notification-center-trigger .app-icon { font-size: 25px; }
 .notification-center-trigger > span { position: absolute; top: -5px; right: -5px; min-width: 19px; height: 19px; display: grid; place-items: center; padding: 0 4px; border: 2px solid var(--color-surface-solid); border-radius: 99px; background: var(--color-danger); color: var(--color-surface-solid); font-size: 9px; font-weight: 900; }
 .notification-center-backdrop { position: fixed; z-index: 80; inset: 0; display: grid; align-items: end; padding: 12px; background: color-mix(in srgb, var(--color-text) 48%, transparent); backdrop-filter: blur(5px); }
 .notification-center-dialog { width: min(100%, 520px); max-height: min(86dvh, 720px); display: grid; grid-template-rows: auto auto minmax(0, 1fr); gap: 10px; margin: 0 auto; padding: 15px; overflow: hidden; border-radius: 24px; background: var(--color-surface-solid); box-shadow: var(--shadow-sm); }


### PR DESCRIPTION
## Summary
- strengthen the notification icon size and contrast
- mark visible notifications as read when the center is opened
- hydrate read state per profile without showing a stale badge during profile changes
- bump the application version to 0.7.1

## Validation
- 204 frontend tests
- architecture and design checks
- TypeScript production build
- bundle size check
- 59 backend tests