### PR TITLE
Dispatch scheduled routine checks promptly

### DIFF
--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -9,7 +9,7 @@ import { randomBytes } from 'node:crypto';
 import webpush, { type PushSubscription } from 'web-push';
 import { assertChildName, createLinkCode, createRecoveryCode, createRelationshipInvitationCode, hashLinkCode, isFirestoreDocumentId, isFreshCheckSubmission, isLegacyRecoveryCode, isRecoveryCode, isRelationshipInvitationCode, normalizeLinkCode, sensitiveCodeAttemptState } from './helpers.js';
 import { analyzeWithGemini, parseImageDataUrl, routeAnalysisStatusForReview, type AnalysisResult, type RoutineAnalysisContext } from './analysis.js';
-import { checkExpiresAt, getLocalDateKey, getWindowForDate, monitoringPlanSchema, shouldAutoDispatchCheck } from './planning.js';
+import { checkExpiresAt, getLocalDateKey, getWindowForDate, monitoringPlanSchema, plannedCheckDispatchSchedule, shouldAutoDispatchCheck } from './planning.js';
 import { createDefaultRoutineAssignment, createRoutineAssignment, DEFAULT_ROUTINE_ID, isRoutineValidationMode, routineFromCatalog, type RoutineAssignmentDocument } from './routines.js';
 import { buildCheckNotificationPayload, buildReviewNotificationPayload, buildTestNotificationPayload, normalizePushPreferences, normalizePushSubscription, type SyntheticReceiptPayload } from './notifications.js';
 import { isCheckRequestRateLimited } from './reminders.js';
@@ -2009,7 +2009,7 @@ const aggregateHasActiveParticipant = async (aggregate: FirebaseFirestore.QueryD
 
 export const dispatchPlannedChecks = onSchedule({
   region,
-  schedule: 'every 30 minutes',
+  schedule: plannedCheckDispatchSchedule,
   timeZone: 'UTC',
   secrets: [vapidPrivateKey, vapidPublicKey],
 }, async () => {

--- a/functions/src/planning.test.ts
+++ b/functions/src/planning.test.ts
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
-import { checkExpiresAt, monitoringPlanSchema, shouldAutoDispatchCheck } from './planning.js';
+import { checkExpiresAt, monitoringPlanSchema, plannedCheckDispatchSchedule, shouldAutoDispatchCheck } from './planning.js';
 
 const plan = {
   checksPerDay: 3,
@@ -13,6 +13,10 @@ const plan = {
   expiryMinutes: 20,
   timeZone: 'Europe/Paris',
 };
+
+test('dispatches planned checks every minute so a started routine appears promptly', () => {
+  assert.equal(plannedCheckDispatchSchedule, 'every 1 minutes');
+});
 
 test('validates monitoring plans at the callable boundary', () => {
   assert.equal(monitoringPlanSchema.safeParse(plan).success, true);

--- a/functions/src/planning.ts
+++ b/functions/src/planning.ts
@@ -14,6 +14,8 @@ export interface MonitoringPlan {
   timeZone: string;
 }
 
+export const plannedCheckDispatchSchedule = 'every 1 minutes';
+
 const timePattern = /^(?:[01]\d|2[0-3]):[0-5]\d$/;
 const minutesForTime = (value: string) => {
   const [hours, minutes] = value.split(':').map(Number);

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zadiag-pwa",
   "private": true,
-  "version": "0.9.15",
+  "version": "0.9.16",
   "type": "module",
   "packageManager": "pnpm@11.7.0",
   "engines": {


### PR DESCRIPTION
## Résumé
- exécute le planificateur des contrôles chaque minute au lieu de toutes les 30 minutes
- fait apparaître rapidement sur le Dashboard une routine dont le créneau vient de commencer
- centralise et teste la cadence pour éviter une régression
- passe l’application en version 0.9.16

## Cause
Le Dashboard ne pouvait afficher aucun statut après le début d’un créneau tant que le serveur n’avait pas créé son contrôle. Avec une cadence de 30 minutes, une routine prévue à 17 h pouvait rester invisible près d’une demi-heure.

## Impact
Le contrôle est désormais créé autour de la première minute du créneau et devient alors disponible dans « À faire » ou « Actifs » selon le profil.

## Validation
- npm run check
- 214 tests client
- 12 suites de tests serveur
- TypeScript, build, bundle, architecture et design
- git diff --check