### PR TITLE
Keep recovery diagnostic title on first row

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zadiag-pwa",
   "private": true,
-  "version": "0.9.13",
+  "version": "0.9.14",
   "type": "module",
   "packageManager": "pnpm@11.7.0",
   "engines": {

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -1619,7 +1619,7 @@ button:disabled { cursor: not-allowed; }
 .settings-help-content strong { font-size: 12px; }
 .settings-help-content p { margin: 3px 0 0; color: var(--color-text-muted); font-size: 11px; line-height: 1.45; }
 .settings-diagnostics-list { display: grid; grid-template-columns: 1fr; gap: 8px; margin: 10px 0 0; }
-.settings-diagnostics-row .settings-row-copy { grid-column: 2 / -1; grid-template-columns: minmax(0, 1fr) var(--height-action); column-gap: 12px; }
+.settings-diagnostics-row .settings-row-copy { grid-column: 2 / -1; grid-row: 1; grid-template-columns: minmax(0, 1fr) var(--height-action); column-gap: 12px; }
 .settings-diagnostics-row .settings-row-copy > strong,
 .settings-diagnostics-row .settings-row-copy > small { grid-column: 1; }
 .settings-diagnostics-row .settings-diagnostics-list { width: 95%; grid-column: 1 / -1; justify-self: start; }


### PR DESCRIPTION
## Summary
- explicitly anchor the recovery diagnostic copy block to the first grid row
- keep the title horizontally aligned with the chevron
- preserve the description and expanded details below
- bump the application patch version to 0.9.14

## Why
The chevron had an explicit first-row position while the spanning copy block relied on automatic placement. Because their grid areas overlap in the trailing column, the browser moved the entire copy block to the next row.

## Impact
The recovery diagnostic title and chevron now stay on the same top row while retaining the 5% detail inset.

## Validation
- `npm run check`
- `./node_modules/.bin/vitest run src/screens/SettingsScreen.test.tsx`
- `npm run check:design`
- `git diff --check`