### PR TITLE
Show notifications across participant profiles

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zadiag-pwa",
   "private": true,
-  "version": "0.9.7",
+  "version": "0.9.8",
   "type": "module",
   "packageManager": "pnpm@11.7.0",
   "engines": {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -368,6 +368,20 @@ export function App() {
     setFocusedHistoryEventId(event.id);
     setTab('routines');
   };
+  const openNotificationEvent = async (participantId: string, event: VerificationEvent) => {
+    if (participantId !== state.activeParticipantId) {
+      if (!selectActiveParticipant) return;
+      await selectActiveParticipant(participantId);
+    }
+    const selectedState = repository.snapshot();
+    if (selectedState.role === 'child' && event.status === 'pending' && Date.parse(event.expiresAt) > Date.now()) {
+      startCapture(event);
+      return;
+    }
+    setFocusedHistoryEventId(event.id);
+    setTab('routines');
+    setRoute('app');
+  };
 
   const reset = async () => {
     const previousRole = state.role;
@@ -601,6 +615,7 @@ export function App() {
               onSummaryRangeChange={setDashboardSummaryRange}
               onSelectParticipant={selectActiveParticipant}
               onOpenHistoryEvent={openHistoryEvent}
+              onOpenNotificationEvent={(participantId, event) => { void openNotificationEvent(participantId, event); }}
               t={t}
             />
           : <ChildDashboard
@@ -611,6 +626,7 @@ export function App() {
               summaryRange={dashboardSummaryRange}
               onSummaryRangeChange={setDashboardSummaryRange}
               onOpenHistoryEvent={openHistoryEvent}
+              onOpenNotificationEvent={(participantId, event) => { void openNotificationEvent(participantId, event); }}
               t={t}
             />;
     content = (

--- a/src/components/NotificationCenter.test.tsx
+++ b/src/components/NotificationCenter.test.tsx
@@ -19,8 +19,7 @@ describe('NotificationCenter', () => {
     act(() => root.render(
       <NotificationCenter
         role="child"
-        events={[]}
-        assignments={[]}
+        sources={[]}
         locale="en"
         contextId="maya"
         onOpenEvent={vi.fn()}
@@ -53,8 +52,12 @@ describe('NotificationCenter', () => {
     act(() => root.render(
       <NotificationCenter
         role="child"
-        events={[ready]}
-        assignments={[createDefaultRoutineAssignment()]}
+        sources={[{
+          participant: { id: 'maya', displayName: 'Maya' },
+          role: 'child',
+          events: [ready],
+          assignments: [createDefaultRoutineAssignment()],
+        }]}
         locale="en"
         contextId="maya"
         onOpenEvent={onOpenEvent}
@@ -68,11 +71,53 @@ describe('NotificationCenter', () => {
     act(() => trigger?.click());
     expect(container.textContent).toContain('Check ready');
     expect(container.querySelector('.notification-center-trigger')?.textContent).toBe('');
-    expect(localStorage.getItem('zadiag.notificationCenter.read.child.maya')).toBe('["check_ready:ready"]');
+    expect(localStorage.getItem('zadiag.notificationCenter.read.child.maya')).toBe('["maya:check_ready:ready"]');
     const notification = container.querySelector<HTMLButtonElement>('.notification-center-list > button');
     act(() => notification?.click());
 
-    expect(onOpenEvent).toHaveBeenCalledWith(ready);
+    expect(onOpenEvent).toHaveBeenCalledWith('maya', ready);
+
+    act(() => root.unmount());
+    container.remove();
+  });
+
+  it('shows notifications from every profile and identifies their participant', () => {
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+    const now = Date.now();
+    const eventFor = (id: string): VerificationEvent => ({
+      id,
+      routineId: 'orthodontic-elastics',
+      sessionId: `session-${id}`,
+      requestedAt: new Date(now - 60_000).toISOString(),
+      expiresAt: new Date(now + 60 * 60_000).toISOString(),
+      status: 'pending',
+    });
+    const mayaEvent = eventFor('maya-ready');
+    const leoEvent = eventFor('leo-ready');
+    const onOpenEvent = vi.fn();
+
+    act(() => root.render(
+      <NotificationCenter
+        role="child"
+        sources={[
+          { participant: { id: 'maya', displayName: 'Maya' }, role: 'child', events: [mayaEvent], assignments: [createDefaultRoutineAssignment()] },
+          { participant: { id: 'leo', displayName: 'Léo Martin' }, role: 'child', events: [leoEvent], assignments: [createDefaultRoutineAssignment()] },
+        ]}
+        locale="fr"
+        contextId="account"
+        onOpenEvent={onOpenEvent}
+        t={(key) => translate('fr', key)}
+      />,
+    ));
+
+    act(() => container.querySelector<HTMLButtonElement>('.notification-center-trigger')?.click());
+    expect(Array.from(container.querySelectorAll('.notification-center-profile')).map((item) => item.textContent)).toEqual(['MA', 'LM']);
+    expect(container.textContent).toContain('Maya');
+    expect(container.textContent).toContain('Léo Martin');
+    act(() => container.querySelectorAll<HTMLButtonElement>('.notification-center-list > button')[1]?.click());
+    expect(onOpenEvent).toHaveBeenCalledWith('leo', leoEvent);
 
     act(() => root.unmount());
     container.remove();

--- a/src/components/NotificationCenter.tsx
+++ b/src/components/NotificationCenter.tsx
@@ -1,10 +1,11 @@
-import { useEffect, useMemo, useState } from 'react';
-import type { Locale, Role, RoutineAssignment, VerificationEvent } from '../domain/models';
+import { useEffect, useMemo, useState, type CSSProperties } from 'react';
+import type { Locale, ParticipantNotificationSource, Role, VerificationEvent } from '../domain/models';
 import { notificationsForEvents, type AppNotificationKind } from '../domain/notificationCenter';
 import { presentRoutine } from '../domain/routinePresentation';
 import { useModalFocus } from '../hooks/useModalFocus';
 import type { MessageKey } from '../services/i18n';
 import { languageTag } from '../services/locale';
+import { profileColorFor } from '../domain/profileColor';
 import { readUiStorageJson, writeUiStorageString } from '../services/uiStorage';
 import { AppIcon } from './Icon';
 
@@ -25,23 +26,25 @@ const readNotificationIds = (storageKey: string, notificationIds: string[]) => {
 
 export function NotificationCenter({
   role,
-  events,
-  assignments,
+  sources,
   locale,
   contextId,
   onOpenEvent,
   t,
 }: {
   role: Role;
-  events: VerificationEvent[];
-  assignments: RoutineAssignment[];
+  sources: ParticipantNotificationSource[];
   locale: Locale;
   contextId: string;
-  onOpenEvent: (event: VerificationEvent) => void;
+  onOpenEvent: (participantId: string, event: VerificationEvent) => void;
   t: (key: MessageKey) => string;
 }) {
   const [open, setOpen] = useState(false);
-  const notifications = notificationsForEvents(role, events);
+  const notifications = sources.flatMap((source) => notificationsForEvents(source.role ?? role, source.events).map((notification) => ({
+    ...notification,
+    id: `${source.participant.id}:${notification.id}`,
+    source,
+  }))).sort((left, right) => Date.parse(right.timestamp) - Date.parse(left.timestamp)).slice(0, 50);
   const notificationIds = notifications.map((notification) => notification.id);
   const notificationIdSignature = notificationIds.join('|');
   const storageKey = `zadiag.notificationCenter.read.${role}.${contextId}`;
@@ -50,10 +53,10 @@ export function NotificationCenter({
     ids: readNotificationIds(storageKey, notificationIds),
   }));
   const dialogRef = useModalFocus<HTMLDivElement>(open, () => setOpen(false));
-  const routineNames = useMemo(() => new Map(assignments.map((assignment) => [
-    assignment.routineId,
+  const routineNames = useMemo(() => new Map(sources.flatMap((source) => source.assignments.map((assignment) => [
+    `${source.participant.id}:${assignment.routineId}`,
     presentRoutine(assignment.routine, locale).name,
-  ])), [assignments, locale]);
+  ] as const))), [sources, locale]);
   const dateFormatter = useMemo(() => new Intl.DateTimeFormat(languageTag(locale), {
     dateStyle: 'short',
     timeStyle: 'short',
@@ -77,10 +80,14 @@ export function NotificationCenter({
     if (unreadCount) saveReadIds(notificationIds);
     setOpen(true);
   };
-  const openNotification = (notificationId: string, event: VerificationEvent) => {
+  const openNotification = (notificationId: string, participantId: string, event: VerificationEvent) => {
     if (!readSet.has(notificationId)) saveReadIds([...readIds, notificationId]);
     setOpen(false);
-    onOpenEvent(event);
+    onOpenEvent(participantId, event);
+  };
+  const participantInitials = (name: string) => {
+    const words = name.trim().split(/\s+/).filter(Boolean);
+    return (words.length > 1 ? words.slice(0, 2).map((word) => word[0]).join('') : words[0]?.slice(0, 2) ?? '?').toUpperCase();
   };
 
   return (
@@ -113,12 +120,12 @@ export function NotificationCenter({
                       type="button"
                       className={readSet.has(notification.id) ? 'read' : 'unread'}
                       key={notification.id}
-                      onClick={() => openNotification(notification.id, notification.event)}
+                      onClick={() => openNotification(notification.id, notification.source.participant.id, notification.event)}
                     >
-                      <span className="notification-center-kind" aria-hidden="true"><AppIcon name={notification.kind === 'check_ready' ? 'camera' : notification.kind === 'review' ? 'check' : 'info'} /></span>
+                      <span className="notification-center-kind notification-center-profile" style={{ '--profile-color': profileColorFor(notification.source.participant) } as CSSProperties} aria-hidden="true">{participantInitials(notification.source.participant.displayName)}</span>
                       <span>
                         <strong>{t(titleKeys[notification.kind])}</strong>
-                        <small>{routineNames.get(notification.event.routineId) ?? t('routine')} · {dateFormatter.format(new Date(notification.timestamp))}</small>
+                        <small>{notification.source.participant.displayName} · {routineNames.get(`${notification.source.participant.id}:${notification.event.routineId}`) ?? t('routine')} · {dateFormatter.format(new Date(notification.timestamp))}</small>
                       </span>
                       {!readSet.has(notification.id) ? <i>{t('notificationCenterUnread')}</i> : null}
                     </button>

--- a/src/domain/models.ts
+++ b/src/domain/models.ts
@@ -168,6 +168,13 @@ export interface ParticipantAccess {
   members?: ParticipantMember[];
 }
 
+export interface ParticipantNotificationSource {
+  participant: ParticipantSummary;
+  role: Role;
+  assignments: RoutineAssignment[];
+  events: VerificationEvent[];
+}
+
 export interface PushSubscriptionHealth {
   permission: NotificationPermission | 'unsupported';
   endpointPresent: boolean;
@@ -203,6 +210,7 @@ export interface AppState {
   preferences?: AppPreferences;
   family: FamilyState;
   participantAccess?: ParticipantAccess[];
+  notificationSources?: ParticipantNotificationSource[];
   activeParticipantId?: string;
   routineAssignments: RoutineAssignment[];
   routinesLoaded?: boolean;

--- a/src/screens/ChildDashboard.tsx
+++ b/src/screens/ChildDashboard.tsx
@@ -32,6 +32,7 @@ export function ChildDashboard({
   summaryRange: controlledSummaryRange,
   onSummaryRangeChange,
   onOpenHistoryEvent,
+  onOpenNotificationEvent,
   t,
 }: {
   state: AppState;
@@ -41,6 +42,7 @@ export function ChildDashboard({
   summaryRange?: SummaryRange;
   onSummaryRangeChange?: (range: SummaryRange) => void;
   onOpenHistoryEvent?: (event: VerificationEvent) => void;
+  onOpenNotificationEvent?: (participantId: string, event: VerificationEvent) => void;
   t: (key: MessageKey) => string;
 }) {
   const [localSummaryRange, setLocalSummaryRange] = useState<SummaryRange>('day');
@@ -52,6 +54,12 @@ export function ChildDashboard({
   const activeParticipantAccess = state.participantAccess?.find((entry) => entry.participant.id === state.activeParticipantId)
     ?? state.participantAccess?.find((entry) => entry.membership.status === 'active');
   const reportSubjectName = activeParticipantAccess?.participant.displayName ?? state.family.childName;
+  const notificationSources = state.notificationSources?.length ? state.notificationSources : activeParticipantAccess ? [{
+    participant: activeParticipantAccess.participant,
+    role: 'child' as const,
+    assignments: state.routineAssignments,
+    events: state.events,
+  }] : [];
   useEffect(() => setExpandedStatus('todo'), [state.activeParticipantId]);
   const today = state.events.filter((event) => isToday(event.requestedAt));
   const pending = today.filter((event) => (
@@ -220,11 +228,14 @@ export function ChildDashboard({
           <div><h1>{t('activity')}</h1></div>
           <NotificationCenter
             role="child"
-            events={state.events}
-            assignments={state.routineAssignments}
+            sources={notificationSources}
             locale={state.locale}
-            contextId={state.activeParticipantId ?? state.family.id ?? state.family.childName}
-            onOpenEvent={(event) => event.status === 'pending' ? start(event) : onOpenHistoryEvent?.(event)}
+            contextId="account"
+            onOpenEvent={(participantId, event) => {
+              if (participantId === state.activeParticipantId && event.status === 'pending') start(event);
+              else if (onOpenNotificationEvent) onOpenNotificationEvent(participantId, event);
+              else onOpenHistoryEvent?.(event);
+            }}
             t={t}
           />
         </header>

--- a/src/screens/ParentDashboard.tsx
+++ b/src/screens/ParentDashboard.tsx
@@ -29,6 +29,7 @@ export function ParentDashboard({
   onSummaryRangeChange,
   onSelectParticipant,
   onOpenHistoryEvent,
+  onOpenNotificationEvent,
   t,
 }: {
   state: AppState;
@@ -41,6 +42,7 @@ export function ParentDashboard({
   onSummaryRangeChange?: (range: SummaryRange) => void;
   onSelectParticipant?: (participantId: string) => void;
   onOpenHistoryEvent?: (event: VerificationEvent) => void;
+  onOpenNotificationEvent?: (participantId: string, event: VerificationEvent) => void;
   t: (key: MessageKey) => string;
 }) {
   const [regenerating, setRegenerating] = useState(false);
@@ -198,6 +200,12 @@ export function ParentDashboard({
   const handleMouseUp = (event: MouseEvent<HTMLElement>, eventId: string) => completeSwipe(eventId, event.clientX, event.clientY);
   const activeParticipantAccess = state.participantAccess?.find((entry) => entry.participant.id === state.activeParticipantId)
     ?? state.participantAccess?.find((entry) => entry.membership.status === 'active');
+  const notificationSources = state.notificationSources?.length ? state.notificationSources : activeParticipantAccess ? [{
+    participant: activeParticipantAccess.participant,
+    role: 'parent' as const,
+    assignments: state.routineAssignments,
+    events: displayEvents,
+  }] : [];
   useEffect(() => setExpandedStatus(undefined), [state.activeParticipantId]);
   return (
     <div className="content-screen child-home parent-overview-screen">
@@ -206,15 +214,15 @@ export function ParentDashboard({
           <div><h1>{t('activity')}</h1></div>
           <NotificationCenter
             role="parent"
-            events={displayEvents}
-            assignments={state.routineAssignments}
+            sources={notificationSources}
             locale={state.locale}
-            contextId={state.activeParticipantId ?? state.family.id ?? state.family.childName}
-            onOpenEvent={(event) => {
-              if (event.status === 'uncertain') {
+            contextId="account"
+            onOpenEvent={(participantId, event) => {
+              if (participantId === state.activeParticipantId && event.status === 'uncertain') {
                 setExpandedStatus('review');
                 window.requestAnimationFrame(() => document.getElementById(`review-${event.id}`)?.scrollIntoView({ block: 'center' }));
               }
+              else if (onOpenNotificationEvent) onOpenNotificationEvent(participantId, event);
               else onOpenHistoryEvent?.(event);
             }}
             t={t}

--- a/src/services/appStateDefaults.ts
+++ b/src/services/appStateDefaults.ts
@@ -30,6 +30,7 @@ export const initialRemoteState = (): AppState => {
     preferences: normalizeAppPreferences(preferences),
     family: { linked: false, childLinked: false, childName: '', linkingCode: '', parentRecoveryCode: '', consented: false },
     participantAccess: [],
+    notificationSources: [],
     routineAssignments: [],
     routinesLoaded: false,
     routinesError: false,

--- a/src/services/firebaseRepository.ts
+++ b/src/services/firebaseRepository.ts
@@ -25,6 +25,7 @@ import {
   type MembershipRole,
   type ParticipantAccess,
   type ParticipantMember,
+  type ParticipantNotificationSource,
   type ProfileColorKey,
   type Role,
   type RoutineAssignment,
@@ -127,6 +128,7 @@ export class FirebaseRepository implements AppRepository {
   private state = initialRemoteState();
   private listeners = new Set<() => void>();
   private remoteSubscriptions: Unsubscribe[] = [];
+  private notificationSubscriptions: Unsubscribe[] = [];
   private accessSubscription?: Unsubscribe;
   private inFlightCallables = new Map<string, Promise<unknown>>();
   private user?: User;
@@ -159,6 +161,7 @@ export class FirebaseRepository implements AppRepository {
       this.state.accessStatus = access?.status === 'suspended' ? 'suspended' : 'active';
       if (this.state.accessStatus === 'suspended') {
         this.remoteSubscriptions.splice(0).forEach((unsubscribe) => unsubscribe());
+        this.notificationSubscriptions.splice(0).forEach((unsubscribe) => unsubscribe());
       }
       this.emit();
     });
@@ -567,6 +570,7 @@ export class FirebaseRepository implements AppRepository {
 
   private async resetOnce() {
     this.remoteSubscriptions.splice(0).forEach((unsubscribe) => unsubscribe());
+    this.notificationSubscriptions.splice(0).forEach((unsubscribe) => unsubscribe());
     this.accessSubscription?.();
     this.accessSubscription = undefined;
     if (this.state.family.linked) {
@@ -689,6 +693,7 @@ export class FirebaseRepository implements AppRepository {
     this.state.participantAccess = access.sort((left, right) => (
       left.participant.displayName.localeCompare(right.participant.displayName, this.state.locale)
     ));
+    this.subscribeToParticipantNotifications();
     const storageKey = `${ACTIVE_PARTICIPANT_KEY_PREFIX}${this.user.uid}`;
     this.state.activeParticipantId = preferredParticipantId(
       this.state.participantAccess,
@@ -697,6 +702,35 @@ export class FirebaseRepository implements AppRepository {
     );
     if (this.state.activeParticipantId) writeUiStorageString(storageKey, this.state.activeParticipantId);
     else removeUiStorageItem(storageKey);
+  }
+
+  private subscribeToParticipantNotifications() {
+    this.notificationSubscriptions.splice(0).forEach((unsubscribe) => unsubscribe());
+    const access = this.state.participantAccess ?? [];
+    this.state.notificationSources = access.map((entry): ParticipantNotificationSource => ({
+      participant: { ...entry.participant },
+      role: entry.membership.role === 'participant' ? 'child' : 'parent',
+      assignments: [],
+      events: [],
+    }));
+    const updateSource = (participantId: string, update: Partial<Pick<ParticipantNotificationSource, 'assignments' | 'events'>>) => {
+      const source = this.state.notificationSources?.find((item) => item.participant.id === participantId);
+      if (!source) return;
+      Object.assign(source, update);
+      this.emit();
+    };
+    access.forEach((entry) => {
+      const participantId = entry.participant.id;
+      const participantRef = doc(this.services.db, 'participants', participantId);
+      const assignments = query(collection(participantRef, 'routineAssignments'), orderBy('assignedAt', 'asc'));
+      const checks = query(collection(participantRef, 'checks'), orderBy('requestedAt', 'desc'));
+      this.notificationSubscriptions.push(onSnapshot(assignments, (snapshot) => {
+        updateSource(participantId, { assignments: snapshot.docs.map((item) => asRoutineAssignment(item.id, item.data())) });
+      }, (error) => console.error('Unable to load notification routine assignments', error)));
+      this.notificationSubscriptions.push(onSnapshot(checks, (snapshot) => {
+        updateSource(participantId, { events: snapshot.docs.map((item) => asEvent(item.id, item.data())) });
+      }, (error) => console.error('Unable to load notification checks', error)));
+    });
   }
 
   private async attachParticipant(participantId: string, membershipRole: MembershipRole) {

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -453,6 +453,7 @@ button:disabled { cursor: not-allowed; }
 .notification-center-list > button { width: 100%; min-height: 62px; display: grid; grid-template-columns: 36px minmax(0, 1fr) auto; align-items: center; gap: 10px; padding: 9px; border: 1px solid var(--color-border); border-radius: 14px; background: var(--color-surface-solid); color: var(--color-text); text-align: left; }
 .notification-center-list > button.unread { background: var(--color-primary-soft); }
 .notification-center-kind { width: 36px; height: 36px; display: grid; place-items: center; border-radius: 11px; background: var(--color-control-surface); color: var(--color-primary); }
+.notification-center-profile { background: color-mix(in srgb, var(--profile-color) 14%, var(--color-surface-solid)); color: var(--profile-color); font-size: 11px; font-weight: 950; letter-spacing: .02em; }
 .notification-center-list > button > span:nth-child(2) { min-width: 0; display: grid; gap: 3px; }
 .notification-center-list strong { font-size: 12px; }
 .notification-center-list small { overflow: hidden; color: var(--color-text-muted); font-size: 10px; text-overflow: ellipsis; white-space: nowrap; }


### PR DESCRIPTION
## Summary
- aggregate notification events and routine labels across every accessible participant
- identify each notification with the participant’s initials, profile color, and full name
- switch to the notification’s participant before opening its action or routine history
- keep read state global across profile switches
- clean up multi-profile listeners on suspension and account reset
- bump the application patch version to 0.9.8

## Why
The notification center only received the active participant’s events, so activity from other followed profiles was invisible and notification clicks could not restore the correct context.

## Impact
Caregivers and participants can review one account-wide notification stream, immediately see who each event concerns, and navigate to the matching profile and event in one tap.

## Validation
- `npm run check`
- `./node_modules/.bin/vitest run src/components/NotificationCenter.test.tsx src/screens/ChildDashboard.test.tsx src/screens/ParentDashboard.test.tsx`
- `./node_modules/.bin/tsc -b --pretty false`
- `npm run check:architecture`
- `npm run check:design`
- `git diff --check`