### PR TITLE
Align help center chevron

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zadiag-pwa",
   "private": true,
-  "version": "0.9.4",
+  "version": "0.9.5",
   "type": "module",
   "packageManager": "pnpm@11.7.0",
   "engines": {

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -1615,7 +1615,7 @@ button:disabled { cursor: not-allowed; }
 .settings-help-center > summary { min-height: 62px; display: flex; align-items: center; gap: 11px; padding: var(--row-padding-y) var(--row-padding-x); cursor: pointer; list-style: none; }
 .settings-help-center > summary::-webkit-details-marker { display: none; }
 .settings-help-center > summary:focus-visible { outline: 3px solid color-mix(in srgb, var(--color-primary) 35%, transparent); outline-offset: -3px; }
-.settings-help-chevron { flex: 0 0 auto; color: var(--color-text-muted); transition: transform .2s ease; }
+.settings-help-chevron { width: var(--height-action); height: var(--height-action); box-sizing: border-box; flex: 0 0 auto; margin-left: auto; padding: 10px; border-radius: 12px; background: var(--color-subtle-action); color: var(--color-primary); transition: transform .2s ease; }
 .settings-help-center[open] .settings-help-chevron { transform: rotate(180deg); }
 .settings-help-content { display: grid; gap: 12px; padding: 0 var(--row-padding-x) 14px 54px; }
 .settings-help-content div { padding-top: 10px; border-top: 1px solid var(--color-border); }


### PR DESCRIPTION
## Summary
- align the Help Center chevron with the recovery diagnostics control
- reuse the same action sizing, surface, color, and right alignment
- bump the application patch version to 0.9.5

## Why
The Help Center used a bare chevron while the adjacent recovery diagnostics row used a dedicated action surface, leaving the controls visually misaligned.

## Impact
The two expandable support rows now present consistent controls without changing their interaction behavior.

## Validation
- `npm run check`
- `./node_modules/.bin/vitest run src/screens/SettingsScreen.test.tsx`
- `npm run check:design`
- `git diff --check`