### PR TITLE
Align recovery diagnostics action

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zadiag-pwa",
   "private": true,
-  "version": "0.9.5",
+  "version": "0.9.6",
   "type": "module",
   "packageManager": "pnpm@11.7.0",
   "engines": {

--- a/src/screens/SettingsScreen.tsx
+++ b/src/screens/SettingsScreen.tsx
@@ -394,21 +394,19 @@ export function SettingsScreen({
           </details>
           <ListRow
             icon={<SvgIcon icon={informationCircleOutline} />}
-            title={(
-              <span className="settings-diagnostics-header">
-                <span>{t('settingsRecoveryDiagnosticsTitle')}</span>
-                <button
-                  type="button"
-                  className="settings-diagnostics-toggle"
-                  aria-expanded={diagnosticsOpen}
-                  aria-label={t('settingsRecoveryDiagnosticsTitle')}
-                  onClick={() => setDiagnosticsOpen((open) => !open)}
-                >
-                  <SvgIcon className={diagnosticsOpen ? 'expanded' : undefined} icon={chevronDownOutline} />
-                </button>
-              </span>
-            )}
+            title={t('settingsRecoveryDiagnosticsTitle')}
             detail={t('settingsRecoveryDiagnosticsDetail')}
+            trailing={(
+              <button
+                type="button"
+                className="settings-diagnostics-toggle"
+                aria-expanded={diagnosticsOpen}
+                aria-label={t('settingsRecoveryDiagnosticsTitle')}
+                onClick={() => setDiagnosticsOpen((open) => !open)}
+              >
+                <SvgIcon className={diagnosticsOpen ? 'expanded' : undefined} icon={chevronDownOutline} />
+              </button>
+            )}
           >
             <dl className="settings-diagnostics-list">
               {diagnosticsOpen ? (

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -1627,8 +1627,6 @@ button:disabled { cursor: not-allowed; }
 .settings-diagnostics-list dd { margin: 0; max-width: 58%; overflow-wrap: anywhere; color: var(--color-text); font-size: 12px; font-weight: 900; text-align: right; }
 .settings-diagnostics-list .settings-diagnostics-family-id dd { width: 67%; max-width: 67%; }
 .settings-diagnostics-family-id .copyable-text { width: 100%; box-sizing: border-box; }
-.settings-diagnostics-header { display: flex; align-items: flex-start; justify-content: space-between; gap: 10px; }
-.settings-diagnostics-header > span { min-width: 0; }
 .settings-diagnostics-toggle { width: var(--height-action); height: var(--height-action); display: grid; place-items: center; flex: 0 0 auto; padding: 0; border: 0; border-radius: 12px; background: var(--color-subtle-action); color: var(--color-primary); }
 .settings-diagnostics-toggle .svg-icon { font-size: 20px; transition: transform .18s ease; }
 .settings-diagnostics-toggle .svg-icon.expanded { transform: rotate(180deg); }


### PR DESCRIPTION
## Summary
- move the recovery diagnostics chevron into the ListRow action column
- remove the obsolete title-level layout wrapper
- bump the application patch version to 0.9.6

## Why
The toggle was rendered inside the content column while the row grid still reserved an empty trailing action column. That invisible grid gap shifted the control about 12 px to the left.

## Impact
The recovery diagnostics control now aligns exactly with the Help Center control and uses the full intended row width.

## Validation
- `npm run check`
- `./node_modules/.bin/vitest run src/screens/SettingsScreen.test.tsx`
- `npm run check:design`
- `git diff --check`