### PR TITLE
Route notification events to dashboard actions

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zadiag-pwa",
   "private": true,
-  "version": "0.9.14",
+  "version": "0.9.15",
   "type": "module",
   "packageManager": "pnpm@11.7.0",
   "engines": {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -125,6 +125,7 @@ export function App() {
   const [savingRoutineId, setSavingRoutineId] = useState<string>();
   const [selectedSessionId, setSelectedSessionId] = useState<string>();
   const [focusedHistoryEventId, setFocusedHistoryEventId] = useState<string>();
+  const [focusedDashboardEventId, setFocusedDashboardEventId] = useState<string>();
   const [lastSyncAt, setLastSyncAt] = useState<string>();
   const [online, setOnline] = useState(() => navigator.onLine);
   const [pendingSyncOperations, setPendingSyncOperations] = useState(0);
@@ -373,13 +374,8 @@ export function App() {
       if (!selectActiveParticipant) return;
       await selectActiveParticipant(participantId);
     }
-    const selectedState = repository.snapshot();
-    if (selectedState.role === 'child' && event.status === 'pending' && Date.parse(event.expiresAt) > Date.now()) {
-      startCapture(event);
-      return;
-    }
-    setFocusedHistoryEventId(event.id);
-    setTab('routines');
+    setFocusedDashboardEventId(event.id);
+    setTab('home');
     setRoute('app');
   };
 
@@ -392,6 +388,7 @@ export function App() {
     setSubmitError(undefined);
     setSelectedSessionId(undefined);
     setFocusedHistoryEventId(undefined);
+    setFocusedDashboardEventId(undefined);
     setSavingRoutineId(undefined);
     resetDismissedUpdate();
     setResetNoticeKey(resetNoticeMessageKey(previousRole));
@@ -616,6 +613,8 @@ export function App() {
               onSelectParticipant={selectActiveParticipant}
               onOpenHistoryEvent={openHistoryEvent}
               onOpenNotificationEvent={(participantId, event) => { void openNotificationEvent(participantId, event); }}
+              notificationEventId={focusedDashboardEventId}
+              onNotificationEventConsumed={() => setFocusedDashboardEventId(undefined)}
               t={t}
             />
           : <ChildDashboard
@@ -627,6 +626,8 @@ export function App() {
               onSummaryRangeChange={setDashboardSummaryRange}
               onOpenHistoryEvent={openHistoryEvent}
               onOpenNotificationEvent={(participantId, event) => { void openNotificationEvent(participantId, event); }}
+              notificationEventId={focusedDashboardEventId}
+              onNotificationEventConsumed={() => setFocusedDashboardEventId(undefined)}
               t={t}
             />;
     content = (

--- a/src/screens/ChildDashboard.test.tsx
+++ b/src/screens/ChildDashboard.test.tsx
@@ -125,11 +125,12 @@ describe('participant Today screen', () => {
       events: [failed],
     };
     const retake = vi.fn();
+    const notificationConsumed = vi.fn();
 
-    act(() => root.render(<ChildDashboard state={state} start={() => undefined} retake={retake} t={(key) => translate('en', key)} />));
+    act(() => root.render(<ChildDashboard state={state} start={() => undefined} retake={retake} notificationEventId={failed.id} onNotificationEventConsumed={notificationConsumed} t={(key) => translate('en', key)} />));
 
-    expect(container.querySelector('.participant-review-section')).toBeNull();
-    selectDashboardStatus('To retry');
+    expect(container.querySelector('.dashboard-status-summary button[aria-pressed="true"]')?.textContent).toContain('To retry');
+    expect(notificationConsumed).toHaveBeenCalledOnce();
     const todayButton = container.querySelector<HTMLButtonElement>('.today-retake-button');
     expect(todayButton).toBeTruthy();
     expect(Array.from(container.querySelectorAll('.dashboard-status-summary strong')).map((item) => item.textContent)).toEqual(['0', '1', '1']);

--- a/src/screens/ChildDashboard.tsx
+++ b/src/screens/ChildDashboard.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import type { AppState, VerificationEvent } from '../domain/models';
 import { formatMessage, type MessageKey } from '../services/i18n';
 import { languageTag } from '../services/locale';
@@ -33,6 +33,8 @@ export function ChildDashboard({
   onSummaryRangeChange,
   onOpenHistoryEvent,
   onOpenNotificationEvent,
+  notificationEventId,
+  onNotificationEventConsumed,
   t,
 }: {
   state: AppState;
@@ -43,10 +45,13 @@ export function ChildDashboard({
   onSummaryRangeChange?: (range: SummaryRange) => void;
   onOpenHistoryEvent?: (event: VerificationEvent) => void;
   onOpenNotificationEvent?: (participantId: string, event: VerificationEvent) => void;
+  notificationEventId?: string;
+  onNotificationEventConsumed?: () => void;
   t: (key: MessageKey) => string;
 }) {
   const [localSummaryRange, setLocalSummaryRange] = useState<SummaryRange>('day');
   const [expandedStatus, setExpandedStatus] = useState<'todo' | 'retry' | 'next' | undefined>('todo');
+  const handledNotificationEventIdRef = useRef<string | undefined>(undefined);
   const summaryRange = controlledSummaryRange ?? localSummaryRange;
   const setSummaryRange = onSummaryRangeChange ?? setLocalSummaryRange;
   const now = Date.now();
@@ -122,6 +127,26 @@ export function ChildDashboard({
     : undefined;
   const upcomingChecks = useMemo(() => presentedUpcomingRoutineChecks(state.routineAssignments, state.locale, nowDate),
   [nowDate, state.locale, state.routineAssignments]);
+  useEffect(() => {
+    if (!notificationEventId) {
+      handledNotificationEventIdRef.current = undefined;
+      return;
+    }
+    if (handledNotificationEventIdRef.current === notificationEventId) return;
+    const event = state.events.find((item) => item.id === notificationEventId);
+    if (!event) return;
+    handledNotificationEventIdRef.current = notificationEventId;
+    const retryable = attentionCompleted.some((entry) => entry.event.id === event.id);
+    const targetId = event.status === 'pending' || event.status === 'analyzing'
+      ? 'pending-tasks-title'
+      : retryable
+        ? 'participant-review-title'
+        : 'participant-history-title';
+    if (retryable) setExpandedStatus('retry');
+    else if (event.status === 'pending' || event.status === 'analyzing') setExpandedStatus('todo');
+    window.requestAnimationFrame(() => document.getElementById(targetId)?.scrollIntoView?.({ block: 'center' }));
+    onNotificationEventConsumed?.();
+  }, [attentionCompleted, notificationEventId, onNotificationEventConsumed, state.events]);
   const pendingSection = (
     <section className="today-section" aria-labelledby="pending-tasks-title">
       <div className="today-pending-panel">
@@ -232,8 +257,8 @@ export function ChildDashboard({
             locale={state.locale}
             contextId="account"
             onOpenEvent={(participantId, event) => {
-              if (participantId === state.activeParticipantId && event.status === 'pending') start(event);
-              else if (onOpenNotificationEvent) onOpenNotificationEvent(participantId, event);
+              if (onOpenNotificationEvent) onOpenNotificationEvent(participantId, event);
+              else if (participantId === state.activeParticipantId && event.status === 'pending') start(event);
               else onOpenHistoryEvent?.(event);
             }}
             t={t}

--- a/src/screens/ParentDashboard.test.tsx
+++ b/src/screens/ParentDashboard.test.tsx
@@ -472,6 +472,7 @@ describe('ParentDashboard', () => {
     const assignment = createDefaultRoutineAssignment();
     const getProofImageUrl = vi.fn().mockResolvedValue('data:image/png;base64,TEST');
     const reviewCheck = vi.fn().mockResolvedValue(undefined);
+    const notificationConsumed = vi.fn();
     const state: AppState = {
       role: 'parent',
       locale: 'en',
@@ -503,13 +504,16 @@ describe('ParentDashboard', () => {
           regenerateCode={vi.fn()}
           getProofImageUrl={getProofImageUrl}
           reviewCheck={reviewCheck}
+          notificationEventId="review"
+          onNotificationEventConsumed={notificationConsumed}
           t={(key) => translate('en', key)}
         />,
       );
       await Promise.resolve();
     });
 
-    selectDashboardStatus('To review');
+    expect(container.querySelector('.dashboard-status-summary button[aria-pressed="true"]')?.textContent).toContain('To review');
+    expect(notificationConsumed).toHaveBeenCalledOnce();
     expect(container.textContent).toContain('Checks to verify');
     expect(Array.from(container.querySelectorAll('.dashboard-status-summary strong')).map((item) => item.textContent)).toEqual(['0', '1', '1']);
     const reviewSection = container.querySelector('.parent-review-section');

--- a/src/screens/ParentDashboard.tsx
+++ b/src/screens/ParentDashboard.tsx
@@ -30,6 +30,8 @@ export function ParentDashboard({
   onSelectParticipant,
   onOpenHistoryEvent,
   onOpenNotificationEvent,
+  notificationEventId,
+  onNotificationEventConsumed,
   t,
 }: {
   state: AppState;
@@ -43,6 +45,8 @@ export function ParentDashboard({
   onSelectParticipant?: (participantId: string) => void;
   onOpenHistoryEvent?: (event: VerificationEvent) => void;
   onOpenNotificationEvent?: (participantId: string, event: VerificationEvent) => void;
+  notificationEventId?: string;
+  onNotificationEventConsumed?: () => void;
   t: (key: MessageKey) => string;
 }) {
   const [regenerating, setRegenerating] = useState(false);
@@ -57,6 +61,7 @@ export function ParentDashboard({
   const [activeReminderStatus, setActiveReminderStatus] = useState<'sent' | 'error'>();
   const [enlargedProofUrl, setEnlargedProofUrl] = useState<string>();
   const swipeStartRef = useRef<{ eventId: string; x: number; y: number } | undefined>(undefined);
+  const handledNotificationEventIdRef = useRef<string | undefined>(undefined);
   const summaryRange = controlledSummaryRange ?? localSummaryRange;
   const setSummaryRange = onSummaryRangeChange ?? setLocalSummaryRange;
   const now = Date.now();
@@ -207,6 +212,23 @@ export function ParentDashboard({
     events: displayEvents,
   }] : [];
   useEffect(() => setExpandedStatus(undefined), [state.activeParticipantId]);
+  useEffect(() => {
+    if (!notificationEventId) {
+      handledNotificationEventIdRef.current = undefined;
+      return;
+    }
+    if (handledNotificationEventIdRef.current === notificationEventId) return;
+    const event = state.events.find((item) => item.id === notificationEventId);
+    if (!event) return;
+    handledNotificationEventIdRef.current = notificationEventId;
+    const needsReview = event.status === 'uncertain' && !['approved', 'rejected'].includes(event.reviewStatus ?? '');
+    const active = event.status === 'pending' && Date.parse(event.expiresAt) > now;
+    const targetId = needsReview ? `review-${event.id}` : active ? `active-${event.id}` : 'responsible-history-title';
+    if (needsReview) setExpandedStatus('review');
+    else if (active) setExpandedStatus('active');
+    window.requestAnimationFrame(() => document.getElementById(targetId)?.scrollIntoView?.({ block: 'center' }));
+    onNotificationEventConsumed?.();
+  }, [notificationEventId, now, onNotificationEventConsumed, state.events]);
   return (
     <div className="content-screen child-home parent-overview-screen">
       <div className="page-context-top parent-context-top">
@@ -218,11 +240,7 @@ export function ParentDashboard({
             locale={state.locale}
             contextId="account"
             onOpenEvent={(participantId, event) => {
-              if (participantId === state.activeParticipantId && event.status === 'uncertain') {
-                setExpandedStatus('review');
-                window.requestAnimationFrame(() => document.getElementById(`review-${event.id}`)?.scrollIntoView({ block: 'center' }));
-              }
-              else if (onOpenNotificationEvent) onOpenNotificationEvent(participantId, event);
+              if (onOpenNotificationEvent) onOpenNotificationEvent(participantId, event);
               else onOpenHistoryEvent?.(event);
             }}
             t={t}
@@ -276,7 +294,7 @@ export function ParentDashboard({
                     const presentation = routinePresentationFor(event);
                     const proofExample = routineProofExampleFor(event);
                     return (
-                      <article className="today-task today-routine-card parent-active-check-card actionable" style={presentation.style} key={event.id}>
+                      <article id={`active-${event.id}`} className="today-task today-routine-card parent-active-check-card actionable" style={presentation.style} key={event.id}>
                         <div className="today-routine-main">
                           <div className="today-routine-primary">
                             <div className="today-task-copy">


### PR DESCRIPTION
## Résumé
- ouvre le Dashboard du profil concerné depuis chaque notification
- affiche automatiquement la section À faire, À réessayer ou À vérifier correspondant à l’événement
- centre l’action demandée et rapproche les événements terminés de l’historique
- évite les réouvertures répétées pendant le chargement du profil
- passe l’application en version 0.9.15

## Cause
Le centre de notifications envoyait les événements vers l’onglet Routines, indépendamment de leur état et de l’action réellement attendue.

## Validation
- npm run check
- 214 tests client
- 12 tests fonctions serveur
- TypeScript, build, bundle, architecture et design
- git diff --check