### PR TITLE
Open participant todo actions by default

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zadiag-pwa",
   "private": true,
-  "version": "0.9.6",
+  "version": "0.9.7",
   "type": "module",
   "packageManager": "pnpm@11.7.0",
   "engines": {

--- a/src/screens/ChildDashboard.test.tsx
+++ b/src/screens/ChildDashboard.test.tsx
@@ -73,8 +73,7 @@ describe('participant Today screen', () => {
 
     act(() => root.render(<ChildDashboard state={state} active={pending} start={start} t={(key) => translate('en', key)} />));
 
-    expect(container.querySelector('.today-task')).toBeNull();
-    selectDashboardStatus('To do');
+    expect(container.querySelector('.dashboard-status-summary button[aria-pressed="true"]')?.textContent).toContain('To do');
     expect(container.textContent).toContain('1 check to complete');
     expect(Array.from(container.querySelectorAll('.dashboard-status-summary strong')).map((item) => item.textContent)).toEqual(['1', '0', '1']);
     expect(container.textContent).not.toContain('Completed today');
@@ -104,7 +103,6 @@ describe('participant Today screen', () => {
 
     act(() => root.render(<ChildDashboard state={state} active={elasticsPending} start={start} t={(key) => translate('en', key)} />));
 
-    selectDashboardStatus('To do');
     const actions = Array.from(container.querySelectorAll('button')).filter((button) => button.textContent?.includes('Proof'));
     expect(actions).toHaveLength(2);
     act(() => actions[1]?.dispatchEvent(new MouseEvent('click', { bubbles: true })));
@@ -151,7 +149,6 @@ describe('participant Today screen', () => {
     };
 
     act(() => root.render(<ChildDashboard state={base} active={pending} start={() => undefined} t={(key) => translate('en', key)} />));
-    selectDashboardStatus('To do');
     expect(container.textContent).toContain('1 check to complete');
 
     const analyzing = { ...pending, status: 'analyzing' as const };
@@ -196,7 +193,6 @@ describe('participant Today screen', () => {
 
     act(() => root.render(<ChildDashboard state={state} start={() => undefined} t={(key) => translate('fr', key)} />));
 
-    selectDashboardStatus('À faire');
     expect(container.textContent).toContain('0 contrôles à réaliser');
     expect(container.textContent).toContain('On garde le cap.');
     expect(container.textContent).toContain('2 contrôles manqués');
@@ -264,7 +260,6 @@ describe('participant Today screen', () => {
 
     act(() => root.render(<ChildDashboard state={state} active={pending} start={() => undefined} t={(key) => translate('en', key)} />));
 
-    selectDashboardStatus('To do');
     expect(container.textContent).toContain('This morning');
     expect(container.textContent).not.toContain('This evening');
     vi.useRealTimers();
@@ -284,7 +279,6 @@ describe('participant Today screen', () => {
     const openHistoryEvent = vi.fn();
     act(() => root.render(<ChildDashboard state={state} start={() => undefined} onOpenHistoryEvent={openHistoryEvent} t={(key) => translate('en', key)} />));
 
-    selectDashboardStatus('To do');
     const content = container.textContent ?? '';
     expect(content).toContain('0 checks to complete');
     expect(content).not.toContain('Completed today');

--- a/src/screens/ChildDashboard.tsx
+++ b/src/screens/ChildDashboard.tsx
@@ -44,7 +44,7 @@ export function ChildDashboard({
   t: (key: MessageKey) => string;
 }) {
   const [localSummaryRange, setLocalSummaryRange] = useState<SummaryRange>('day');
-  const [expandedStatus, setExpandedStatus] = useState<'todo' | 'retry' | 'next'>();
+  const [expandedStatus, setExpandedStatus] = useState<'todo' | 'retry' | 'next' | undefined>('todo');
   const summaryRange = controlledSummaryRange ?? localSummaryRange;
   const setSummaryRange = onSummaryRangeChange ?? setLocalSummaryRange;
   const now = Date.now();
@@ -52,7 +52,7 @@ export function ChildDashboard({
   const activeParticipantAccess = state.participantAccess?.find((entry) => entry.participant.id === state.activeParticipantId)
     ?? state.participantAccess?.find((entry) => entry.membership.status === 'active');
   const reportSubjectName = activeParticipantAccess?.participant.displayName ?? state.family.childName;
-  useEffect(() => setExpandedStatus(undefined), [state.activeParticipantId]);
+  useEffect(() => setExpandedStatus('todo'), [state.activeParticipantId]);
   const today = state.events.filter((event) => isToday(event.requestedAt));
   const pending = today.filter((event) => (
     event.status === 'analyzing'


### PR DESCRIPTION
## Summary
- open the participant “To do” status section on first render
- reopen “To do” when switching participant profiles
- keep “To retry” and “Next” collapsed until explicitly selected
- bump the application patch version to 0.9.7

## Why
Participant actions became hidden behind the status summary by default, making the primary task flow easy to miss.

## Impact
Participants immediately see their actions while retaining the ability to collapse the section or open another status.

## Validation
- `npm run check`
- `./node_modules/.bin/vitest run src/screens/ChildDashboard.test.tsx`
- `npm run check:design`
- `git diff --check`