### PR TITLE
Deep link participant check notifications

### DIFF
--- a/functions/src/notifications.test.ts
+++ b/functions/src/notifications.test.ts
@@ -45,6 +45,7 @@ test('builds the current French check notification payload', () => {
   assert.equal(payload.title, '🦷 Élastiques orthodontiques · prêt');
   assert.equal(payload.body, 'Envoie ta preuve.');
   assert.equal(payload.tag, 'verification:session-1');
+  assert.equal(payload.path, '/?open=verification&session=session-1');
 });
 
 test('builds the current English reminder notification payload', () => {
@@ -62,6 +63,7 @@ test('builds the current English reminder notification payload', () => {
   assert.equal(payload.title, '🦷 Orthodontic Elastics · reminder');
   assert.equal(payload.body, 'Check waiting.');
   assert.equal(payload.tag, 'reminder:session-2');
+  assert.equal(payload.path, '/?open=verification&session=session-2');
 });
 
 test('builds a French review notification payload for responsible users only', () => {

--- a/functions/src/notifications.ts
+++ b/functions/src/notifications.ts
@@ -137,7 +137,7 @@ export const buildCheckNotificationPayload = (input: CheckNotificationInput): Ch
     body: input.resend
       ? (locale === 'fr' ? 'Contrôle attendu.' : 'Check waiting.')
       : (locale === 'fr' ? 'Envoie ta preuve.' : 'Send your proof.'),
-    path: '/?open=verification',
+    path: `/?open=verification&session=${encodeURIComponent(input.sessionId)}`,
   };
 };
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zadiag-pwa",
   "private": true,
-  "version": "0.9.26",
+  "version": "0.9.27",
   "type": "module",
   "packageManager": "pnpm@11.7.0",
   "engines": {

--- a/src/App.test.ts
+++ b/src/App.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { DEFAULT_ROUTINE_ID, type AppState, type VerificationEvent } from './domain/models';
-import { appBadgeCountForState, documentLanguageForLocale, eventIdForNotificationLaunch, isParticipantInvitationCode, participantIdForNotificationLaunch, resetNoticeMessageKey, setupCompletionTransition, syncStatusFor, syncStatusIsVisible } from './App';
+import { appBadgeCountForState, documentLanguageForLocale, eventIdForNotificationLaunch, isParticipantInvitationCode, participantEventIdForNotificationLaunch, participantIdForNotificationLaunch, resetNoticeMessageKey, setupCompletionTransition, syncStatusFor, syncStatusIsVisible } from './App';
 
 const activePendingEvent = (expiresAt: string): VerificationEvent => ({
   id: 'check-1',
@@ -118,6 +118,23 @@ describe('eventIdForNotificationLaunch', () => {
   it('falls back safely for legacy links and events no longer available', () => {
     expect(eventIdForNotificationLaunch(state, { kind: 'review', participantId: 'alex' })).toBeUndefined();
     expect(eventIdForNotificationLaunch(state, { kind: 'review', participantId: 'alex', eventId: 'deleted' })).toBeUndefined();
+  });
+});
+
+describe('participantEventIdForNotificationLaunch', () => {
+  const activeEvent = { id: 'check-42', sessionId: 'session-42', status: 'pending', expiresAt: '2026-07-16T12:30:00.000Z' };
+  const state = { role: 'child', events: [activeEvent] } as AppState;
+
+  it('targets the active check carried by the participant notification', () => {
+    expect(participantEventIdForNotificationLaunch(state, { kind: 'verification', sessionId: 'session-42' }, Date.parse('2026-07-16T12:00:00.000Z'))).toBe('check-42');
+  });
+
+  it('does not target expired, completed, missing, or responsible checks', () => {
+    const intent = { kind: 'verification' as const, sessionId: 'session-42' };
+    expect(participantEventIdForNotificationLaunch(state, intent, Date.parse('2026-07-16T12:31:00.000Z'))).toBeUndefined();
+    expect(participantEventIdForNotificationLaunch({ ...state, events: [{ ...activeEvent, status: 'detected' }] } as AppState, intent, Date.parse('2026-07-16T12:00:00.000Z'))).toBeUndefined();
+    expect(participantEventIdForNotificationLaunch(state, { kind: 'verification', sessionId: 'missing' }, Date.parse('2026-07-16T12:00:00.000Z'))).toBeUndefined();
+    expect(participantEventIdForNotificationLaunch({ ...state, role: 'parent' }, intent, Date.parse('2026-07-16T12:00:00.000Z'))).toBeUndefined();
   });
 });
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -100,6 +100,7 @@ export const participantIdForNotificationLaunch = (
   state: AppState,
   intent = notificationLaunchIntent(),
 ) => intent
+  && intent.kind === 'review'
   && state.role === 'parent'
   && state.participantAccess?.some((entry) => (
     entry.participant.id === intent.participantId && entry.membership.status === 'active'
@@ -110,12 +111,23 @@ export const participantIdForNotificationLaunch = (
 export const eventIdForNotificationLaunch = (
   state: AppState,
   intent: NotificationLaunchIntent | undefined,
-) => intent?.eventId
+) => intent?.kind === 'review'
+  && intent.eventId
   && state.role === 'parent'
   && state.activeParticipantId === intent.participantId
   && state.events.some((event) => event.id === intent.eventId)
   ? intent.eventId
   : undefined;
+
+export const participantEventIdForNotificationLaunch = (
+  state: AppState,
+  intent: NotificationLaunchIntent | undefined,
+  now = Date.now(),
+) => {
+  if (intent?.kind !== 'verification' || state.role !== 'child') return undefined;
+  const event = state.events.find((candidate) => candidate.sessionId === intent.sessionId);
+  return event?.status === 'pending' && Date.parse(event.expiresAt) > now ? event.id : undefined;
+};
 
 export function App() {
   const repository = useMemo(createRepository, []);
@@ -205,6 +217,22 @@ export function App() {
     if (!ready) return;
     const intent = notificationLaunchIntentRef.current;
     if (!intent) return;
+    if (intent.kind === 'verification') {
+      if (state.role !== 'child') {
+        notificationLaunchIntentRef.current = undefined;
+        return;
+      }
+      const eventId = participantEventIdForNotificationLaunch(state, intent);
+      if (!eventId) {
+        if (state.events.some((event) => event.sessionId === intent.sessionId)) notificationLaunchIntentRef.current = undefined;
+        return;
+      }
+      setFocusedDashboardEventId(eventId);
+      setTab('home');
+      setRoute('app');
+      notificationLaunchIntentRef.current = undefined;
+      return;
+    }
     const participantId = participantIdForNotificationLaunch(state, intent);
     if (!participantId) {
       notificationLaunchIntentRef.current = undefined;

--- a/src/services/browserEnvironment.test.ts
+++ b/src/services/browserEnvironment.test.ts
@@ -14,6 +14,10 @@ describe('notification launch intent', () => {
     expect(notificationLaunchIntent('?open=review&participant=participant-alex')).toEqual({ kind: 'review', participantId: 'participant-alex' });
   });
 
+  it('targets the exact participant check session', () => {
+    expect(notificationLaunchIntent('?open=verification&session=session-42')).toEqual({ kind: 'verification', sessionId: 'session-42' });
+  });
+
   it('ignores incomplete and unrelated notification routes', () => {
     expect(notificationLaunchIntent('?open=review')).toBeUndefined();
     expect(notificationLaunchIntent('?open=verification&participant=participant-alex')).toBeUndefined();

--- a/src/services/browserEnvironment.ts
+++ b/src/services/browserEnvironment.ts
@@ -6,14 +6,21 @@ const RELATIONSHIP_INVITATION_STORAGE_KEY = 'zadiag.relationshipInvitationCode';
 const useFirebase = import.meta.env.VITE_USE_FIREBASE === 'true';
 export const routineCentricUiEnabled = import.meta.env.VITE_ROUTINE_CENTRIC_UI !== 'false';
 
-export interface NotificationLaunchIntent {
+export type NotificationLaunchIntent = {
   kind: 'review';
   participantId: string;
   eventId?: string;
-}
+} | {
+  kind: 'verification';
+  sessionId: string;
+};
 
 export const notificationLaunchIntent = (search = window.location.search): NotificationLaunchIntent | undefined => {
   const parameters = new URLSearchParams(search);
+  if (parameters.get('open') === 'verification') {
+    const sessionId = parameters.get('session')?.trim();
+    return sessionId ? { kind: 'verification', sessionId } : undefined;
+  }
   const participantId = parameters.get('participant')?.trim();
   if (parameters.get('open') !== 'review' || !participantId) return undefined;
   const eventId = parameters.get('event')?.trim();
@@ -25,6 +32,7 @@ export const clearNotificationLaunchUrl = () => {
   url.searchParams.delete('open');
   url.searchParams.delete('participant');
   url.searchParams.delete('event');
+  url.searchParams.delete('session');
   window.history.replaceState(window.history.state, '', url);
 };
 


### PR DESCRIPTION
## Summary
- include the exact session identifier in participant check and reminder push links
- restore active participant checks on the Dashboard after cold startup or delayed sync
- expose the existing proof action without automatically starting the camera
- ignore expired, completed, missing, or wrong-role sessions safely
- bump the application patch version to 0.9.27

## Validation
- App launch, participant Dashboard, notification routing, and service-worker tests (36 tests)
- complete functions test suite
- architecture and design checks
- production build
- bundle-size check
- git diff check