### PR TITLE
Swap profile and page icons

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zadiag-pwa",
   "private": true,
-  "version": "0.9.8",
+  "version": "0.9.9",
   "type": "module",
   "packageManager": "pnpm@11.7.0",
   "engines": {

--- a/src/components/ParticipantSelector.tsx
+++ b/src/components/ParticipantSelector.tsx
@@ -1,5 +1,5 @@
 import { useRef, type CSSProperties } from 'react';
-import { checkmarkOutline, personCircleOutline } from 'ionicons/icons';
+import { checkmarkOutline, peopleOutline, personCircleOutline } from 'ionicons/icons';
 import type { ParticipantAccess } from '../domain/models';
 import { ProfileContextCard } from './ProfileContextCard';
 import { SvgIcon } from './SvgIcon';
@@ -34,7 +34,8 @@ export function ParticipantSelector({ access, activeParticipantId, label, title,
         className="card"
         title={displayTitle}
         subtitle={subtitle}
-        actionIcon={personCircleOutline}
+        leadingIcon={personCircleOutline}
+        actionIcon={peopleOutline}
         actionLabel={`${actionLabel ?? label} : ${selected.participant.displayName}`}
         profileColor={profileColorFor(selected.participant)}
       />

--- a/src/components/RelationshipManager.tsx
+++ b/src/components/RelationshipManager.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState, type CSSProperties, type FormEvent } from 'react';
-import { settingsOutline } from 'ionicons/icons';
+import { peopleOutline, settingsOutline } from 'ionicons/icons';
 import type { MembershipRole, ParticipantAccess, ParticipantMember, ProfileColorKey } from '../domain/models';
 import { formatMessage, type MessageKey } from '../services/i18n';
 import { ProfileContextCard } from './ProfileContextCard';
@@ -133,7 +133,8 @@ export function RelationshipManager({ access, activeParticipantId, accountDispla
           className="relationship-manager-toggle"
           title={selectedAccess?.participant.displayName ?? t('relationshipManagerTitle')}
           profileColor={selectedAccess ? profileColorFor(selectedAccess.participant) : undefined}
-          actionIcon={settingsOutline}
+          leadingIcon={settingsOutline}
+          actionIcon={peopleOutline}
           actionLabel={t('relationshipManageAction')}
           expanded={open}
           onClick={() => { setError(undefined); setOpen((current) => !current); }}


### PR DESCRIPTION
## Summary
- place the page action icon in the leading slot of top profile blocks
- place the profile icon in the trailing profile-colored slot
- cover participant switching and relationship settings contexts
- preserve the existing colors and surfaces of both positions
- bump the application patch version to 0.9.9

## Why
The profile glyph and the page-specific action glyph were displayed in the opposite visual roles from the intended hierarchy.

## Impact
Top profile blocks now associate the dark leading area with the current page action and the participant-colored trailing area with the profile, without changing interactions.

## Validation
- `npm run check`
- `./node_modules/.bin/vitest run src/components/ParticipantSelector.test.tsx src/components/RelationshipManager.test.tsx src/screens/SettingsScreen.test.tsx src/screens/ParentDashboard.test.tsx src/screens/RoutinesScreen.test.tsx`
- `npm run check:design`
- `git diff --check`