### PR TITLE
Reveal dashboard status details on demand

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zadiag-pwa",
   "private": true,
-  "version": "0.8.1",
+  "version": "0.9.0",
   "type": "module",
   "packageManager": "pnpm@11.7.0",
   "engines": {

--- a/src/components/DashboardStatusSummary.tsx
+++ b/src/components/DashboardStatusSummary.tsx
@@ -1,17 +1,34 @@
 export interface DashboardStatusItem {
+  id: string;
   label: string;
   value: number;
   tone?: 'default' | 'attention';
 }
 
-export function DashboardStatusSummary({ label, items }: { label: string; items: DashboardStatusItem[] }) {
+export function DashboardStatusSummary({
+  label,
+  items,
+  selectedId,
+  onSelect,
+}: {
+  label: string;
+  items: DashboardStatusItem[];
+  selectedId?: string;
+  onSelect: (id: string) => void;
+}) {
   return (
     <section className="card dashboard-status-summary" aria-label={label}>
       {items.map((item) => (
-        <div className={item.tone === 'attention' && item.value > 0 ? 'attention' : undefined} key={item.label}>
+        <button
+          type="button"
+          className={`${item.tone === 'attention' && item.value > 0 ? 'attention ' : ''}${selectedId === item.id ? 'selected' : ''}`.trim() || undefined}
+          aria-pressed={selectedId === item.id}
+          key={item.id}
+          onClick={() => onSelect(item.id)}
+        >
           <strong>{item.value}</strong>
           <span>{item.label}</span>
-        </div>
+        </button>
       ))}
     </section>
   );

--- a/src/screens/ChildDashboard.test.tsx
+++ b/src/screens/ChildDashboard.test.tsx
@@ -51,6 +51,12 @@ describe('participant Today screen', () => {
     container.remove();
   });
 
+  const selectDashboardStatus = (label: string) => {
+    const button = Array.from(container.querySelectorAll<HTMLButtonElement>('.dashboard-status-summary button'))
+      .find((item) => item.textContent?.includes(label));
+    act(() => button?.click());
+  };
+
   it('shows today pending tasks with an action for the active task', () => {
     const yesterday = new Date();
     yesterday.setDate(yesterday.getDate() - 1);
@@ -67,6 +73,8 @@ describe('participant Today screen', () => {
 
     act(() => root.render(<ChildDashboard state={state} active={pending} start={start} t={(key) => translate('en', key)} />));
 
+    expect(container.querySelector('.today-task')).toBeNull();
+    selectDashboardStatus('To do');
     expect(container.textContent).toContain('1 check to complete');
     expect(Array.from(container.querySelectorAll('.dashboard-status-summary strong')).map((item) => item.textContent)).toEqual(['1', '0', '1']);
     expect(container.textContent).not.toContain('Completed today');
@@ -96,6 +104,7 @@ describe('participant Today screen', () => {
 
     act(() => root.render(<ChildDashboard state={state} active={elasticsPending} start={start} t={(key) => translate('en', key)} />));
 
+    selectDashboardStatus('To do');
     const actions = Array.from(container.querySelectorAll('button')).filter((button) => button.textContent?.includes('Proof'));
     expect(actions).toHaveLength(2);
     act(() => actions[1]?.dispatchEvent(new MouseEvent('click', { bubbles: true })));
@@ -121,12 +130,14 @@ describe('participant Today screen', () => {
 
     act(() => root.render(<ChildDashboard state={state} start={() => undefined} retake={retake} t={(key) => translate('en', key)} />));
 
+    expect(container.querySelector('.participant-review-section')).toBeNull();
+    selectDashboardStatus('To retry');
     const todayButton = container.querySelector<HTMLButtonElement>('.today-retake-button');
     expect(todayButton).toBeTruthy();
     expect(Array.from(container.querySelectorAll('.dashboard-status-summary strong')).map((item) => item.textContent)).toEqual(['0', '1', '1']);
     const retrySection = container.querySelector('.participant-review-section');
-    const upcomingSection = container.querySelector('.upcoming-checks-section');
-    expect(Boolean(retrySection && upcomingSection && (retrySection.compareDocumentPosition(upcomingSection) & Node.DOCUMENT_POSITION_FOLLOWING))).toBe(true);
+    expect(retrySection).not.toBeNull();
+    expect(container.querySelector('.upcoming-checks-section')).toBeNull();
     act(() => todayButton?.dispatchEvent(new MouseEvent('click', { bubbles: true })));
     expect(retake).toHaveBeenCalledWith(failed);
   });
@@ -140,6 +151,7 @@ describe('participant Today screen', () => {
     };
 
     act(() => root.render(<ChildDashboard state={base} active={pending} start={() => undefined} t={(key) => translate('en', key)} />));
+    selectDashboardStatus('To do');
     expect(container.textContent).toContain('1 check to complete');
 
     const analyzing = { ...pending, status: 'analyzing' as const };
@@ -184,6 +196,7 @@ describe('participant Today screen', () => {
 
     act(() => root.render(<ChildDashboard state={state} start={() => undefined} t={(key) => translate('fr', key)} />));
 
+    selectDashboardStatus('À faire');
     expect(container.textContent).toContain('0 contrôles à réaliser');
     expect(container.textContent).toContain('On garde le cap.');
     expect(container.textContent).toContain('2 contrôles manqués');
@@ -227,7 +240,8 @@ describe('participant Today screen', () => {
 
     act(() => root.render(<ChildDashboard state={state} start={() => undefined} t={(key) => translate('en', key)} />));
 
-    expect(container.textContent).toContain('0 checks to complete');
+    expect(container.textContent).not.toContain('Upcoming checks');
+    selectDashboardStatus('Next');
     expect(container.textContent).toContain('Upcoming checks');
     expect(container.textContent).toContain('Orthodontic Elastics');
     expect(container.textContent).not.toContain('Before');
@@ -250,6 +264,7 @@ describe('participant Today screen', () => {
 
     act(() => root.render(<ChildDashboard state={state} active={pending} start={() => undefined} t={(key) => translate('en', key)} />));
 
+    selectDashboardStatus('To do');
     expect(container.textContent).toContain('This morning');
     expect(container.textContent).not.toContain('This evening');
     vi.useRealTimers();
@@ -269,6 +284,7 @@ describe('participant Today screen', () => {
     const openHistoryEvent = vi.fn();
     act(() => root.render(<ChildDashboard state={state} start={() => undefined} onOpenHistoryEvent={openHistoryEvent} t={(key) => translate('en', key)} />));
 
+    selectDashboardStatus('To do');
     const content = container.textContent ?? '';
     expect(content).toContain('0 checks to complete');
     expect(content).not.toContain('Completed today');

--- a/src/screens/ChildDashboard.tsx
+++ b/src/screens/ChildDashboard.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import type { AppState, VerificationEvent } from '../domain/models';
 import { formatMessage, type MessageKey } from '../services/i18n';
 import { languageTag } from '../services/locale';
@@ -44,6 +44,7 @@ export function ChildDashboard({
   t: (key: MessageKey) => string;
 }) {
   const [localSummaryRange, setLocalSummaryRange] = useState<SummaryRange>('day');
+  const [expandedStatus, setExpandedStatus] = useState<'todo' | 'retry' | 'next'>();
   const summaryRange = controlledSummaryRange ?? localSummaryRange;
   const setSummaryRange = onSummaryRangeChange ?? setLocalSummaryRange;
   const now = Date.now();
@@ -51,6 +52,7 @@ export function ChildDashboard({
   const activeParticipantAccess = state.participantAccess?.find((entry) => entry.participant.id === state.activeParticipantId)
     ?? state.participantAccess?.find((entry) => entry.membership.status === 'active');
   const reportSubjectName = activeParticipantAccess?.participant.displayName ?? state.family.childName;
+  useEffect(() => setExpandedStatus(undefined), [state.activeParticipantId]);
   const today = state.events.filter((event) => isToday(event.requestedAt));
   const pending = today.filter((event) => (
     event.status === 'analyzing'
@@ -237,14 +239,16 @@ export function ChildDashboard({
       <DashboardStatusSummary
         label={t('dashboardStatusSummary')}
         items={[
-          { label: t('dashboardToDo'), value: actionableCount },
-          { label: t('dashboardRetry'), value: attentionCompleted.length, tone: 'attention' },
-          { label: t('dashboardNext'), value: upcomingChecks.length },
+          { id: 'todo', label: t('dashboardToDo'), value: actionableCount },
+          { id: 'retry', label: t('dashboardRetry'), value: attentionCompleted.length, tone: 'attention' },
+          { id: 'next', label: t('dashboardNext'), value: upcomingChecks.length },
         ]}
+        selectedId={expandedStatus}
+        onSelect={(id) => setExpandedStatus((current) => current === id ? undefined : id as typeof current)}
       />
-      {pendingSection}
-      {attentionSection}
-      <UpcomingChecksSection checks={upcomingChecks} now={nowDate} locale={locale} titleId="upcoming-checks-title" t={t} />
+      {expandedStatus === 'todo' ? pendingSection : null}
+      {expandedStatus === 'retry' ? attentionSection : null}
+      {expandedStatus === 'next' ? <UpcomingChecksSection checks={upcomingChecks} now={nowDate} locale={locale} titleId="upcoming-checks-title" t={t} /> : null}
       {historySection}
       <Disclaimer t={t} />
     </div>

--- a/src/screens/ParentDashboard.test.tsx
+++ b/src/screens/ParentDashboard.test.tsx
@@ -24,6 +24,12 @@ describe('ParentDashboard', () => {
     vi.restoreAllMocks();
   });
 
+  const selectDashboardStatus = (label: string) => {
+    const button = Array.from(container.querySelectorAll<HTMLButtonElement>('.dashboard-status-summary button'))
+      .find((item) => item.textContent?.includes(label));
+    act(() => button?.click());
+  };
+
   it('keeps the parent overview blocks and replaces needs attention with filterable history', () => {
     const requestedAt = new Date().toISOString();
     const expiresAt = new Date(Date.now() + 60 * 60_000).toISOString();
@@ -79,6 +85,8 @@ describe('ParentDashboard', () => {
 
     act(() => root.render(<ParentDashboard state={state} regenerateCode={vi.fn()} t={(key) => translate('en', key)} />));
 
+    expect(container.textContent).not.toContain('Upcoming checks');
+    selectDashboardStatus('Next');
     expect(container.textContent).toContain('Upcoming checks');
     expect(container.textContent).not.toContain('Finish setting up Zadiag');
     expect(container.textContent).toContain('Orthodontic Elastics');
@@ -220,6 +228,8 @@ describe('ParentDashboard', () => {
 
     act(() => root.render(<ParentDashboard state={baseState} regenerateCode={vi.fn()} t={(key) => translate('en', key)} />));
 
+    expect(container.textContent).not.toContain('Upcoming checks');
+    selectDashboardStatus('Next');
     expect(container.textContent).toContain('Upcoming checks');
     expect(container.textContent).not.toContain('Active checks');
 
@@ -242,6 +252,7 @@ describe('ParentDashboard', () => {
       />,
     ));
 
+    selectDashboardStatus('Active');
     expect(container.textContent).toContain('1 check to complete');
     expect(container.textContent).toContain('Orthodontic Elastics');
     expect(container.textContent).toContain('Expected proof: Mouth photo');
@@ -270,6 +281,7 @@ describe('ParentDashboard', () => {
 
     act(() => root.render(<ParentDashboard state={state} regenerateCode={vi.fn()} requestCheck={requestCheck} t={(key) => translate('en', key)} />));
 
+    selectDashboardStatus('Active');
     const resend = Array.from(container.querySelectorAll('button')).find((button) => button.getAttribute('aria-label') === 'Resend reminder');
     expect(resend).toBeTruthy();
     expect(resend?.textContent).toContain('Remind');
@@ -313,6 +325,7 @@ describe('ParentDashboard', () => {
 
     act(() => root.render(<ParentDashboard state={state} regenerateCode={vi.fn()} requestCheck={vi.fn()} t={(key) => translate('en', key)} />));
 
+    selectDashboardStatus('Active');
     expect(container.textContent).toContain('1 check to complete');
     expect(container.querySelectorAll('.parent-active-check-card')).toHaveLength(1);
     expect(container.querySelectorAll('.parent-history-row')).toHaveLength(1);
@@ -496,11 +509,12 @@ describe('ParentDashboard', () => {
       await Promise.resolve();
     });
 
+    selectDashboardStatus('To review');
     expect(container.textContent).toContain('Checks to verify');
     expect(Array.from(container.querySelectorAll('.dashboard-status-summary strong')).map((item) => item.textContent)).toEqual(['0', '1', '1']);
     const reviewSection = container.querySelector('.parent-review-section');
-    const upcomingSection = container.querySelector('.upcoming-checks-section');
-    expect(Boolean(reviewSection && upcomingSection && (reviewSection.compareDocumentPosition(upcomingSection) & Node.DOCUMENT_POSITION_FOLLOWING))).toBe(true);
+    expect(reviewSection).not.toBeNull();
+    expect(container.querySelector('.upcoming-checks-section')).toBeNull();
     expect(container.textContent).toContain('Expected proof: Mouth photo');
     expect(container.textContent).toContain('Source: AI');
     expect(container.textContent).toContain('AI result: Not detected');
@@ -552,6 +566,7 @@ describe('ParentDashboard', () => {
       await Promise.resolve();
     });
 
+    selectDashboardStatus('To review');
     expect(container.textContent).toContain('Checks to verify');
     expect(getProofImageUrl).toHaveBeenCalledWith('legacy-review');
     const reject = Array.from(container.querySelectorAll('button')).find((button) => button.getAttribute('aria-label') === 'Reject');
@@ -607,6 +622,7 @@ describe('ParentDashboard', () => {
       );
     });
 
+    selectDashboardStatus('To review');
     const cards = Array.from(container.querySelectorAll<HTMLElement>('.parent-review-card'));
     await act(async () => {
       cards[0].dispatchEvent(new MouseEvent('mousedown', { bubbles: true, clientX: 20, clientY: 24 }));

--- a/src/screens/ParentDashboard.tsx
+++ b/src/screens/ParentDashboard.tsx
@@ -46,6 +46,7 @@ export function ParentDashboard({
   const [regenerating, setRegenerating] = useState(false);
   const [codeError, setCodeError] = useState(false);
   const [localSummaryRange, setLocalSummaryRange] = useState<SummaryRange>('day');
+  const [expandedStatus, setExpandedStatus] = useState<'active' | 'review' | 'next'>();
   const [proofUrls, setProofUrls] = useState<Record<string, string>>({});
   const [proofErrors, setProofErrors] = useState<Record<string, boolean>>({});
   const [reviewingId, setReviewingId] = useState<string>();
@@ -197,6 +198,7 @@ export function ParentDashboard({
   const handleMouseUp = (event: MouseEvent<HTMLElement>, eventId: string) => completeSwipe(eventId, event.clientX, event.clientY);
   const activeParticipantAccess = state.participantAccess?.find((entry) => entry.participant.id === state.activeParticipantId)
     ?? state.participantAccess?.find((entry) => entry.membership.status === 'active');
+  useEffect(() => setExpandedStatus(undefined), [state.activeParticipantId]);
   return (
     <div className="content-screen child-home parent-overview-screen">
       <div className="page-context-top parent-context-top">
@@ -209,7 +211,10 @@ export function ParentDashboard({
             locale={state.locale}
             contextId={state.activeParticipantId ?? state.family.id ?? state.family.childName}
             onOpenEvent={(event) => {
-              if (event.status === 'uncertain') document.getElementById(`review-${event.id}`)?.scrollIntoView({ block: 'center' });
+              if (event.status === 'uncertain') {
+                setExpandedStatus('review');
+                window.requestAnimationFrame(() => document.getElementById(`review-${event.id}`)?.scrollIntoView({ block: 'center' }));
+              }
               else onOpenHistoryEvent?.(event);
             }}
             t={t}
@@ -240,19 +245,21 @@ export function ParentDashboard({
         <DashboardStatusSummary
           label={t('dashboardStatusSummary')}
           items={[
-            { label: t('dashboardActive'), value: activePendingEvents.length },
-            { label: t('dashboardReview'), value: reviewEvents.length, tone: 'attention' },
-            { label: t('dashboardNext'), value: upcomingChecks.length },
+            { id: 'active', label: t('dashboardActive'), value: activePendingEvents.length },
+            { id: 'review', label: t('dashboardReview'), value: reviewEvents.length, tone: 'attention' },
+            { id: 'next', label: t('dashboardNext'), value: upcomingChecks.length },
           ]}
+          selectedId={expandedStatus}
+          onSelect={(id) => setExpandedStatus((current) => current === id ? undefined : id as typeof current)}
         />
       ) : null}
 
-      {(responsibleEmptyState || activePendingEvents.length || (!state.family.childLinked && state.family.linkingCode) || (!state.routineAssignments.length && onCreateRoutine)) ? (
+      {(responsibleEmptyState || (expandedStatus === 'active' && activePendingEvents.length) || (!state.family.childLinked && state.family.linkingCode) || (!state.routineAssignments.length && onCreateRoutine)) ? (
         <section className="settings-section parent-setup-section" aria-labelledby="parent-setup-title">
           <h2 id="parent-setup-title">{activePendingEvents.length ? `${activePendingEvents.length} ${t(activePendingEvents.length === 1 ? 'checkToComplete' : 'checksToComplete')}` : t('responsibleCurrentChecksTitle')}</h2>
 
           <div className="today-task-list">
-            {activePendingEvents.length ? (
+            {expandedStatus === 'active' && activePendingEvents.length ? (
               <>
                 {activePendingEvents
                   .slice()
@@ -347,7 +354,7 @@ export function ParentDashboard({
         </section>
       ) : null}
 
-      {reviewEvents.length ? (
+      {expandedStatus === 'review' && reviewEvents.length ? (
         <section className="settings-section parent-review-section" aria-labelledby="parent-review-title">
           <div className="section-heading parent-review-heading">
             <h2 id="parent-review-title">{t('responsibleReviewTitle')}</h2>
@@ -436,7 +443,7 @@ export function ParentDashboard({
         </section>
       ) : null}
 
-      {!activePendingEvents.length && state.family.childLinked && state.routineAssignments.length && upcomingChecks.length ? (
+      {expandedStatus === 'next' && state.family.childLinked && state.routineAssignments.length && upcomingChecks.length ? (
         <UpcomingChecksSection checks={upcomingChecks} now={nowDate} locale={locale} titleId="responsible-upcoming-checks-title" t={t} />
       ) : null}
 

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -360,8 +360,10 @@ button:disabled { cursor: not-allowed; }
 .parent-onboarding-heading .eyebrow { display: inline-flex; background: var(--color-primary-soft); color: var(--color-primary); }
 .parent-onboarding-card .setup-progress { margin: 18px 0 2px; }
 .dashboard-status-summary { display: grid; grid-template-columns: repeat(3, minmax(0, 1fr)); gap: 0; padding: 9px 4px; }
-.dashboard-status-summary div { min-width: 0; display: grid; justify-items: center; gap: 1px; padding: 2px 8px; border-right: 1px solid var(--color-border); text-align: center; }
-.dashboard-status-summary div:last-child { border-right: 0; }
+.dashboard-status-summary button { min-width: 0; display: grid; justify-items: center; gap: 1px; padding: 4px 8px; border: 0; border-right: 1px solid var(--color-border); border-radius: 10px; background: transparent; text-align: center; }
+.dashboard-status-summary button:last-child { border-right: 0; }
+.dashboard-status-summary button.selected { background: var(--color-control-surface); }
+.dashboard-status-summary button:focus-visible { outline: 3px solid color-mix(in srgb, var(--color-primary) 32%, transparent); outline-offset: -2px; }
 .dashboard-status-summary strong { color: var(--color-text-strong); font-size: 19px; line-height: 1.15; }
 .dashboard-status-summary span { max-width: 100%; overflow: hidden; color: var(--color-text-muted); font-size: 10px; font-weight: 800; text-overflow: ellipsis; white-space: nowrap; }
 .dashboard-status-summary .attention strong { color: var(--color-warning-strong); }


### PR DESCRIPTION
## Summary
- turn dashboard status counters into accessible toggle buttons
- keep active, review/retry, and upcoming detail groups collapsed by default
- show only the selected status group and collapse it on a second click
- reset the selection when switching followed profiles
- preserve notification deep-link access to hidden review items
- apply the behavior to responsible and participant dashboards
- bump the application version to 0.9.0

## Validation
- npm run check
- 207 frontend tests
- architecture and design checks
- production PWA build and bundle check
- 59 backend tests