### PR TITLE
Make codes and support values easier to copy

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zadiag-pwa",
   "private": true,
-  "version": "0.9.1",
+  "version": "0.9.2",
   "type": "module",
   "packageManager": "pnpm@11.7.0",
   "engines": {

--- a/src/components/CodeBox.tsx
+++ b/src/components/CodeBox.tsx
@@ -2,25 +2,8 @@ import { useEffect, useRef, useState } from 'react';
 import type { ReactNode } from 'react';
 import { checkmarkOutline, copyOutline, eyeOffOutline, eyeOutline } from 'ionicons/icons';
 import type { MessageKey } from '../services/i18n';
+import { copyTextToClipboard } from '../services/clipboard';
 import { SvgIcon } from './SvgIcon';
-
-async function copyToClipboard(value: string) {
-  if (navigator.clipboard?.writeText) {
-    await navigator.clipboard.writeText(value);
-    return;
-  }
-
-  const textarea = document.createElement('textarea');
-  textarea.value = value;
-  textarea.setAttribute('readonly', 'true');
-  textarea.style.position = 'absolute';
-  textarea.style.left = '-9999px';
-  document.body.appendChild(textarea);
-  textarea.select();
-  const copied = document.execCommand('copy');
-  document.body.removeChild(textarea);
-  if (!copied) throw new Error('copy_failed');
-}
 
 export function CodeBox({
   label,
@@ -51,7 +34,7 @@ export function CodeBox({
 
   const handleCopy = async () => {
     try {
-      await copyToClipboard(value);
+      await copyTextToClipboard(value);
       setCopyState('copied');
     } catch {
       setCopyState('error');

--- a/src/components/CopyableText.test.tsx
+++ b/src/components/CopyableText.test.tsx
@@ -1,0 +1,34 @@
+import { act } from 'react';
+import { createRoot } from 'react-dom/client';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { translate } from '../services/i18n';
+import { CopyableText } from './CopyableText';
+
+describe('CopyableText', () => {
+  let container: HTMLDivElement | undefined;
+  let root: ReturnType<typeof createRoot> | undefined;
+  const clipboardDescriptor = Object.getOwnPropertyDescriptor(navigator, 'clipboard');
+
+  afterEach(() => {
+    if (root) act(() => root?.unmount());
+    container?.remove();
+    if (clipboardDescriptor) Object.defineProperty(navigator, 'clipboard', clipboardDescriptor);
+    else Reflect.deleteProperty(navigator, 'clipboard');
+  });
+
+  it('copies the complete displayed value and confirms the action', async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, 'clipboard', { configurable: true, value: { writeText } });
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+    act(() => root?.render(<CopyableText value="ZI-862051" t={(key) => translate('en', key)} />));
+
+    const button = container.querySelector('button') as HTMLButtonElement;
+    await act(async () => button.click());
+
+    expect(writeText).toHaveBeenCalledWith('ZI-862051');
+    expect(button.textContent).toContain('Copied');
+    expect(container.querySelector('strong')?.textContent).toBe('ZI-862051');
+  });
+});

--- a/src/components/CopyableText.tsx
+++ b/src/components/CopyableText.tsx
@@ -1,0 +1,40 @@
+import { useEffect, useRef, useState } from 'react';
+import { checkmarkOutline, copyOutline } from 'ionicons/icons';
+import type { MessageKey } from '../services/i18n';
+import { copyTextToClipboard } from '../services/clipboard';
+import { SvgIcon } from './SvgIcon';
+
+export function CopyableText({ value, t, compact = false }: {
+  value: string;
+  t: (key: MessageKey) => string;
+  compact?: boolean;
+}) {
+  const [state, setState] = useState<'idle' | 'copied' | 'error'>('idle');
+  const resetTimer = useRef<number | null>(null);
+  const label = t(state === 'copied' ? 'copiedCode' : state === 'error' ? 'copyCodeError' : 'copyCode');
+
+  useEffect(() => () => {
+    if (resetTimer.current) window.clearTimeout(resetTimer.current);
+  }, []);
+
+  const copy = async () => {
+    try {
+      await copyTextToClipboard(value);
+      setState('copied');
+    } catch {
+      setState('error');
+    }
+    if (resetTimer.current) window.clearTimeout(resetTimer.current);
+    resetTimer.current = window.setTimeout(() => setState('idle'), 1_200);
+  };
+
+  return (
+    <span className={`copyable-text${compact ? ' compact' : ''}`}>
+      <strong>{value}</strong>
+      <button type="button" className={state} aria-label={label} title={label} onClick={() => { void copy(); }}>
+        <SvgIcon icon={state === 'copied' ? checkmarkOutline : copyOutline} />
+        {!compact ? <span>{label}</span> : null}
+      </button>
+    </span>
+  );
+}

--- a/src/components/RelationshipManager.test.tsx
+++ b/src/components/RelationshipManager.test.tsx
@@ -93,6 +93,7 @@ describe('RelationshipManager', () => {
     expect(container.textContent).toContain('ZI-654321');
     expect(container.textContent).toContain('Share link');
     expect(container.textContent).toContain('Copy link');
+    expect(container.querySelector('.relationship-invitation-code .copyable-text')).not.toBeNull();
   });
 
   it('targets the visible participant when a stale legacy id is still active', async () => {

--- a/src/components/RelationshipManager.tsx
+++ b/src/components/RelationshipManager.tsx
@@ -6,6 +6,8 @@ import { ProfileContextCard } from './ProfileContextCard';
 import { profileColorFor, profileColorHex, profileColorKeyFor, profileColorPalette } from '../domain/profileColor';
 import { relationshipInvitationUrl } from '../services/browserEnvironment';
 import { AppIcon } from './Icon';
+import { CopyableText } from './CopyableText';
+import { copyTextToClipboard } from '../services/clipboard';
 
 type InviteRole = MembershipRole;
 
@@ -14,8 +16,7 @@ function InvitationOutput({ code, t }: { code: string; t: (key: MessageKey) => s
   const url = relationshipInvitationUrl(code);
   const copy = async () => {
     try {
-      if (!navigator.clipboard) throw new Error('clipboard_unavailable');
-      await navigator.clipboard.writeText(url);
+      await copyTextToClipboard(url);
       setCopyStatus('copied');
     } catch {
       setCopyStatus('error');
@@ -35,7 +36,8 @@ function InvitationOutput({ code, t }: { code: string; t: (key: MessageKey) => s
 
   return (
     <output className="relationship-invitation-code">
-      {t('relationshipInvitationCode')}: <strong>{code}</strong>
+      <span className="relationship-invitation-label">{t('relationshipInvitationCode')}</span>
+      <CopyableText value={code} t={t} />
       <small>{t('relationshipInvitationLinkHint')}</small>
       <span className="relationship-invitation-actions">
         <button type="button" onClick={() => { void share(); }}><AppIcon name="share" />{t('relationshipInvitationShareAction')}</button>
@@ -267,7 +269,7 @@ export function RelationshipManager({ access, activeParticipantId, accountDispla
               const recovery = await onCreateRecovery(selectedParticipantId);
               setRecoveryCode(recovery.recoveryCode);
             }); }}>{busy === 'recovery' ? <span className="button-spinner" aria-hidden="true" /> : null}{t('relationshipRecoveryCreate')}</button>
-            {recoveryCode ? <output className="relationship-invitation-code">{t('relationshipRecoveryCode')}: <strong>{recoveryCode}</strong></output> : null}
+            {recoveryCode ? <output className="relationship-invitation-code"><span className="relationship-invitation-label">{t('relationshipRecoveryCode')}</span><CopyableText value={recoveryCode} t={t} /></output> : null}
           </div>
         ) : null}
         {onRecover ? (

--- a/src/screens/SettingsScreen.tsx
+++ b/src/screens/SettingsScreen.tsx
@@ -22,6 +22,7 @@ import { Disclaimer } from '../components/Disclaimer';
 import { ActionButton, ListRow, SegmentedControl } from '../components/ui';
 import { SvgIcon } from '../components/SvgIcon';
 import { RelationshipManager } from '../components/RelationshipManager';
+import { CopyableText } from '../components/CopyableText';
 import { languageTag } from '../services/locale';
 import type { SyncStatus } from '../services/contracts';
 
@@ -412,7 +413,7 @@ export function SettingsScreen({
             <dl className="settings-diagnostics-list">
               {diagnosticsOpen ? (
                 <>
-                  <div><dt>{t('settingsDiagnosticsFamilyId')}</dt><dd>{familyId ?? t('settingsDiagnosticsMissing')}</dd></div>
+                  <div><dt>{t('settingsDiagnosticsFamilyId')}</dt><dd>{familyId ? <CopyableText value={familyId} compact t={t} /> : t('settingsDiagnosticsMissing')}</dd></div>
                   <div><dt>{t('settingsDiagnosticsNotifications')}</dt><dd>{notificationsEnabled ? t('settingsNotificationsStatusEnabled') : t('settingsNotificationsStatusDisabled')}</dd></div>
                   <div><dt>{t('settingsDiagnosticsPushPermission')}</dt><dd>{effectivePushHealth?.permission ?? t('settingsDiagnosticsMissing')}</dd></div>
                   <div><dt>{t('settingsDiagnosticsPushEndpoint')}</dt><dd>{effectivePushHealth?.endpointPresent ? t('yes') : t('no')}</dd></div>

--- a/src/services/clipboard.ts
+++ b/src/services/clipboard.ts
@@ -1,0 +1,17 @@
+export async function copyTextToClipboard(value: string) {
+  if (navigator.clipboard?.writeText) {
+    await navigator.clipboard.writeText(value);
+    return;
+  }
+
+  const textarea = document.createElement('textarea');
+  textarea.value = value;
+  textarea.setAttribute('readonly', 'true');
+  textarea.style.position = 'absolute';
+  textarea.style.left = '-9999px';
+  document.body.appendChild(textarea);
+  textarea.select();
+  const copied = document.execCommand('copy');
+  document.body.removeChild(textarea);
+  if (!copied) throw new Error('copy_failed');
+}

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -860,7 +860,17 @@ button:disabled { cursor: not-allowed; }
 .relationship-invitation-actions .app-icon { font-size: 16px; }
 .relationship-checkbox { display: flex; align-items: center; gap: 8px; color: var(--color-text); font-size: 13px; }
 .relationship-checkbox input { width: 18px; min-height: 18px; }
-.relationship-invitation-code { padding: 10px; border-radius: 10px; background: var(--color-primary-soft); color: var(--color-text); text-align: center; }
+.relationship-invitation-code { display: grid; gap: 10px; padding: 15px; border-radius: 14px; background: var(--color-primary-soft); color: var(--color-text); text-align: left; }
+.relationship-invitation-label { color: var(--color-text-muted); font-size: 10px; font-weight: 900; letter-spacing: .06em; text-transform: uppercase; }
+.copyable-text { min-width: 0; display: flex; align-items: center; justify-content: space-between; gap: 10px; padding: 9px 10px 9px 12px; border: 1px solid var(--color-border); border-radius: 11px; background: var(--color-surface-solid); }
+.copyable-text > strong { min-width: 0; overflow-wrap: anywhere; color: var(--color-text-strong); font-size: 17px; letter-spacing: .05em; line-height: 1.3; user-select: text; -webkit-user-select: text; }
+.copyable-text > button { min-height: var(--height-action); display: inline-flex; flex: 0 0 auto; align-items: center; justify-content: center; gap: 6px; padding: 7px 9px; border: 0; border-radius: 9px; background: var(--color-control-surface); color: var(--color-primary); font-size: 10px; font-weight: 900; }
+.copyable-text > button .svg-icon { font-size: 16px; }
+.copyable-text > button.copied { background: var(--color-primary-soft); }
+.copyable-text > button.error { background: var(--color-danger-soft); color: var(--color-danger); }
+.copyable-text.compact { gap: 5px; padding: 2px 3px 2px 7px; }
+.copyable-text.compact > strong { font-size: 11px; letter-spacing: 0; }
+.copyable-text.compact > button { width: 32px; min-height: 32px; padding: 0; }
 .relationship-leave-button { min-height: var(--height-action); display: inline-flex; align-items: center; justify-content: center; gap: 8px; border: 1px solid var(--color-danger); border-radius: 12px; background: var(--color-surface-solid); color: var(--color-danger); font-weight: 800; }
 .relationship-leave-button:disabled { border-color: var(--color-border); color: var(--color-text-muted); background: #f6f8f8; }
 .relationship-leave-zone { display: grid; gap: 6px; padding-top: 14px; border-top: 1px solid var(--color-border); }


### PR DESCRIPTION
## Summary
- space invitation codes into a dedicated readable block
- add a consistent copy action with icon and confirmation
- keep displayed values selectable through native long press
- reuse the behavior for recovery codes and support identifiers
- centralize clipboard handling with a legacy fallback
- bump the application patch version to 0.9.2

## Validation
- npm run check
- 213 frontend tests
- architecture and design checks
- production PWA build and bundle check
- 59 backend tests