### PR TITLE
Deep link system review notifications

### DIFF
--- a/functions/src/notifications.test.ts
+++ b/functions/src/notifications.test.ts
@@ -81,7 +81,7 @@ test('builds a French review notification payload for responsible users only', (
   assert.equal(payload.title, '🦷 Élastiques orthodontiques · à vérifier');
   assert.equal(payload.body, 'Une preuve attend votre validation.');
   assert.equal(payload.tag, 'review:check-1');
-  assert.equal(payload.path, '/?open=review&participant=participant-alex');
+  assert.equal(payload.path, '/?open=review&participant=participant-alex&event=check-1');
 });
 
 test('builds a localized test notification payload', () => {

--- a/functions/src/notifications.ts
+++ b/functions/src/notifications.ts
@@ -153,7 +153,7 @@ export const buildReviewNotificationPayload = (input: ReviewNotificationInput): 
     tag: `review:${input.checkId}`,
     title: locale === 'fr' ? `${titlePrefix} · à vérifier` : `${titlePrefix} · review`,
     body: locale === 'fr' ? 'Une preuve attend votre validation.' : 'A proof needs your review.',
-    path: `/?open=review&participant=${encodeURIComponent(input.participantId)}`,
+    path: `/?open=review&participant=${encodeURIComponent(input.participantId)}&event=${encodeURIComponent(input.checkId)}`,
   };
 };
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zadiag-pwa",
   "private": true,
-  "version": "0.9.25",
+  "version": "0.9.26",
   "type": "module",
   "packageManager": "pnpm@11.7.0",
   "engines": {

--- a/src/App.test.ts
+++ b/src/App.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { DEFAULT_ROUTINE_ID, type AppState, type VerificationEvent } from './domain/models';
-import { appBadgeCountForState, documentLanguageForLocale, isParticipantInvitationCode, participantIdForNotificationLaunch, resetNoticeMessageKey, setupCompletionTransition, syncStatusFor, syncStatusIsVisible } from './App';
+import { appBadgeCountForState, documentLanguageForLocale, eventIdForNotificationLaunch, isParticipantInvitationCode, participantIdForNotificationLaunch, resetNoticeMessageKey, setupCompletionTransition, syncStatusFor, syncStatusIsVisible } from './App';
 
 const activePendingEvent = (expiresAt: string): VerificationEvent => ({
   id: 'check-1',
@@ -100,6 +100,24 @@ describe('participantIdForNotificationLaunch', () => {
       { ...state, role: 'child' },
       { kind: 'review', participantId: 'alex' },
     )).toBeUndefined();
+  });
+});
+
+describe('eventIdForNotificationLaunch', () => {
+  const state = {
+    role: 'parent',
+    activeParticipantId: 'alex',
+    events: [{ id: 'check-42' }],
+  } as AppState;
+
+  it('opens an existing event only after its target profile is active', () => {
+    expect(eventIdForNotificationLaunch(state, { kind: 'review', participantId: 'alex', eventId: 'check-42' })).toBe('check-42');
+    expect(eventIdForNotificationLaunch({ ...state, activeParticipantId: 'lea' }, { kind: 'review', participantId: 'alex', eventId: 'check-42' })).toBeUndefined();
+  });
+
+  it('falls back safely for legacy links and events no longer available', () => {
+    expect(eventIdForNotificationLaunch(state, { kind: 'review', participantId: 'alex' })).toBeUndefined();
+    expect(eventIdForNotificationLaunch(state, { kind: 'review', participantId: 'alex', eventId: 'deleted' })).toBeUndefined();
   });
 });
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,7 +10,7 @@ import { Snackbar } from './components/Snackbar';
 import { PullToUpdate } from './components/PullToUpdate';
 import { isSummaryRange, type SummaryRange } from './components/AdherenceSummaryCard';
 import { firebaseEnabled } from './services/firebaseConfig';
-import { browserRouteContext, captureRelationshipInvitationCode, clearRelationshipInvitationUrl, isLocalDemoEnvironment, notificationLaunchIntent, routineCentricUiEnabled } from './services/browserEnvironment';
+import { browserRouteContext, captureRelationshipInvitationCode, clearNotificationLaunchUrl, clearRelationshipInvitationUrl, isLocalDemoEnvironment, notificationLaunchIntent, routineCentricUiEnabled, type NotificationLaunchIntent } from './services/browserEnvironment';
 import { runWhenStartupIsIdle } from './services/appUpdate';
 import { InstallScreen } from './screens/InstallScreen';
 import { WelcomeScreen } from './screens/WelcomeScreen';
