### PR TITLE
Top-align settings row icons and actions

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zadiag-pwa",
   "private": true,
-  "version": "0.9.9",
+  "version": "0.9.10",
   "type": "module",
   "packageManager": "pnpm@11.7.0",
   "engines": {

--- a/scripts/check-design.mjs
+++ b/scripts/check-design.mjs
@@ -27,9 +27,20 @@ const tokens = await readFile(tokensPath, 'utf8');
 const appCss = await readFile(appCssPath, 'utf8');
 const allCss = `${tokens}\n${appCss}`;
 const normalizeColor = (value) => value.toLowerCase().replace(/\s+/g, '');
+const escapeRegExp = (value) => value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+const cssRuleHasDeclaration = (selector, declaration) => {
+  const rule = appCss.match(new RegExp(`${escapeRegExp(selector)}\\s*\\{([^}]*)\\}`));
+  return Boolean(rule?.[1] && declaration.test(rule[1]));
+};
 
 if (!/^:root\s*\{/m.test(tokens)) errors.push(`${relativePath(tokensPath)}: missing :root token scope`);
 if (/:root\s*\{/.test(appCss)) errors.push(`${relativePath(appCssPath)}: foundational tokens must live in src/styles/tokens.css`);
+
+for (const selector of ['.settings-row', '.settings-help-center > summary']) {
+  if (!cssRuleHasDeclaration(selector, /align-items\s*:\s*flex-start\s*;/)) {
+    errors.push(`${relativePath(appCssPath)}: ${selector} must keep row icons and actions aligned to the top`);
+  }
+}
 
 const legacyTokens = ['navy', 'teal', 'mint', 'cream', 'coral', 'muted', 'line', 'surface', 'surface-solid'];
 for (const token of legacyTokens) {

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -1531,10 +1531,9 @@ button:disabled { cursor: not-allowed; }
 
 .settings-section { gap: 9px; }
 .settings-list { padding: 0; overflow: hidden; }
-.settings-row { display: grid; grid-template-columns: 42px minmax(0, 1fr) auto; align-items: center; gap: 12px; min-height: 76px; padding: var(--row-padding-y) var(--row-padding-x); border-bottom: 1px solid rgba(16,42,67,.07); }
+.settings-row { display: grid; grid-template-columns: 42px minmax(0, 1fr) auto; align-items: flex-start; gap: 12px; min-height: 76px; padding: var(--row-padding-y) var(--row-padding-x); border-bottom: 1px solid rgba(16,42,67,.07); }
 .settings-row:last-child { border-bottom: 0; }
 .settings-row-icon { width: 42px; height: 42px; display: grid; place-items: center; border-radius: 13px; background: #e9f5f2; color: var(--color-primary); font-size: 22px; box-shadow: inset 0 1px rgba(255,255,255,.8); }
-.settings-row > .settings-row-icon { align-self: start; }
 .settings-row-icon.today-task-icon,
 .settings-row-icon.routine-icon,
 .settings-row-icon.routine-history-icon {
@@ -1605,7 +1604,6 @@ button:disabled { cursor: not-allowed; }
 .settings-action-error { color: var(--color-danger); font-size: 12px; font-weight: 800; margin-top: 4px; }
 .settings-account-section { gap: 12px; }
 .settings-account-section > h2 { margin-bottom: -3px; }
-.trust-center-list .settings-row { align-items: flex-start; }
 .settings-account-delete-detail { color: var(--color-text-muted); font-size: 11px; line-height: 1.4; text-align: center; }
 .settings-health-online { color: var(--color-primary); }
 .settings-health-offline { background: var(--color-warning-soft); color: var(--color-warning-strong); }
@@ -1613,7 +1611,7 @@ button:disabled { cursor: not-allowed; }
 .settings-health-badge.online { background: var(--color-primary-soft); color: var(--color-primary); }
 .settings-health-badge.offline { background: var(--color-warning-soft); color: var(--color-warning-strong); }
 .settings-help-center { border-bottom: 1px solid var(--color-border); }
-.settings-help-center > summary { min-height: 62px; display: flex; align-items: center; gap: 11px; padding: var(--row-padding-y) var(--row-padding-x); cursor: pointer; list-style: none; }
+.settings-help-center > summary { min-height: 62px; display: flex; align-items: flex-start; gap: 11px; padding: var(--row-padding-y) var(--row-padding-x); cursor: pointer; list-style: none; }
 .settings-help-center > summary::-webkit-details-marker { display: none; }
 .settings-help-center > summary:focus-visible { outline: 3px solid color-mix(in srgb, var(--color-primary) 35%, transparent); outline-offset: -3px; }
 .settings-help-chevron { width: var(--height-action); height: var(--height-action); box-sizing: border-box; flex: 0 0 auto; margin-left: auto; padding: 10px; border-radius: 12px; background: var(--color-subtle-action); color: var(--color-primary); transition: transform .2s ease; }


### PR DESCRIPTION
## Summary
- align settings row icons, content, and trailing actions to the top
- apply the same alignment to the Help Center row
- remove superseded one-off alignment overrides
- add a design guardrail that fails if either row container returns to vertical centering
- bump the application patch version to 0.9.10

## Why
The recovery diagnostics chevron occupied the trailing grid column, whose parent still vertically centered all items. Left icons had a local exception, creating inconsistent alignment across rows.

## Impact
The recovery diagnostics chevron and all settings-row icons/actions now share a consistent top edge, while intentionally centered icons in buttons and other card types remain unchanged.

## Validation
- `npm run check`
- `./node_modules/.bin/vitest run src/screens/SettingsScreen.test.tsx src/components/RelationshipManager.test.tsx`
- `npm run check:design`
- `git diff --check`