### PR TITLE
Match captured photos to the visible camera frame

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zadiag-pwa",
   "private": true,
-  "version": "0.9.19",
+  "version": "0.9.20",
   "type": "module",
   "packageManager": "pnpm@11.7.0",
   "engines": {

--- a/src/components/CameraCapture.tsx
+++ b/src/components/CameraCapture.tsx
@@ -3,6 +3,7 @@ import { camera, checkmark, refresh } from 'ionicons/icons';
 import type { MessageKey } from '../services/i18n';
 import { SvgIcon } from './SvgIcon';
 import { ActionButton } from './ui';
+import { cameraFrameGeometry } from '../domain/cameraFrame';
 
 interface CameraCaptureProps {
   t: (key: MessageKey) => string;
@@ -93,12 +94,28 @@ export function CameraCapture({ t, busy, submitError, onSubmit }: CameraCaptureP
 
   const capture = () => {
     const video = videoRef.current;
-    if (!video || video.readyState < HTMLMediaElement.HAVE_CURRENT_DATA) return;
+    if (!video || video.readyState < HTMLMediaElement.HAVE_CURRENT_DATA || video.videoWidth <= 0 || video.videoHeight <= 0) return;
     const canvas = document.createElement('canvas');
-    const scale = Math.min(1, captureMaxSide / Math.max(video.videoWidth, video.videoHeight));
-    canvas.width = Math.max(1, Math.round(video.videoWidth * scale));
-    canvas.height = Math.max(1, Math.round(video.videoHeight * scale));
-    canvas.getContext('2d')?.drawImage(video, 0, 0);
+    const frame = cameraFrameGeometry(
+      video.videoWidth,
+      video.videoHeight,
+      video.clientWidth,
+      video.clientHeight,
+      captureMaxSide,
+    );
+    canvas.width = frame.outputWidth;
+    canvas.height = frame.outputHeight;
+    canvas.getContext('2d')?.drawImage(
+      video,
+      frame.sourceX,
+      frame.sourceY,
+      frame.sourceWidth,
+      frame.sourceHeight,
+      0,
+      0,
+      frame.outputWidth,
+      frame.outputHeight,
+    );
     const timestamp = new Date();
     setCapturedAt(timestamp);
     setLocalCheckError(undefined);

--- a/src/domain/cameraFrame.test.ts
+++ b/src/domain/cameraFrame.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+import { cameraFrameGeometry } from './cameraFrame';
+
+describe('camera frame geometry', () => {
+  it('crops a landscape sensor to the portrait area visible in the camera', () => {
+    const frame = cameraFrameGeometry(1920, 1080, 360, 560);
+
+    expect(frame.sourceX).toBeCloseTo(612.86);
+    expect(frame.sourceY).toBe(0);
+    expect(frame.sourceWidth).toBeCloseTo(694.29);
+    expect(frame.sourceHeight).toBe(1080);
+    expect([frame.outputWidth, frame.outputHeight]).toEqual([694, 1080]);
+  });
+
+  it('crops a portrait sensor vertically for a wider visible frame', () => {
+    const frame = cameraFrameGeometry(1080, 1920, 560, 360);
+
+    expect(frame.sourceX).toBe(0);
+    expect(frame.sourceY).toBeCloseTo(612.86);
+    expect(frame.sourceWidth).toBe(1080);
+    expect(frame.sourceHeight).toBeCloseTo(694.29);
+    expect([frame.outputWidth, frame.outputHeight]).toEqual([1080, 694]);
+  });
+
+  it('keeps matching aspect ratios and caps the output size', () => {
+    expect(cameraFrameGeometry(2400, 1600, 600, 400)).toEqual({
+      sourceX: 0,
+      sourceY: 0,
+      sourceWidth: 2400,
+      sourceHeight: 1600,
+      outputWidth: 1600,
+      outputHeight: 1067,
+    });
+  });
+});

--- a/src/domain/cameraFrame.ts
+++ b/src/domain/cameraFrame.ts
@@ -1,0 +1,33 @@
+export interface CameraFrameGeometry {
+  sourceX: number;
+  sourceY: number;
+  sourceWidth: number;
+  sourceHeight: number;
+  outputWidth: number;
+  outputHeight: number;
+}
+
+export const cameraFrameGeometry = (
+  sourceWidth: number,
+  sourceHeight: number,
+  viewportWidth: number,
+  viewportHeight: number,
+  maxOutputSide = 1600,
+): CameraFrameGeometry => {
+  const safeViewportWidth = viewportWidth > 0 ? viewportWidth : sourceWidth;
+  const safeViewportHeight = viewportHeight > 0 ? viewportHeight : sourceHeight;
+  const sourceRatio = sourceWidth / sourceHeight;
+  const viewportRatio = safeViewportWidth / safeViewportHeight;
+  const sourceCropWidth = sourceRatio > viewportRatio ? sourceHeight * viewportRatio : sourceWidth;
+  const sourceCropHeight = sourceRatio > viewportRatio ? sourceHeight : sourceWidth / viewportRatio;
+  const scale = Math.min(1, maxOutputSide / Math.max(sourceCropWidth, sourceCropHeight));
+
+  return {
+    sourceX: (sourceWidth - sourceCropWidth) / 2,
+    sourceY: (sourceHeight - sourceCropHeight) / 2,
+    sourceWidth: sourceCropWidth,
+    sourceHeight: sourceCropHeight,
+    outputWidth: Math.max(1, Math.round(sourceCropWidth * scale)),
+    outputHeight: Math.max(1, Math.round(sourceCropHeight * scale)),
+  };
+};

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -1916,7 +1916,7 @@ button:disabled { cursor: not-allowed; }
 .camera-page h1 { font-size: 21px; margin: 0; color: var(--color-surface-solid); }
 .camera-flow { max-width: 600px; margin: auto; }
 .camera-viewport { width: 100%; height: min(58dvh, 560px); position: relative; overflow: hidden; background: #0d2335; border: 1px solid rgba(255,255,255,.2); border-radius: 28px; }
-.camera-video, .camera-preview { width: 100%; height: 100%; object-fit: cover; transform: scaleX(-1); }
+.camera-video, .camera-preview { width: 100%; height: 100%; object-fit: cover; object-position: center; transform: scaleX(-1); }
 .mouth-guide { position: absolute; inset: 0; display: flex; flex-direction: column; align-items: center; justify-content: center; pointer-events: none; }
 .mouth-guide span { position: absolute; top: 24px; font-size: 13px; }
 .mouth-oval { width: min(75%, 280px); aspect-ratio: 1.7; border: 3px solid var(--color-surface-solid); border-radius: 50%; box-shadow: 0 0 0 999px rgba(5,18,29,.25); }


### PR DESCRIPTION
## Résumé
- recadre la photo sur la zone réellement visible dans l’aperçu caméra
- aligne le calcul de capture avec `object-fit: cover` et un centrage explicite
- conserve le miroir de la caméra avant entre la visée et l’aperçu capturé
- adapte la géométrie aux capteurs portrait et paysage
- conserve la limite de résolution à 1600 pixels
- passe l’application en version 0.9.20

## Cause
La visée affichait une découpe centrée du flux vidéo, mais le canvas enregistrait l’intégralité du capteur. Le guide pouvait donc sembler correct avant le déclenchement alors que la photo résultante utilisait un cadrage différent.

## Validation
- npm run check
- 223 tests client
- 12 suites de tests serveur
- tests dédiés aux capteurs portrait, paysage et haute résolution
- TypeScript, build, bundle, architecture et design
- git diff --check