### PR TITLE
Hide idle synchronization status

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zadiag-pwa",
   "private": true,
-  "version": "0.8.0",
+  "version": "0.8.1",
   "type": "module",
   "packageManager": "pnpm@11.7.0",
   "engines": {

--- a/src/App.test.ts
+++ b/src/App.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { DEFAULT_ROUTINE_ID, type AppState, type VerificationEvent } from './domain/models';
-import { appBadgeCountForState, documentLanguageForLocale, isParticipantInvitationCode, participantIdForNotificationLaunch, resetNoticeMessageKey, setupCompletionTransition, syncStatusFor } from './App';
+import { appBadgeCountForState, documentLanguageForLocale, isParticipantInvitationCode, participantIdForNotificationLaunch, resetNoticeMessageKey, setupCompletionTransition, syncStatusFor, syncStatusIsVisible } from './App';
 
 const activePendingEvent = (expiresAt: string): VerificationEvent => ({
   id: 'check-1',
@@ -47,6 +47,14 @@ describe('syncStatusFor', () => {
     expect(syncStatusFor(true, 1, true)).toBe('syncing');
     expect(syncStatusFor(true, 0, true)).toBe('failed');
     expect(syncStatusFor(true, 0, false)).toBe('synced');
+  });
+
+  it('hides the idle state after confirmation but keeps actionable states visible', () => {
+    expect(syncStatusIsVisible('synced', false)).toBe(false);
+    expect(syncStatusIsVisible('synced', true)).toBe(true);
+    expect(syncStatusIsVisible('syncing', false)).toBe(true);
+    expect(syncStatusIsVisible('offline', false)).toBe(true);
+    expect(syncStatusIsVisible('failed', false)).toBe(true);
   });
 });
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -76,6 +76,9 @@ export const syncStatusFor = (online: boolean, pendingOperations: number, failed
   return failed ? 'failed' : 'synced';
 };
 
+export const syncStatusIsVisible = (status: SyncStatus, recentSuccess: boolean) =>
+  status !== 'synced' || recentSuccess;
+
 export const setupCompletionTransition = (
   previous: boolean | undefined,
   state: Pick<AppState, 'role' | 'family' | 'notificationsEnabled' | 'routineAssignments' | 'routinesLoaded'>,
@@ -125,6 +128,8 @@ export function App() {
   const [online, setOnline] = useState(() => navigator.onLine);
   const [pendingSyncOperations, setPendingSyncOperations] = useState(0);
   const [syncFailed, setSyncFailed] = useState(false);
+  const [syncConfirmationSequence, setSyncConfirmationSequence] = useState(0);
+  const [syncConfirmationVisible, setSyncConfirmationVisible] = useState(false);
   const [dashboardSummaryRange, setDashboardSummaryRange] = useState<SummaryRange>(readDashboardSummaryRange);
   const [serviceWorkerStatus, setServiceWorkerStatus] = useState<'unsupported' | 'registered' | 'notRegistered'>(
     () => ('serviceWorker' in navigator ? 'notRegistered' : 'unsupported'),
@@ -158,6 +163,13 @@ export function App() {
       window.removeEventListener('offline', updateConnection);
     };
   }, []);
+
+  useEffect(() => {
+    if (!syncConfirmationSequence) return;
+    setSyncConfirmationVisible(true);
+    const timeout = window.setTimeout(() => setSyncConfirmationVisible(false), 2_000);
+    return () => window.clearTimeout(timeout);
+  }, [syncConfirmationSequence]);
 
   useEffect(() => {
     if (state.accessStatus === 'suspended') setRoute('suspended');
@@ -283,6 +295,7 @@ export function App() {
       const result = await action.apply(repository, args);
       sync();
       setLastSyncAt(new Date().toISOString());
+      setSyncConfirmationSequence((sequence) => sequence + 1);
       return result;
     } catch (error) {
       setSyncFailed(true);
@@ -574,13 +587,15 @@ export function App() {
         t={t}
       >
         {screen}
-        <div className={`global-sync-status ${syncStatus}`} role="status" aria-live="polite">
-          <span aria-hidden="true" />
-          <strong>{t(syncStatusMessageKeys[syncStatus])}</strong>
-          {(syncStatus === 'failed' || syncStatus === 'offline') && retrySync ? (
-            <button type="button" disabled={!online} onClick={() => { void retrySync(); }}>{t('retryNow')}</button>
-          ) : null}
-        </div>
+        {syncStatusIsVisible(syncStatus, syncConfirmationVisible) ? (
+          <div className={`global-sync-status ${syncStatus}`} role="status" aria-live="polite">
+            <span aria-hidden="true" />
+            <strong>{t(syncStatusMessageKeys[syncStatus])}</strong>
+            {(syncStatus === 'failed' || syncStatus === 'offline') && retrySync ? (
+              <button type="button" disabled={!online} onClick={() => { void retrySync(); }}>{t('retryNow')}</button>
+            ) : null}
+          </div>
+        ) : null}
         <BottomNav
           tab={tab}
           role={role}


### PR DESCRIPTION
## Summary
- keep the synchronization indicator hidden while the app is idle
- show syncing during repository operations
- show synchronized confirmation for two seconds
- keep offline and failed states visible until resolved
- bump the application version to 0.8.1

## Validation
- npm run check
- 207 frontend tests
- production PWA build and bundle check
- 59 backend tests