@@ -107,8 +107,19 @@ export const participantIdForNotificationLaunch = (
   ? intent.participantId
   : undefined;
 
+export const eventIdForNotificationLaunch = (
+  state: AppState,
+  intent: NotificationLaunchIntent | undefined,
+) => intent?.eventId
+  && state.role === 'parent'
+  && state.activeParticipantId === intent.participantId
+  && state.events.some((event) => event.id === intent.eventId)
+  ? intent.eventId
+  : undefined;
+
 export function App() {
   const repository = useMemo(createRepository, []);
+  const notificationLaunchIntentRef = useRef(notificationLaunchIntent());
   const [state, setState] = useState(repository.snapshot());
   const [route, setRoute] = useState<AppRoute>(() => routeForState(state, browserRouteContext()));
   const [ready, setReady] = useState(false);
@@ -191,6 +202,28 @@ export function App() {
   }, [ready, state.family.childLinked, state.family.linked, state.notificationsEnabled, state.role, state.routineAssignments.length, state.routinesLoaded]);
 
   useEffect(() => {
+    if (!ready) return;
+    const intent = notificationLaunchIntentRef.current;
+    if (!intent) return;
+    const participantId = participantIdForNotificationLaunch(state, intent);
+    if (!participantId) {
+      notificationLaunchIntentRef.current = undefined;
+      return;
+    }
+    if (state.activeParticipantId !== participantId) return;
+    if (!intent.eventId) {
+      notificationLaunchIntentRef.current = undefined;
+      return;
+    }
+    const eventId = eventIdForNotificationLaunch(state, intent);
+    if (!eventId) return;
+    setFocusedDashboardEventId(eventId);
+    setTab('home');
+    setRoute('app');
+    notificationLaunchIntentRef.current = undefined;
+  }, [ready, state]);
+
+  useEffect(() => {
     if (!ready || !firebaseEnabled || !state.family.id || !state.role) return;
     if (!('Notification' in window) || Notification.permission !== 'granted') return;
     let cancelled = false;
@@ -236,13 +269,15 @@ export function App() {
       if (!alive) return;
       window.clearInterval(startupProgressTicker);
       let restored = repository.snapshot();
-      const notificationParticipantId = participantIdForNotificationLaunch(restored);
+      const notificationIntent = notificationLaunchIntentRef.current;
+      const notificationParticipantId = participantIdForNotificationLaunch(restored, notificationIntent);
       if (notificationParticipantId && repository.selectActiveParticipant) {
         await repository.selectActiveParticipant(notificationParticipantId);
         if (!alive) return;
         restored = repository.snapshot();
         setTab('home');
       }
+      if (notificationIntent) clearNotificationLaunchUrl();
       setState(restored);
       setLastSyncAt(new Date().toISOString());
       setRoute(routeForState(restored, browserRouteContext()));

--- a/src/services/browserEnvironment.test.ts
+++ b/src/services/browserEnvironment.test.ts
@@ -1,17 +1,30 @@
 import { beforeEach, describe, expect, it } from 'vitest';
-import { captureRelationshipInvitationCode, notificationLaunchIntent, relationshipInvitationCode, relationshipInvitationUrl } from './browserEnvironment';
+import { captureRelationshipInvitationCode, clearNotificationLaunchUrl, notificationLaunchIntent, relationshipInvitationCode, relationshipInvitationUrl } from './browserEnvironment';
 
 describe('notification launch intent', () => {
   it('targets the participant carried by a review notification', () => {
-    expect(notificationLaunchIntent('?open=review&participant=participant-alex')).toEqual({
+    expect(notificationLaunchIntent('?open=review&participant=participant-alex&event=check-42')).toEqual({
       kind: 'review',
       participantId: 'participant-alex',
+      eventId: 'check-42',
     });
+  });
+
+  it('keeps compatibility with review links sent before event targeting', () => {
+    expect(notificationLaunchIntent('?open=review&participant=participant-alex')).toEqual({ kind: 'review', participantId: 'participant-alex' });
   });
 
   it('ignores incomplete and unrelated notification routes', () => {
     expect(notificationLaunchIntent('?open=review')).toBeUndefined();
     expect(notificationLaunchIntent('?open=verification&participant=participant-alex')).toBeUndefined();
+  });
+
+  it('consumes notification parameters without removing unrelated URL state', () => {
+    window.history.replaceState({}, '', '/?open=review&participant=alex&event=check-42&source=pwa#section');
+    clearNotificationLaunchUrl();
+    expect(window.location.href).toContain('?source=pwa#section');
+    expect(window.location.href).not.toContain('participant=');
+    window.history.replaceState({}, '', '/');
   });
 });
 

--- a/src/services/browserEnvironment.ts
+++ b/src/services/browserEnvironment.ts
@@ -9,13 +9,23 @@ export const routineCentricUiEnabled = import.meta.env.VITE_ROUTINE_CENTRIC_UI !
 export interface NotificationLaunchIntent {
   kind: 'review';
   participantId: string;
+  eventId?: string;
 }
 
 export const notificationLaunchIntent = (search = window.location.search): NotificationLaunchIntent | undefined => {
   const parameters = new URLSearchParams(search);
   const participantId = parameters.get('participant')?.trim();
   if (parameters.get('open') !== 'review' || !participantId) return undefined;
-  return { kind: 'review', participantId };
+  const eventId = parameters.get('event')?.trim();
+  return { kind: 'review', participantId, ...(eventId ? { eventId } : {}) };
+};
+
+export const clearNotificationLaunchUrl = () => {
+  const url = new URL(window.location.href);
+  url.searchParams.delete('open');
+  url.searchParams.delete('participant');
+  url.searchParams.delete('event');
+  window.history.replaceState(window.history.state, '', url);
 };
 
 export const relationshipInvitationCode = (hash = window.location.hash, storage = window.localStorage): string | undefined => {


### PR DESCRIPTION
## Summary
- include the participant and check identifiers in responsible review push links
- restore the target profile and event detail during cold app startup
- retain the launch intent until delayed event data is available
- consume notification URL parameters after startup
- keep legacy participant-only push links compatible and fall back safely for unavailable events
- bump the application patch version to 0.9.26

## Validation
- notification routing, App launch, service-worker helper tests (27 tests)
- complete functions test suite
- architecture and design checks
- production build
- bundle-size check
- git diff check