### PR TITLE
Open notifications in event details

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zadiag-pwa",
   "private": true,
-  "version": "0.9.23",
+  "version": "0.9.24",
   "type": "module",
   "packageManager": "pnpm@11.7.0",
   "engines": {

--- a/src/screens/ParentDashboard.test.tsx
+++ b/src/screens/ParentDashboard.test.tsx
@@ -538,6 +538,9 @@ describe('ParentDashboard', () => {
 
     expect(container.querySelector('.dashboard-status-summary button[aria-pressed="true"]')?.textContent).toContain('To review');
     expect(notificationConsumed).toHaveBeenCalledOnce();
+    const detailDialog = container.querySelector('.history-detail-dialog');
+    expect(detailDialog).not.toBeNull();
+    expect(detailDialog?.textContent).toContain('The proof is unclear.');
     expect(container.textContent).toContain('Checks to verify');
     expect(Array.from(container.querySelectorAll('.dashboard-status-summary strong')).map((item) => item.textContent)).toEqual(['0', '1', '1']);
     const reviewSection = container.querySelector('.parent-review-section');
@@ -550,7 +553,7 @@ describe('ParentDashboard', () => {
     expect(container.textContent).toContain('Estimated quality 82%');
     expect(getProofImageUrl).toHaveBeenCalledWith('review');
     vi.useRealTimers();
-    const validate = Array.from(container.querySelectorAll('button')).find((button) => button.getAttribute('aria-label') === 'Validate');
+    const validate = detailDialog?.querySelector<HTMLButtonElement>('button[aria-label="Validate"]');
 
     await act(async () => {
       validate?.dispatchEvent(new MouseEvent('click', { bubbles: true }));

--- a/src/screens/ParentDashboard.tsx
+++ b/src/screens/ParentDashboard.tsx
@@ -229,10 +229,9 @@ export function ParentDashboard({
     handledNotificationEventIdRef.current = notificationEventId;
     const needsReview = isReviewableVerification(event);
     const active = event.status === 'pending' && Date.parse(event.expiresAt) > now;
-    const targetId = needsReview ? `review-${event.id}` : active ? `active-${event.id}` : 'responsible-history-title';
     if (needsReview) setExpandedStatus('review');
     else if (active) setExpandedStatus('active');
-    window.requestAnimationFrame(() => document.getElementById(targetId)?.scrollIntoView?.({ block: 'center' }));
+    setDetailEventId(event.id);
     onNotificationEventConsumed?.();
   }, [notificationEventId, now, onNotificationEventConsumed, state.events]);
   return (


### PR DESCRIPTION
## Summary
- open the selected notification event directly in the shared detail dialog
- keep the responsible Dashboard visible after automatic profile selection
- preserve review expansion and validate/reject actions for uncertain checks
- bump the application patch version to 0.9.24

## Validation
- ParentDashboard test suite (16 tests)
- architecture and design checks
- production build
- bundle-size check
- git diff check