### PR TITLE
Allow check review from event details

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zadiag-pwa",
   "private": true,
-  "version": "0.9.20",
+  "version": "0.9.21",
   "type": "module",
   "packageManager": "pnpm@11.7.0",
   "engines": {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -540,6 +540,7 @@ export function App() {
             edit={canManageRoutines}
             requestCheck={canManageRoutines ? withRepositorySync(repository.requestCheckNow) : undefined}
             getProofImageUrl={(eventId) => repository.getProofImageUrl(eventId)}
+            reviewCheck={canManageRoutines ? withRepositorySyncVoid(repository.reviewCheck) : undefined}
             onAssignRoutine={canManageRoutines ? withRepositorySync(repository.assignRoutine) : undefined}
             onDeleteRoutine={canManageRoutines ? withRepositorySync(repository.deleteRoutine) : undefined}
             onRetryRoutines={withOptionalRepositorySync(repository.retryRemoteSync)}

--- a/src/domain/adherence.test.ts
+++ b/src/domain/adherence.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { adherenceSummary, canRetakeCapture, isFreshCapture, resolvedEventStatus, stalePendingCheckReason } from './adherence';
+import { adherenceSummary, canRetakeCapture, isFreshCapture, isReviewableVerification, resolvedEventStatus, stalePendingCheckReason } from './adherence';
 import type { VerificationEvent } from './models';
 
 const event = (status: VerificationEvent['status']): VerificationEvent => ({
@@ -25,6 +25,16 @@ describe('resolvedEventStatus', () => {
   it('treats expired pending checks as missed for display', () => {
     expect(resolvedEventStatus(event('pending'), Date.parse('2026-06-30T12:21:00.000Z'))).toBe('missed');
     expect(resolvedEventStatus(event('pending'), Date.parse('2026-06-30T12:19:00.000Z'))).toBe('pending');
+  });
+});
+
+describe('isReviewableVerification', () => {
+  it('only exposes uncertain checks without a final responsible decision', () => {
+    expect(isReviewableVerification(event('uncertain'))).toBe(true);
+    expect(isReviewableVerification({ ...event('uncertain'), reviewStatus: 'pending' })).toBe(true);
+    expect(isReviewableVerification({ ...event('uncertain'), reviewStatus: 'approved' })).toBe(false);
+    expect(isReviewableVerification({ ...event('uncertain'), reviewStatus: 'rejected' })).toBe(false);
+    expect(isReviewableVerification(event('detected'))).toBe(false);
   });
 });
 

--- a/src/domain/adherence.ts
+++ b/src/domain/adherence.ts
@@ -11,6 +11,9 @@ const retakeWindowMs = 15 * 60_000;
 
 export const isCompletedVerification = (event: VerificationEvent) => finalStatuses.has(event.status);
 
+export const isReviewableVerification = (event: VerificationEvent) =>
+  event.status === 'uncertain' && !['approved', 'rejected'].includes(event.reviewStatus ?? '');
+
 export function adherenceSummary(events: VerificationEvent[]) {
   const completed = events.filter(isCompletedVerification);
   const successful = completed.filter((event) => event.status === 'detected');

--- a/src/screens/ParentDashboard.tsx
+++ b/src/screens/ParentDashboard.tsx
@@ -8,7 +8,7 @@ import { AdherenceSummaryCard, filterEventsBySummaryRange, type SummaryRange } f
 import { UpcomingChecksSection } from '../components/UpcomingChecksSection';
 import { presentRoutine } from '../domain/routinePresentation';
 import { eventWindowLabel } from '../domain/taskTimeLabel';
-import { withResolvedEventStatuses } from '../domain/adherence';
+import { isReviewableVerification, withResolvedEventStatuses } from '../domain/adherence';
 import { EmptyState } from '../components/ui';
 import { activePendingEvents as activePendingChecks, presentedAwaitingRoutineChecks, presentedUpcomingRoutineChecks } from '../domain/dashboardChecks';
 import { ParticipantSelector } from '../components/ParticipantSelector';
@@ -71,7 +71,7 @@ export function ParentDashboard({
   const rangedEvents = filterEventsBySummaryRange(displayEvents, summaryRange, now);
   const rangedRawEvents = filterEventsBySummaryRange(state.events, summaryRange, now);
   const reviewEvents = useMemo(() => state.events
-    .filter((event) => event.status === 'uncertain' && !['approved', 'rejected'].includes(event.reviewStatus ?? ''))
+    .filter(isReviewableVerification)
     .sort((a, b) => Date.parse(b.capturedAt ?? b.requestedAt) - Date.parse(a.capturedAt ?? a.requestedAt)),
   [state.events]);
   const locale = languageTag(state.locale);
@@ -226,7 +226,7 @@ export function ParentDashboard({
     const event = state.events.find((item) => item.id === notificationEventId);
     if (!event) return;
     handledNotificationEventIdRef.current = notificationEventId;
-    const needsReview = event.status === 'uncertain' && !['approved', 'rejected'].includes(event.reviewStatus ?? '');
+    const needsReview = isReviewableVerification(event);
     const active = event.status === 'pending' && Date.parse(event.expiresAt) > now;
     const targetId = needsReview ? `review-${event.id}` : active ? `active-${event.id}` : 'responsible-history-title';
     if (needsReview) setExpandedStatus('review');

--- a/src/screens/RoutineDetailScreen.tsx
+++ b/src/screens/RoutineDetailScreen.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef, useState } from 'react';
 import { cameraOutline, chevronBackOutline, chevronForwardOutline, ellipsisHorizontal, peopleOutline, sendOutline, timeOutline } from 'ionicons/icons';
-import { adherenceSummary, withResolvedEventStatuses } from '../domain/adherence';
+import { adherenceSummary, isReviewableVerification, withResolvedEventStatuses } from '../domain/adherence';
 import { presentRoutine } from '../domain/routinePresentation';
 import type { AppState, RoutineAssignment, RoutineValidationMode, VerificationEvent } from '../domain/models';
 import type { MessageKey } from '../services/i18n';
@@ -152,12 +152,13 @@ const renderRoutineStepIcon = (icon: string) => {
   return icon;
 };
 
-export function RoutineDetailScreen({ assignment, state, back, start, getProofImageUrl, t, edit, initialTab, initialEventId, onInitialEventConsumed, onSaveMonitoringPlan, routinePlanBusy }: {
+export function RoutineDetailScreen({ assignment, state, back, start, getProofImageUrl, reviewCheck, t, edit, initialTab, initialEventId, onInitialEventConsumed, onSaveMonitoringPlan, routinePlanBusy }: {
   assignment: RoutineAssignment;
   state: AppState;
   back: () => void;
   start?: () => void;
   getProofImageUrl?: (eventId: string) => Promise<string>;
+  reviewCheck?: (eventId: string, decision: 'detected' | 'not_detected') => Promise<void>;
   t: (key: MessageKey) => string;
   edit?: boolean;
   initialTab?: DetailInitialTab;
@@ -171,6 +172,8 @@ export function RoutineDetailScreen({ assignment, state, back, start, getProofIm
   const [proofErrors, setProofErrors] = useState<Record<string, boolean>>({});
   const [enlargedProofUrl, setEnlargedProofUrl] = useState<string>();
   const [selectedHistoryEventId, setSelectedHistoryEventId] = useState<string | undefined>(initialEventId);
+  const [reviewingEventId, setReviewingEventId] = useState<string>();
+  const [reviewErrorEventId, setReviewErrorEventId] = useState<string>();
   const historyDialogRef = useModalFocus<HTMLDivElement>(Boolean(selectedHistoryEventId), () => setSelectedHistoryEventId(undefined));
   const todayHeatmapRef = useRef<HTMLSpanElement | null>(null);
   const now = Date.now();
@@ -189,6 +192,19 @@ export function RoutineDetailScreen({ assignment, state, back, start, getProofIm
   const tabs: DetailTab[] = edit ? ['plan', 'details', 'tracking'] : ['details', 'tracking'];
   const analysisSourceLabel = (source?: VerificationEvent['analysisSource']) => source ? t(source === 'ai' ? 'analysisSourceAi' : source === 'fallback' ? 'analysisSourceFallback' : 'analysisSourceSelf') : undefined;
   const reviewStatusLabel = (status?: VerificationEvent['reviewStatus']) => status ? t(status === 'approved' ? 'historyReviewApproved' : status === 'rejected' ? 'historyReviewRejected' : 'historyReviewPending') : undefined;
+  const decide = async (eventId: string, decision: 'detected' | 'not_detected') => {
+    if (!reviewCheck) return;
+    setReviewingEventId(eventId);
+    setReviewErrorEventId(undefined);
+    try {
+      await reviewCheck(eventId, decision);
+    } catch (error) {
+      console.error(error);
+      setReviewErrorEventId(eventId);
+    } finally {
+      setReviewingEventId(undefined);
+    }
+  };
 
   useEffect(() => {
     if (initialEventId) onInitialEventConsumed?.();
@@ -322,7 +338,7 @@ export function RoutineDetailScreen({ assignment, state, back, start, getProofIm
 
       {selectedHistoryEvent ? (
         <div className="history-detail-backdrop" onClick={() => setSelectedHistoryEventId(undefined)}>
-          <div ref={historyDialogRef} className={`history-detail-dialog${proofUrls[selectedHistoryEvent.id] ? '' : ' no-proof'}`} role="dialog" aria-modal="true" aria-labelledby="history-detail-title" tabIndex={-1} onClick={(event) => event.stopPropagation()}>
+          <div ref={historyDialogRef} className={`history-detail-dialog${proofUrls[selectedHistoryEvent.id] ? '' : ' no-proof'}${reviewCheck && isReviewableVerification(selectedHistoryEvent) ? ' has-actions' : ''}`} role="dialog" aria-modal="true" aria-labelledby="history-detail-title" tabIndex={-1} onClick={(event) => event.stopPropagation()}>
             <header>
               <div className="history-detail-heading"><small>{t('historyDetailTitle')}</small><h2 id="history-detail-title">{formatDateTime(selectedHistoryEvent.requestedAt)}</h2><StatusPill status={selectedHistoryEvent.status} t={t} /></div>
               <button type="button" data-autofocus aria-label={t('close')} onClick={() => setSelectedHistoryEventId(undefined)}><AppIcon name="close" /></button>
@@ -344,6 +360,15 @@ export function RoutineDetailScreen({ assignment, state, back, start, getProofIm
               {selectedHistoryEvent.reviewedAt ? <div><dt>{t('historyReviewedAt')}</dt><dd>{formatDateTime(selectedHistoryEvent.reviewedAt)}</dd></div> : null}
               {selectedHistoryEvent.reviewReason ? <div className="wide"><dt>{t('historyReviewComment')}</dt><dd>{selectedHistoryEvent.reviewReason}</dd></div> : null}
             </dl>
+            {reviewCheck && isReviewableVerification(selectedHistoryEvent) ? (
+              <div className="history-detail-review-actions">
+                {reviewErrorEventId === selectedHistoryEvent.id ? <p className="request-feedback error" role="alert">{t('responsibleReviewError')}</p> : null}
+                <div>
+                  <button type="button" className="parent-review-button reject" aria-label={t('responsibleReviewReject')} disabled={reviewingEventId === selectedHistoryEvent.id} onClick={() => { void decide(selectedHistoryEvent.id, 'not_detected'); }}><AppIcon name="close" /></button>
+                  <button type="button" className="parent-review-button approve" aria-label={t('responsibleReviewApprove')} disabled={reviewingEventId === selectedHistoryEvent.id} onClick={() => { void decide(selectedHistoryEvent.id, 'detected'); }}><AppIcon name="check" /></button>
+                </div>
+              </div>
+            ) : null}
           </div>
         </div>
       ) : null}

--- a/src/screens/RoutinesScreen.test.tsx
+++ b/src/screens/RoutinesScreen.test.tsx
@@ -214,6 +214,43 @@ describe('participant routines navigation', () => {
     expect(consumed).toHaveBeenCalledOnce();
   });
 
+  it('lets a responsible validate an uncertain check from its detail dialog', async () => {
+    await import('./RoutineDetailScreen');
+    const assignment = createDefaultRoutineAssignment('2026-07-02T08:00:00.000Z');
+    const historyEvent = {
+      id: 'history-review',
+      routineId: assignment.routineId,
+      sessionId: 'history-session',
+      requestedAt: '2026-07-02T10:00:00.000Z',
+      capturedAt: '2026-07-02T10:10:00.000Z',
+      expiresAt: '2026-07-02T11:00:00.000Z',
+      status: 'uncertain' as const,
+      reviewStatus: 'pending' as const,
+    };
+    const state: AppState = {
+      role: 'parent', locale: 'en', notificationsEnabled: true,
+      family: { linked: true, childLinked: true, childName: 'Maya', linkingCode: '', parentRecoveryCode: '', consented: true },
+      routineAssignments: [assignment], events: [historyEvent], routinesLoaded: true, routinesError: false,
+    };
+    const reviewCheck = vi.fn().mockResolvedValue(undefined);
+
+    await act(async () => {
+      root.render(<RoutinesScreen state={state} edit focusedEventId={historyEvent.id} reviewCheck={reviewCheck} t={(key) => translate('en', key)} />);
+      await new Promise((resolve) => window.setTimeout(resolve, 100));
+    });
+
+    const dialog = container.querySelector('.history-detail-dialog');
+    expect(dialog?.querySelector('button[aria-label="Validate"]')).not.toBeNull();
+    expect(dialog?.querySelector('button[aria-label="Reject"]')).not.toBeNull();
+
+    await act(async () => {
+      dialog?.querySelector<HTMLButtonElement>('button[aria-label="Validate"]')?.click();
+      await Promise.resolve();
+    });
+
+    expect(reviewCheck).toHaveBeenCalledWith(historyEvent.id, 'detected');
+  });
+
   it('keeps participant routine management read-only even when edit callbacks are provided', async () => {
     await import('./RoutineDetailScreen');
     const assignment = createDefaultRoutineAssignment();

--- a/src/screens/RoutinesScreen.tsx
+++ b/src/screens/RoutinesScreen.tsx
@@ -113,6 +113,7 @@ export function RoutinesScreen({
   edit,
   requestCheck,
   getProofImageUrl,
+  reviewCheck,
   onAssignRoutine,
   onDeleteRoutine,
   onRetryRoutines,
@@ -128,6 +129,7 @@ export function RoutinesScreen({
   edit?: boolean;
   requestCheck?: (routineId: string) => Promise<void>;
   getProofImageUrl?: (eventId: string) => Promise<string>;
+  reviewCheck?: (eventId: string, decision: 'detected' | 'not_detected') => Promise<void>;
   onAssignRoutine?: (routineId: string) => Promise<void>;
   onDeleteRoutine?: (routineId: string) => Promise<void>;
   onRetryRoutines?: () => Promise<void>;
@@ -202,7 +204,7 @@ export function RoutinesScreen({
     writeUiStorageString(ROUTINES_EXPANDED_SCHEDULES_KEY, JSON.stringify([...expandedScheduleIds]));
   }, [expandedScheduleIds]);
 
-  if (selected) return <Suspense fallback={<div className="content-screen routines-state" role="status"><p>{t('loadingRoutineDetails')}</p></div>}><RoutineDetailScreen key={`${selected.id}-${detailInitialTab ?? 'default'}`} assignment={selected} state={state} back={backToList} start={start} edit={canManageRoutines} initialTab={detailInitialTab} initialEventId={focusedEventId} onInitialEventConsumed={onFocusedEventConsumed} getProofImageUrl={getProofImageUrl} onSaveMonitoringPlan={canManageRoutines && onSaveMonitoringPlan ? (plan, validationMode) => onSaveMonitoringPlan(selected.routineId, plan, validationMode) : undefined} routinePlanBusy={savingRoutineId === selected.routineId} t={t} /></Suspense>;
+  if (selected) return <Suspense fallback={<div className="content-screen routines-state" role="status"><p>{t('loadingRoutineDetails')}</p></div>}><RoutineDetailScreen key={`${selected.id}-${detailInitialTab ?? 'default'}`} assignment={selected} state={state} back={backToList} start={start} edit={canManageRoutines} initialTab={detailInitialTab} initialEventId={focusedEventId} onInitialEventConsumed={onFocusedEventConsumed} getProofImageUrl={getProofImageUrl} reviewCheck={canManageRoutines ? reviewCheck : undefined} onSaveMonitoringPlan={canManageRoutines && onSaveMonitoringPlan ? (plan, validationMode) => onSaveMonitoringPlan(selected.routineId, plan, validationMode) : undefined} routinePlanBusy={savingRoutineId === selected.routineId} t={t} /></Suspense>;
 
   const setRequestStatus = (routineId: string, status: RequestStatus) => {
     setRequestStatuses((current) => ({ ...current, [routineId]: status }));

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -1374,6 +1374,8 @@ button:disabled { cursor: not-allowed; }
 .history-detail-backdrop { position: fixed; z-index: 70; inset: 0; display: grid; align-items: end; padding: 12px; background: rgba(8,26,40,.48); backdrop-filter: blur(5px); }
 .history-detail-dialog { width: min(100%, 520px); height: min(90dvh, 760px); display: grid; grid-template-rows: auto minmax(150px, 34%) minmax(0, 1fr); gap: 10px; margin: 0 auto; padding: 15px; overflow: hidden; border-radius: 24px; background: var(--color-surface-solid); box-shadow: 0 24px 70px rgba(8,26,40,.28); }
 .history-detail-dialog.no-proof { grid-template-rows: auto minmax(0, 1fr); }
+.history-detail-dialog.has-actions { grid-template-rows: auto minmax(150px, 34%) minmax(0, 1fr) auto; }
+.history-detail-dialog.no-proof.has-actions { grid-template-rows: auto minmax(0, 1fr) auto; }
 .history-detail-dialog > header { display: flex; align-items: flex-start; justify-content: space-between; gap: 12px; }
 .history-detail-dialog > header small { color: var(--color-text-muted); font-size: 10px; font-weight: 900; letter-spacing: .08em; text-transform: uppercase; }
 .history-detail-dialog > header h2 { margin-top: 3px; font-size: 18px; }
@@ -1387,6 +1389,10 @@ button:disabled { cursor: not-allowed; }
 .history-detail-dialog dl > div.wide { grid-column: 1 / -1; min-height: auto; }
 .history-detail-dialog dt { color: var(--color-text-muted); font-size: 11px; font-weight: 850; }
 .history-detail-dialog dd { margin: 0; overflow-wrap: anywhere; color: var(--color-text); font-size: 12px; font-weight: 800; }
+.history-detail-review-actions { display: grid; gap: 8px; }
+.history-detail-review-actions > div { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 8px; }
+.history-detail-review-actions .parent-review-button { width: 100%; }
+.history-detail-review-actions .request-feedback { margin: 0; }
 .progress-summary { display: flex; align-items: center; gap: 18px; padding: var(--block-padding); }
 .progress-summary dl { flex: 1; margin: 0; }
 .progress-summary dl div { display: flex; justify-content: space-between; gap: 15px; font-size: 12px; }


### PR DESCRIPTION
## Summary
- expose validate and reject actions directly in reviewable event details
- reuse the Dashboard review eligibility rule across both entry points
- keep actions responsible-only with loading and retryable error states
- bump the application patch version to 0.9.21

## Validation
- targeted domain and routine screen tests
- architecture and design checks
- production build and bundle-size check
- functions test suite

Note: the aggregate `npm run check` Vitest phase stalled in the local runner after starting with no remaining Vitest process; its constituent checks were rerun separately.