### PR TITLE
Reuse the open app for notification clicks

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zadiag-pwa",
   "private": true,
-  "version": "0.9.27",
+  "version": "0.9.28",
   "type": "module",
   "packageManager": "pnpm@11.7.0",
   "engines": {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,7 +10,7 @@ import { Snackbar } from './components/Snackbar';
 import { PullToUpdate } from './components/PullToUpdate';
 import { isSummaryRange, type SummaryRange } from './components/AdherenceSummaryCard';
 import { firebaseEnabled } from './services/firebaseConfig';
-import { browserRouteContext, captureRelationshipInvitationCode, clearNotificationLaunchUrl, clearRelationshipInvitationUrl, isLocalDemoEnvironment, notificationLaunchIntent, routineCentricUiEnabled, type NotificationLaunchIntent } from './services/browserEnvironment';
+import { browserRouteContext, captureRelationshipInvitationCode, clearNotificationLaunchUrl, clearRelationshipInvitationUrl, isLocalDemoEnvironment, notificationLaunchIntent, notificationLaunchIntentFromMessage, routineCentricUiEnabled, type NotificationLaunchIntent } from './services/browserEnvironment';
 import { runWhenStartupIsIdle } from './services/appUpdate';
 import { InstallScreen } from './screens/InstallScreen';
 import { WelcomeScreen } from './screens/WelcomeScreen';
@@ -132,6 +132,7 @@ export const participantEventIdForNotificationLaunch = (
 export function App() {
   const repository = useMemo(createRepository, []);
   const notificationLaunchIntentRef = useRef(notificationLaunchIntent());
+  const selectingNotificationParticipantRef = useRef<string | undefined>(undefined);
   const [state, setState] = useState(repository.snapshot());
   const [route, setRoute] = useState<AppRoute>(() => routeForState(state, browserRouteContext()));
   const [ready, setReady] = useState(false);
@@ -149,6 +150,7 @@ export function App() {
   const [selectedSessionId, setSelectedSessionId] = useState<string>();
   const [focusedHistoryEventId, setFocusedHistoryEventId] = useState<string>();
   const [focusedDashboardEventId, setFocusedDashboardEventId] = useState<string>();
+  const [notificationIntentSequence, setNotificationIntentSequence] = useState(0);
   const [lastSyncAt, setLastSyncAt] = useState<string>();
   const [online, setOnline] = useState(() => navigator.onLine);
   const [pendingSyncOperations, setPendingSyncOperations] = useState(0);
@@ -214,6 +216,18 @@ export function App() {
   }, [ready, state.family.childLinked, state.family.linked, state.notificationsEnabled, state.role, state.routineAssignments.length, state.routinesLoaded]);
 
   useEffect(() => {
+    if (!('serviceWorker' in navigator)) return undefined;
+    const receiveNotification = (message: MessageEvent<unknown>) => {
+      const intent = notificationLaunchIntentFromMessage(message.data);
+      if (!intent) return;
+      notificationLaunchIntentRef.current = intent;
+      setNotificationIntentSequence((current) => current + 1);
+    };
+    navigator.serviceWorker.addEventListener('message', receiveNotification);
+    return () => navigator.serviceWorker.removeEventListener('message', receiveNotification);
+  }, []);
+
+  useEffect(() => {
     if (!ready) return;
     const intent = notificationLaunchIntentRef.current;
     if (!intent) return;
@@ -238,7 +252,19 @@ export function App() {
       notificationLaunchIntentRef.current = undefined;
       return;
     }
-    if (state.activeParticipantId !== participantId) return;
+    if (state.activeParticipantId !== participantId) {
+      if (repository.selectActiveParticipant && selectingNotificationParticipantRef.current !== participantId) {
+        selectingNotificationParticipantRef.current = participantId;
+        void repository.selectActiveParticipant(participantId)
+          .then(() => setState(repository.snapshot()))
+          .catch((error) => {
+            console.error(error);
+            notificationLaunchIntentRef.current = undefined;
+          })
+          .finally(() => { selectingNotificationParticipantRef.current = undefined; });
+      }
+      return;
+    }
     if (!intent.eventId) {
       notificationLaunchIntentRef.current = undefined;
       return;
@@ -249,7 +275,7 @@ export function App() {
     setTab('home');
     setRoute('app');
     notificationLaunchIntentRef.current = undefined;
-  }, [ready, state]);
+  }, [notificationIntentSequence, ready, repository, state]);
 
   useEffect(() => {
     if (!ready || !firebaseEnabled || !state.family.id || !state.role) return;

--- a/src/services/browserEnvironment.test.ts
+++ b/src/services/browserEnvironment.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it } from 'vitest';
-import { captureRelationshipInvitationCode, clearNotificationLaunchUrl, notificationLaunchIntent, relationshipInvitationCode, relationshipInvitationUrl } from './browserEnvironment';
+import { captureRelationshipInvitationCode, clearNotificationLaunchUrl, notificationLaunchIntent, notificationLaunchIntentFromMessage, relationshipInvitationCode, relationshipInvitationUrl } from './browserEnvironment';
 
 describe('notification launch intent', () => {
   it('targets the participant carried by a review notification', () => {
@@ -21,6 +21,12 @@ describe('notification launch intent', () => {
   it('ignores incomplete and unrelated notification routes', () => {
     expect(notificationLaunchIntent('?open=review')).toBeUndefined();
     expect(notificationLaunchIntent('?open=verification&participant=participant-alex')).toBeUndefined();
+  });
+
+  it('accepts only same-origin notification messages from the service worker', () => {
+    expect(notificationLaunchIntentFromMessage({ type: 'OPEN_NOTIFICATION', path: '/?open=verification&session=session-42' }, 'https://app.zadiag.test')).toEqual({ kind: 'verification', sessionId: 'session-42' });
+    expect(notificationLaunchIntentFromMessage({ type: 'OPEN_NOTIFICATION', path: 'https://evil.test/?open=verification&session=session-42' }, 'https://app.zadiag.test')).toBeUndefined();
+    expect(notificationLaunchIntentFromMessage({ type: 'OTHER', path: '/?open=verification&session=session-42' }, 'https://app.zadiag.test')).toBeUndefined();
   });
 
   it('consumes notification parameters without removing unrelated URL state', () => {

--- a/src/services/browserEnvironment.ts
+++ b/src/services/browserEnvironment.ts
@@ -27,6 +27,20 @@ export const notificationLaunchIntent = (search = window.location.search): Notif
   return { kind: 'review', participantId, ...(eventId ? { eventId } : {}) };
 };
 
+export const notificationLaunchIntentFromMessage = (
+  data: unknown,
+  origin = window.location.origin,
+): NotificationLaunchIntent | undefined => {
+  const message = data as { type?: unknown; path?: unknown } | undefined;
+  if (message?.type !== 'OPEN_NOTIFICATION' || typeof message.path !== 'string') return undefined;
+  try {
+    const url = new URL(message.path, origin);
+    return url.origin === origin ? notificationLaunchIntent(url.search) : undefined;
+  } catch {
+    return undefined;
+  }
+};
+
 export const clearNotificationLaunchUrl = () => {
   const url = new URL(window.location.href);
   url.searchParams.delete('open');

--- a/src/services/serviceWorkerNotifications.ts
+++ b/src/services/serviceWorkerNotifications.ts
@@ -37,6 +37,26 @@ export const notificationOptionsForPayload = (payload?: PushPayload): Notificati
 export const notificationClickPath = (notification: Pick<Notification, 'data'>) =>
   String((notification.data as { path?: string } | undefined)?.path ?? '/');
 
+type NotificationWindowClient = Pick<WindowClient, 'focus' | 'postMessage' | 'visibilityState' | 'focused'>;
+type NotificationClients = {
+  matchAll: (options: ClientQueryOptions) => Promise<readonly (Client | NotificationWindowClient)[]>;
+  openWindow: (url: string) => Promise<WindowClient | null>;
+};
+
+export const openNotificationClient = async (
+  notification: Pick<Notification, 'data'>,
+  clients: NotificationClients,
+) => {
+  const path = notificationClickPath(notification);
+  const matchedClients = await clients.matchAll({ type: 'window', includeUncontrolled: true });
+  const windows = matchedClients.filter((client): client is NotificationWindowClient => 'focus' in client);
+  const existing = windows.sort((left, right) => Number(right.focused) - Number(left.focused)
+    || Number(right.visibilityState === 'visible') - Number(left.visibilityState === 'visible'))[0];
+  if (!existing) return clients.openWindow(path);
+  existing.postMessage({ type: 'OPEN_NOTIFICATION', path });
+  return existing.focus();
+};
+
 export const reportSyntheticPushReceipt = async (
   payload: PushPayload | undefined,
   stage: 'received' | 'opened',

--- a/src/sw.test.ts
+++ b/src/sw.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from 'vitest';
-import { clearBadgeAndCheckNotifications, notificationClickPath, notificationOptionsForPayload } from './services/serviceWorkerNotifications';
+import { clearBadgeAndCheckNotifications, notificationClickPath, notificationOptionsForPayload, openNotificationClient } from './services/serviceWorkerNotifications';
 
 describe('service worker notification helpers', () => {
   it('builds notification options from the push payload', () => {
@@ -31,6 +31,28 @@ describe('service worker notification helpers', () => {
   it('falls back to the verification route when click data is missing', () => {
     expect(notificationClickPath({ data: { path: '/settings' } })).toBe('/settings');
     expect(notificationClickPath({ data: undefined })).toBe('/');
+  });
+
+  it('focuses an existing app window and forwards the notification without reloading', async () => {
+    const focus = vi.fn().mockResolvedValue(undefined);
+    const postMessage = vi.fn();
+    const openWindow = vi.fn();
+    await openNotificationClient({ data: { path: '/?open=review&participant=alex&event=check-1' } }, {
+      matchAll: vi.fn().mockResolvedValue([{ focused: false, visibilityState: 'visible', focus, postMessage }]),
+      openWindow,
+    });
+    expect(postMessage).toHaveBeenCalledWith({ type: 'OPEN_NOTIFICATION', path: '/?open=review&participant=alex&event=check-1' });
+    expect(focus).toHaveBeenCalledOnce();
+    expect(openWindow).not.toHaveBeenCalled();
+  });
+
+  it('opens a new app window only when no instance exists', async () => {
+    const openWindow = vi.fn().mockResolvedValue(null);
+    await openNotificationClient({ data: { path: '/?open=verification&session=session-1' } }, {
+      matchAll: vi.fn().mockResolvedValue([]),
+      openWindow,
+    });
+    expect(openWindow).toHaveBeenCalledWith('/?open=verification&session=session-1');
   });
 
   it('clears app badge and closes check notification tags', async () => {

--- a/src/sw.ts
+++ b/src/sw.ts
@@ -2,8 +2,8 @@
 import { cleanupOutdatedCaches, precacheAndRoute } from 'workbox-precaching';
 import {
   clearBadgeAndCheckNotifications,
-  notificationClickPath,
   notificationOptionsForPayload,
+  openNotificationClient,
   reportSyntheticPushReceipt,
   type PushPayload,
 } from './services/serviceWorkerNotifications';
@@ -43,6 +43,6 @@ self.addEventListener('notificationclick', (event: NotificationEvent) => {
   const payload = event.notification.data as PushPayload | undefined;
   event.waitUntil(Promise.allSettled([
     reportSyntheticPushReceipt(payload, 'opened'),
-    self.clients.openWindow(notificationClickPath(event.notification)),
+    openNotificationClient(event.notification, self.clients),
   ]));
 });


### PR DESCRIPTION
## Summary
- focus an existing Zadiag window instead of opening a duplicate on notification clicks
- forward the notification intent to the running app without navigation or reload
- switch responsible profiles at runtime before opening the target event
- retain cold-start `openWindow` behavior when no app instance exists
- reject malformed and cross-origin notification messages
- bump the application patch version to 0.9.28

## Validation
- service-worker click, runtime message, and App routing tests (29 tests)
- architecture and design checks
- production build
- bundle-size check
- git diff check