### PR TITLE
Widen Family ID diagnostic value

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zadiag-pwa",
   "private": true,
-  "version": "0.9.3",
+  "version": "0.9.4",
   "type": "module",
   "packageManager": "pnpm@11.7.0",
   "engines": {

--- a/src/screens/SettingsScreen.tsx
+++ b/src/screens/SettingsScreen.tsx
@@ -413,7 +413,7 @@ export function SettingsScreen({
             <dl className="settings-diagnostics-list">
               {diagnosticsOpen ? (
                 <>
-                  <div><dt>{t('settingsDiagnosticsFamilyId')}</dt><dd>{familyId ? <CopyableText value={familyId} compact t={t} /> : t('settingsDiagnosticsMissing')}</dd></div>
+                  <div className="settings-diagnostics-family-id"><dt>{t('settingsDiagnosticsFamilyId')}</dt><dd>{familyId ? <CopyableText value={familyId} compact t={t} /> : t('settingsDiagnosticsMissing')}</dd></div>
                   <div><dt>{t('settingsDiagnosticsNotifications')}</dt><dd>{notificationsEnabled ? t('settingsNotificationsStatusEnabled') : t('settingsNotificationsStatusDisabled')}</dd></div>
                   <div><dt>{t('settingsDiagnosticsPushPermission')}</dt><dd>{effectivePushHealth?.permission ?? t('settingsDiagnosticsMissing')}</dd></div>
                   <div><dt>{t('settingsDiagnosticsPushEndpoint')}</dt><dd>{effectivePushHealth?.endpointPresent ? t('yes') : t('no')}</dd></div>

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -1625,6 +1625,8 @@ button:disabled { cursor: not-allowed; }
 .settings-diagnostics-list div { display: flex; align-items: baseline; justify-content: space-between; gap: 14px; padding-top: 8px; border-top: 1px solid rgba(13,146,125,.12); }
 .settings-diagnostics-list dt { color: var(--color-text-muted); font-size: 11px; font-weight: 900; text-transform: uppercase; }
 .settings-diagnostics-list dd { margin: 0; max-width: 58%; overflow-wrap: anywhere; color: var(--color-text); font-size: 12px; font-weight: 900; text-align: right; }
+.settings-diagnostics-list .settings-diagnostics-family-id dd { width: 67%; max-width: 67%; }
+.settings-diagnostics-family-id .copyable-text { width: 100%; box-sizing: border-box; }
 .settings-diagnostics-header { display: flex; align-items: flex-start; justify-content: space-between; gap: 10px; }
 .settings-diagnostics-header > span { min-width: 0; }
 .settings-diagnostics-toggle { width: var(--height-action); height: var(--height-action); display: grid; place-items: center; flex: 0 0 auto; padding: 0; border: 0; border-radius: 12px; background: var(--color-subtle-action); color: var(--color-primary); }


### PR DESCRIPTION
## Summary
- widen the Family ID value area in recovery diagnostics by about 15%
- preserve the existing copy interaction while allowing the identifier to use the full expanded width
- bump the application patch version to 0.9.4

## Why
The Family ID was constrained by the generic diagnostic value width, making the recovery identifier unnecessarily cramped on mobile.

## Validation
- `npm run check`
- `./node_modules/.bin/vitest run src/screens/SettingsScreen.test.tsx`
- `git diff --check`