### PR TITLE
Align recovery diagnostic details to row edge

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zadiag-pwa",
   "private": true,
-  "version": "0.9.11",
+  "version": "0.9.12",
   "type": "module",
   "packageManager": "pnpm@11.7.0",
   "engines": {

--- a/src/screens/SettingsScreen.tsx
+++ b/src/screens/SettingsScreen.tsx
@@ -393,6 +393,7 @@ export function SettingsScreen({
             </div>
           </details>
           <ListRow
+            className="settings-diagnostics-row"
             icon={<SvgIcon icon={informationCircleOutline} />}
             title={t('settingsRecoveryDiagnosticsTitle')}
             detail={t('settingsRecoveryDiagnosticsDetail')}

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -1619,6 +1619,11 @@ button:disabled { cursor: not-allowed; }
 .settings-help-content strong { font-size: 12px; }
 .settings-help-content p { margin: 3px 0 0; color: var(--color-text-muted); font-size: 11px; line-height: 1.45; }
 .settings-diagnostics-list { display: grid; grid-template-columns: 1fr; gap: 8px; margin: 10px 0 0; }
+.settings-diagnostics-row .settings-row-copy { grid-column: 2 / -1; grid-template-columns: minmax(0, 1fr) var(--height-action); column-gap: 12px; }
+.settings-diagnostics-row .settings-row-copy > strong,
+.settings-diagnostics-row .settings-row-copy > small { grid-column: 1; }
+.settings-diagnostics-row .settings-diagnostics-list { grid-column: 1 / -1; }
+.settings-diagnostics-row > .settings-diagnostics-toggle { z-index: 1; grid-column: 3; grid-row: 1; }
 .settings-diagnostics-list div { display: flex; align-items: baseline; justify-content: space-between; gap: 14px; padding-top: 8px; border-top: 1px solid rgba(13,146,125,.12); }
 .settings-diagnostics-list dt { color: var(--color-text-muted); font-size: 11px; font-weight: 900; text-transform: uppercase; }
 .settings-diagnostics-list dd { margin: 0; max-width: 58%; overflow-wrap: anywhere; color: var(--color-text); font-size: 12px; font-weight: 900; text-align: right; }


### PR DESCRIPTION
## Summary
- let recovery diagnostic details span through the trailing action column
- keep the title and description in their existing text column
- preserve the chevron position above the expanded detail area
- bump the application patch version to 0.9.12

## Why
The expanded diagnostic list was nested inside the text column, so its right edge stopped before the chevron column while the parent row extended farther right.

## Impact
Expanded diagnostic separators and values now align with the right edge used by the level above without affecting other settings-row secondary content.

## Validation
- `npm run check`
- `./node_modules/.bin/vitest run src/screens/SettingsScreen.test.tsx`
- `./node_modules/.bin/tsc -b --pretty false`
- `npm run check:design`
- `git diff --check`