### PR TITLE
Keep event details on the dashboard

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zadiag-pwa",
   "private": true,
-  "version": "0.9.22",
+  "version": "0.9.23",
   "type": "module",
   "packageManager": "pnpm@11.7.0",
   "engines": {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -612,7 +612,6 @@ export function App() {
               summaryRange={dashboardSummaryRange}
               onSummaryRangeChange={setDashboardSummaryRange}
               onSelectParticipant={selectActiveParticipant}
-              onOpenHistoryEvent={openHistoryEvent}
               onOpenNotificationEvent={(participantId, event) => { void openNotificationEvent(participantId, event); }}
               notificationEventId={focusedDashboardEventId}
               onNotificationEventConsumed={() => setFocusedDashboardEventId(undefined)}

--- a/src/components/VerificationEventDetailDialog.tsx
+++ b/src/components/VerificationEventDetailDialog.tsx
@@ -1,0 +1,86 @@
+import { useEffect, useState } from 'react';
+import type { Locale, VerificationEvent } from '../domain/models';
+import { isReviewableVerification } from '../domain/adherence';
+import type { MessageKey } from '../services/i18n';
+import { languageTag } from '../services/locale';
+import { useModalFocus } from '../hooks/useModalFocus';
+import { AppIcon } from './Icon';
+import { StatusPill } from './StatusPill';
+
+export function VerificationEventDetailDialog({ event, locale, proofUrl: providedProofUrl, getProofImageUrl, reviewCheck, onClose, t }: {
+  event: VerificationEvent;
+  locale: Locale;
+  proofUrl?: string;
+  getProofImageUrl?: (eventId: string) => Promise<string>;
+  reviewCheck?: (eventId: string, decision: 'detected' | 'not_detected') => Promise<void>;
+  onClose: () => void;
+  t: (key: MessageKey) => string;
+}) {
+  const dialogRef = useModalFocus<HTMLDivElement>(true, onClose);
+  const [loadedProofUrl, setLoadedProofUrl] = useState<string>();
+  const [reviewing, setReviewing] = useState(false);
+  const [reviewError, setReviewError] = useState(false);
+  const proofUrl = providedProofUrl ?? loadedProofUrl;
+  const canReview = Boolean(reviewCheck) && isReviewableVerification(event);
+  const formatterLocale = languageTag(locale);
+  const formatDateTime = (value: string) => new Intl.DateTimeFormat(formatterLocale, { dateStyle: 'short', timeStyle: 'short' }).format(new Date(value));
+  const analysisSourceLabel = event.analysisSource ? t(event.analysisSource === 'ai' ? 'analysisSourceAi' : event.analysisSource === 'fallback' ? 'analysisSourceFallback' : 'analysisSourceSelf') : undefined;
+  const reviewStatusLabel = event.reviewStatus ? t(event.reviewStatus === 'approved' ? 'historyReviewApproved' : event.reviewStatus === 'rejected' ? 'historyReviewRejected' : 'historyReviewPending') : undefined;
+  const scoreLabel = (score?: number) => score === undefined ? undefined : `${Math.round(score * 100)}%`;
+
+  useEffect(() => {
+    if (providedProofUrl || !event.proofImagePath || !getProofImageUrl) return;
+    let active = true;
+    void getProofImageUrl(event.id)
+      .then((url) => { if (active) setLoadedProofUrl(url); })
+      .catch((error) => { console.error(error); });
+    return () => { active = false; };
+  }, [event.id, event.proofImagePath, getProofImageUrl, providedProofUrl]);
+
+  const decide = async (decision: 'detected' | 'not_detected') => {
+    if (!reviewCheck) return;
+    setReviewing(true);
+    setReviewError(false);
+    try {
+      await reviewCheck(event.id, decision);
+    } catch (error) {
+      console.error(error);
+      setReviewError(true);
+    } finally {
+      setReviewing(false);
+    }
+  };
+
+  return (
+    <div className="history-detail-backdrop" onClick={onClose}>
+      <div ref={dialogRef} className={`history-detail-dialog${proofUrl ? '' : ' no-proof'}${canReview ? ' has-actions' : ''}`} role="dialog" aria-modal="true" aria-labelledby="history-detail-title" tabIndex={-1} onClick={(clickEvent) => clickEvent.stopPropagation()}>
+        <header>
+          <div className="history-detail-heading"><small>{t('historyDetailTitle')}</small><h2 id="history-detail-title">{formatDateTime(event.requestedAt)}</h2><StatusPill status={event.status} t={t} /></div>
+          <button type="button" data-autofocus aria-label={t('close')} onClick={onClose}><AppIcon name="close" /></button>
+        </header>
+        {proofUrl ? <div className="history-detail-proof"><img src={proofUrl} alt={t('responsibleReviewImageAlt')} /></div> : null}
+        {canReview ? (
+          <div className="history-detail-review-actions">
+            {reviewError ? <p className="request-feedback error" role="alert">{t('responsibleReviewError')}</p> : null}
+            <div>
+              <button type="button" className="parent-review-button reject" aria-label={t('responsibleReviewReject')} disabled={reviewing} onClick={() => { void decide('not_detected'); }}><AppIcon name="close" /></button>
+              <button type="button" className="parent-review-button approve" aria-label={t('responsibleReviewApprove')} disabled={reviewing} onClick={() => { void decide('detected'); }}><AppIcon name="check" /></button>
+            </div>
+          </div>
+        ) : null}
+        <dl>
+          <div><dt>{t('historyRequestedAt')}</dt><dd>{formatDateTime(event.requestedAt)}</dd></div>
+          {event.capturedAt ? <div><dt>{t('historyCapturedAt')}</dt><dd>{formatDateTime(event.capturedAt)}</dd></div> : null}
+          <div><dt>{t('historyExpiresAt')}</dt><dd>{formatDateTime(event.expiresAt)}</dd></div>
+          {analysisSourceLabel ? <div><dt>{t('analysisSource')}</dt><dd>{analysisSourceLabel}</dd></div> : null}
+          {scoreLabel(event.confidence) ? <div><dt>{t('analysisConfidence')}</dt><dd>{scoreLabel(event.confidence)}</dd></div> : null}
+          {scoreLabel(event.imageQuality) ? <div><dt>{t('analysisQuality')}</dt><dd>{scoreLabel(event.imageQuality)}</dd></div> : null}
+          {event.reason ? <div className="wide"><dt>{t('analysisReason')}</dt><dd>{event.reason}</dd></div> : null}
+          {reviewStatusLabel ? <div><dt>{t('historyReviewDecision')}</dt><dd>{reviewStatusLabel}</dd></div> : null}
+          {event.reviewedAt ? <div><dt>{t('historyReviewedAt')}</dt><dd>{formatDateTime(event.reviewedAt)}</dd></div> : null}
+          {event.reviewReason ? <div className="wide"><dt>{t('historyReviewComment')}</dt><dd>{event.reviewReason}</dd></div> : null}
+        </dl>
+      </div>
+    </div>
+  );
+}

--- a/src/screens/ParentDashboard.test.tsx
+++ b/src/screens/ParentDashboard.test.tsx
@@ -73,6 +73,27 @@ describe('ParentDashboard', () => {
     expect(container.querySelector('.printable-report')).toBeNull();
   });
 
+  it('opens history details over the dashboard without navigating to routines', () => {
+    const requestedAt = new Date().toISOString();
+    const assignment = createDefaultRoutineAssignment(requestedAt);
+    const state: AppState = {
+      role: 'parent',
+      locale: 'en',
+      notificationsEnabled: true,
+      family: { linked: true, childLinked: true, childName: 'Maya', linkingCode: '', parentRecoveryCode: '', consented: true },
+      routineAssignments: [assignment],
+      events: [{ id: 'dashboard-detail', routineId: assignment.routineId, sessionId: 'one', requestedAt, expiresAt: new Date(Date.now() + 60 * 60_000).toISOString(), status: 'detected', reason: 'Visible from dashboard' }],
+    };
+
+    act(() => root.render(<ParentDashboard state={state} regenerateCode={vi.fn()} t={(key) => translate('en', key)} />));
+    const openDetails = container.querySelector<HTMLButtonElement>('.history-row-open-button');
+    act(() => openDetails?.click());
+
+    expect(container.querySelector('.history-detail-dialog')?.textContent).toContain('Visible from dashboard');
+    expect(container.querySelector('.parent-overview-screen')).not.toBeNull();
+    expect(container.querySelector('.screen-header h1')?.textContent).toBe('Activity');
+  });
+
   it('shows upcoming checks when no responsible check is active', () => {
     const assignment = createDefaultRoutineAssignment();
     const state: AppState = {

--- a/src/screens/ParentDashboard.tsx
+++ b/src/screens/ParentDashboard.tsx
@@ -19,6 +19,7 @@ import { DashboardStatusSummary } from '../components/DashboardStatusSummary';
 import { NotificationCenter } from '../components/NotificationCenter';
 import { AwaitingCheckCards } from '../components/AwaitingCheckCards';
 import { useCurrentTime } from '../hooks/useCurrentTime';
+import { VerificationEventDetailDialog } from '../components/VerificationEventDetailDialog';
 
 export function ParentDashboard({
   state,
@@ -30,7 +31,6 @@ export function ParentDashboard({
   summaryRange: controlledSummaryRange,
   onSummaryRangeChange,
   onSelectParticipant,
-  onOpenHistoryEvent,
   onOpenNotificationEvent,
   notificationEventId,
   onNotificationEventConsumed,
@@ -45,7 +45,6 @@ export function ParentDashboard({
   summaryRange?: SummaryRange;
   onSummaryRangeChange?: (range: SummaryRange) => void;
   onSelectParticipant?: (participantId: string) => void;
-  onOpenHistoryEvent?: (event: VerificationEvent) => void;
   onOpenNotificationEvent?: (participantId: string, event: VerificationEvent) => void;
   notificationEventId?: string;
   onNotificationEventConsumed?: () => void;
@@ -62,12 +61,14 @@ export function ParentDashboard({
   const [requestingActiveReminder, setRequestingActiveReminder] = useState(false);
   const [activeReminderStatus, setActiveReminderStatus] = useState<'sent' | 'error'>();
   const [enlargedProofUrl, setEnlargedProofUrl] = useState<string>();
+  const [detailEventId, setDetailEventId] = useState<string>();
   const swipeStartRef = useRef<{ eventId: string; x: number; y: number } | undefined>(undefined);
   const handledNotificationEventIdRef = useRef<string | undefined>(undefined);
   const summaryRange = controlledSummaryRange ?? localSummaryRange;
   const setSummaryRange = onSummaryRangeChange ?? setLocalSummaryRange;
   const now = useCurrentTime();
   const displayEvents = useMemo(() => withResolvedEventStatuses(state.events, now), [now, state.events]);
+  const detailEvent = displayEvents.find((event) => event.id === detailEventId);
   const rangedEvents = filterEventsBySummaryRange(displayEvents, summaryRange, now);
   const rangedRawEvents = filterEventsBySummaryRange(state.events, summaryRange, now);
   const reviewEvents = useMemo(() => state.events
@@ -246,7 +247,7 @@ export function ParentDashboard({
             contextId="account"
             onOpenEvent={(participantId, event) => {
               if (onOpenNotificationEvent) onOpenNotificationEvent(participantId, event);
-              else onOpenHistoryEvent?.(event);
+              else setDetailEventId(event.id);
             }}
             t={t}
           />
@@ -486,8 +487,9 @@ export function ParentDashboard({
       <section className="today-section participant-history-section parent-history-section dashboard-summary-section" aria-labelledby="responsible-summary-title">
         <h2 id="responsible-summary-title">{t('overview')}</h2>
         <AdherenceSummaryCard events={displayEvents} assignments={state.routineAssignments} locale={state.locale} subjectName={reportSubjectName} range={summaryRange} onRangeChange={setSummaryRange} t={t} />
-        <RoutineHistoryPanel assignments={state.routineAssignments} events={rangedRawEvents} locale={state.locale} titleId="responsible-history-title" onRequestCheck={requestCheck} onOpenEvent={onOpenHistoryEvent} t={t} />
+        <RoutineHistoryPanel assignments={state.routineAssignments} events={rangedRawEvents} locale={state.locale} titleId="responsible-history-title" onRequestCheck={requestCheck} onOpenEvent={(event) => setDetailEventId(event.id)} t={t} />
       </section>
+      {detailEvent ? <VerificationEventDetailDialog event={detailEvent} locale={state.locale} proofUrl={proofUrls[detailEvent.id]} getProofImageUrl={getProofImageUrl} reviewCheck={reviewCheck} onClose={() => setDetailEventId(undefined)} t={t} /> : null}
     </div>
   );
 }

--- a/src/screens/RoutineDetailScreen.tsx
+++ b/src/screens/RoutineDetailScreen.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef, useState } from 'react';
 import { cameraOutline, chevronBackOutline, chevronForwardOutline, ellipsisHorizontal, peopleOutline, sendOutline, timeOutline } from 'ionicons/icons';
-import { adherenceSummary, isReviewableVerification, withResolvedEventStatuses } from '../domain/adherence';
+import { adherenceSummary, withResolvedEventStatuses } from '../domain/adherence';
 import { presentRoutine } from '../domain/routinePresentation';
 import type { AppState, RoutineAssignment, RoutineValidationMode, VerificationEvent } from '../domain/models';
 import type { MessageKey } from '../services/i18n';
@@ -11,8 +11,8 @@ import { RoutineEditScreen } from './RoutineEditScreen';
 import { SvgIcon } from '../components/SvgIcon';
 import { ActionButton } from '../components/ui';
 import { languageTag } from '../services/locale';
-import { useModalFocus } from '../hooks/useModalFocus';
 import { ProofLightbox } from '../components/ProofLightbox';
+import { VerificationEventDetailDialog } from '../components/VerificationEventDetailDialog';
 
 type DetailTab = 'details' | 'tracking' | 'plan';
 type DetailInitialTab = DetailTab | 'overview';
@@ -172,9 +172,6 @@ export function RoutineDetailScreen({ assignment, state, back, start, getProofIm
   const [proofErrors, setProofErrors] = useState<Record<string, boolean>>({});
   const [enlargedProofUrl, setEnlargedProofUrl] = useState<string>();
   const [selectedHistoryEventId, setSelectedHistoryEventId] = useState<string | undefined>(initialEventId);
-  const [reviewingEventId, setReviewingEventId] = useState<string>();
-  const [reviewErrorEventId, setReviewErrorEventId] = useState<string>();
-  const historyDialogRef = useModalFocus<HTMLDivElement>(Boolean(selectedHistoryEventId), () => setSelectedHistoryEventId(undefined));
   const todayHeatmapRef = useRef<HTMLSpanElement | null>(null);
   const now = Date.now();
   const rawEvents = state.events.filter((event) => event.routineId === assignment.routineId);
@@ -190,26 +187,10 @@ export function RoutineDetailScreen({ assignment, state, back, start, getProofIm
   const currentStreak = streakFor(events);
   const selectedHistoryEvent = events.find((event) => event.id === selectedHistoryEventId);
   const tabs: DetailTab[] = edit ? ['plan', 'details', 'tracking'] : ['details', 'tracking'];
-  const analysisSourceLabel = (source?: VerificationEvent['analysisSource']) => source ? t(source === 'ai' ? 'analysisSourceAi' : source === 'fallback' ? 'analysisSourceFallback' : 'analysisSourceSelf') : undefined;
-  const reviewStatusLabel = (status?: VerificationEvent['reviewStatus']) => status ? t(status === 'approved' ? 'historyReviewApproved' : status === 'rejected' ? 'historyReviewRejected' : 'historyReviewPending') : undefined;
-  const decide = async (eventId: string, decision: 'detected' | 'not_detected') => {
-    if (!reviewCheck) return;
-    setReviewingEventId(eventId);
-    setReviewErrorEventId(undefined);
-    try {
-      await reviewCheck(eventId, decision);
-    } catch (error) {
-      console.error(error);
-      setReviewErrorEventId(eventId);
-    } finally {
-      setReviewingEventId(undefined);
-    }
-  };
 
   useEffect(() => {
     if (initialEventId) onInitialEventConsumed?.();
   }, [initialEventId, onInitialEventConsumed]);
-  const scoreLabel = (score?: number) => score === undefined ? undefined : `${Math.round(score * 100)}%`;
 
   useEffect(() => {
     if (!tabs.includes(tab)) {
@@ -337,40 +318,7 @@ export function RoutineDetailScreen({ assignment, state, back, start, getProofIm
       {tab === 'tracking' && trackingPanel}
 
       {selectedHistoryEvent ? (
-        <div className="history-detail-backdrop" onClick={() => setSelectedHistoryEventId(undefined)}>
-          <div ref={historyDialogRef} className={`history-detail-dialog${proofUrls[selectedHistoryEvent.id] ? '' : ' no-proof'}${reviewCheck && isReviewableVerification(selectedHistoryEvent) ? ' has-actions' : ''}`} role="dialog" aria-modal="true" aria-labelledby="history-detail-title" tabIndex={-1} onClick={(event) => event.stopPropagation()}>
-            <header>
-              <div className="history-detail-heading"><small>{t('historyDetailTitle')}</small><h2 id="history-detail-title">{formatDateTime(selectedHistoryEvent.requestedAt)}</h2><StatusPill status={selectedHistoryEvent.status} t={t} /></div>
-              <button type="button" data-autofocus aria-label={t('close')} onClick={() => setSelectedHistoryEventId(undefined)}><AppIcon name="close" /></button>
-            </header>
-            {proofUrls[selectedHistoryEvent.id] ? (
-              <div className="history-detail-proof">
-                <img src={proofUrls[selectedHistoryEvent.id]} alt={t('responsibleReviewImageAlt')} />
-              </div>
-            ) : null}
-            {reviewCheck && isReviewableVerification(selectedHistoryEvent) ? (
-              <div className="history-detail-review-actions">
-                {reviewErrorEventId === selectedHistoryEvent.id ? <p className="request-feedback error" role="alert">{t('responsibleReviewError')}</p> : null}
-                <div>
-                  <button type="button" className="parent-review-button reject" aria-label={t('responsibleReviewReject')} disabled={reviewingEventId === selectedHistoryEvent.id} onClick={() => { void decide(selectedHistoryEvent.id, 'not_detected'); }}><AppIcon name="close" /></button>
-                  <button type="button" className="parent-review-button approve" aria-label={t('responsibleReviewApprove')} disabled={reviewingEventId === selectedHistoryEvent.id} onClick={() => { void decide(selectedHistoryEvent.id, 'detected'); }}><AppIcon name="check" /></button>
-                </div>
-              </div>
-            ) : null}
-            <dl>
-              <div><dt>{t('historyRequestedAt')}</dt><dd>{formatDateTime(selectedHistoryEvent.requestedAt)}</dd></div>
-              {selectedHistoryEvent.capturedAt ? <div><dt>{t('historyCapturedAt')}</dt><dd>{formatDateTime(selectedHistoryEvent.capturedAt)}</dd></div> : null}
-              <div><dt>{t('historyExpiresAt')}</dt><dd>{formatDateTime(selectedHistoryEvent.expiresAt)}</dd></div>
-              {analysisSourceLabel(selectedHistoryEvent.analysisSource) ? <div><dt>{t('analysisSource')}</dt><dd>{analysisSourceLabel(selectedHistoryEvent.analysisSource)}</dd></div> : null}
-              {scoreLabel(selectedHistoryEvent.confidence) ? <div><dt>{t('analysisConfidence')}</dt><dd>{scoreLabel(selectedHistoryEvent.confidence)}</dd></div> : null}
-              {scoreLabel(selectedHistoryEvent.imageQuality) ? <div><dt>{t('analysisQuality')}</dt><dd>{scoreLabel(selectedHistoryEvent.imageQuality)}</dd></div> : null}
-              {selectedHistoryEvent.reason ? <div className="wide"><dt>{t('analysisReason')}</dt><dd>{selectedHistoryEvent.reason}</dd></div> : null}
-              {reviewStatusLabel(selectedHistoryEvent.reviewStatus) ? <div><dt>{t('historyReviewDecision')}</dt><dd>{reviewStatusLabel(selectedHistoryEvent.reviewStatus)}</dd></div> : null}
-              {selectedHistoryEvent.reviewedAt ? <div><dt>{t('historyReviewedAt')}</dt><dd>{formatDateTime(selectedHistoryEvent.reviewedAt)}</dd></div> : null}
-              {selectedHistoryEvent.reviewReason ? <div className="wide"><dt>{t('historyReviewComment')}</dt><dd>{selectedHistoryEvent.reviewReason}</dd></div> : null}
-            </dl>
-          </div>
-        </div>
+        <VerificationEventDetailDialog event={selectedHistoryEvent} locale={state.locale} proofUrl={proofUrls[selectedHistoryEvent.id]} getProofImageUrl={getProofImageUrl} reviewCheck={reviewCheck} onClose={() => setSelectedHistoryEventId(undefined)} t={t} />
       ) : null}
 
       {enlargedProofUrl ? (


### PR DESCRIPTION
## Summary
- open responsible history event details as a modal over the Dashboard instead of switching to Routines
- extract one shared event detail dialog for Dashboard and routine tracking
- preserve proof loading and responsible validation actions in both entry points
- keep participant history navigation unchanged
- bump the application patch version to 0.9.23

## Validation
- ParentDashboard and RoutinesScreen test suites (33 tests)
- architecture and design checks
- production build and bundle-size check
- git diff check

Note: the aggregate `npm run check` Vitest phase stalled in the local runner after starting with no remaining Vitest process; GitHub CI will rerun the complete check in a clean environment.