### PR TITLE
Inset recovery diagnostic details

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zadiag-pwa",
   "private": true,
-  "version": "0.9.12",
+  "version": "0.9.13",
   "type": "module",
   "packageManager": "pnpm@11.7.0",
   "engines": {

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -1622,7 +1622,7 @@ button:disabled { cursor: not-allowed; }
 .settings-diagnostics-row .settings-row-copy { grid-column: 2 / -1; grid-template-columns: minmax(0, 1fr) var(--height-action); column-gap: 12px; }
 .settings-diagnostics-row .settings-row-copy > strong,
 .settings-diagnostics-row .settings-row-copy > small { grid-column: 1; }
-.settings-diagnostics-row .settings-diagnostics-list { grid-column: 1 / -1; }
+.settings-diagnostics-row .settings-diagnostics-list { width: 95%; grid-column: 1 / -1; justify-self: start; }
 .settings-diagnostics-row > .settings-diagnostics-toggle { z-index: 1; grid-column: 3; grid-row: 1; }
 .settings-diagnostics-list div { display: flex; align-items: baseline; justify-content: space-between; gap: 14px; padding-top: 8px; border-top: 1px solid rgba(13,146,125,.12); }
 .settings-diagnostics-list dt { color: var(--color-text-muted); font-size: 11px; font-weight: 900; text-transform: uppercase; }


### PR DESCRIPTION
## Summary
- reduce the expanded recovery diagnostic detail width to 95%
- keep the detail list aligned to the left of its expanded grid area
- create a consistent 5% visual inset on the right
- bump the application patch version to 0.9.13

## Why
Allowing the details to span the full chevron column placed their separators and values too close to the outer edge.

## Impact
The expanded details retain the additional useful width from the previous patch while ending 5% earlier on the right.

## Validation
- `npm run check`
- `./node_modules/.bin/vitest run src/screens/SettingsScreen.test.tsx`
- `npm run check:design`
- `git diff --check`