### PR TITLE
Finalize the pilot cohort operating kit

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ device and does not diagnose, prescribe, or replace professional care.
 
 [**Try the live experience**](https://www.zadiag.com) ·
 [Product brief](docs/product-brief.md) ·
+[Pilot cohort](docs/pilot-cohort-runbook.md) ·
 [Security](SECURITY.md)
 
 ## Quick start

--- a/docs/pilot-cohort-runbook.md
+++ b/docs/pilot-cohort-runbook.md
@@ -1,0 +1,124 @@
+# Pilot cohort runbook
+
+This runbook turns the second near-term milestone into a repeatable four-week
+pilot. It is an operational template, not evidence that a cohort has already
+been run and not a clinical study protocol.
+
+## Purpose and scope
+
+The pilot tests whether a small number of families can set up Zadiag, receive a
+reminder, submit a routine check, and complete responsible review with less
+coordination effort. It does not test diagnosis, treatment effectiveness, or
+clinical outcomes.
+
+A practical first cohort is 5–10 family groups using their own supported routine
+for four weeks. This range is intended to reveal usability and reliability
+problems; it is not statistically powered and must not be presented as proof of
+effectiveness.
+
+## Entry criteria
+
+Each family group must have:
+
+- one responsible adult able to manage access and respond to support;
+- one participant who understands the routine and can use the supported device;
+- an iPhone or compatible browser that can install the PWA and receive
+  notifications;
+- an existing routine chosen independently of Zadiag;
+- explicit acceptance or refusal of the current optional pilot measurement;
+- acknowledgement that Zadiag is a coordination aid, not medical advice.
+
+Do not enroll a situation where missing a Zadiag reminder could create immediate
+danger, where the participant cannot freely stop, or where the expected proof
+would expose another person or unrelated sensitive information.
+
+## Minimal cohort register
+
+Keep the operating register outside application data and restrict it to the
+pilot owner. Use a random cohort code, never a family ID, email address,
+invitation code, or recovery code in analysis notes.
+
+| Field | Allowed value |
+| --- | --- |
+| Cohort code | Random label such as `P01` |
+| Start and planned end | Calendar dates |
+| Platform | iPhone/PWA or other supported platform |
+| Roles active | Responsible, participant, or both |
+| Measurement choice | Accepted, declined, withdrawn; no reason required |
+| Setup observation | Independent, prompted, or blocked |
+| Support incidents | Count and highest severity only |
+| Exit state | Completed, withdrew, or stopped by pilot owner |
+
+Contact details needed for support must remain in the chosen private contact
+channel and must not be copied into the cohort register.
+
+## Launch checklist
+
+Before inviting the first family:
+
+- confirm production is on the intended version and CI is green;
+- confirm the support mailbox is monitored and the incident owner is named;
+- perform synthetic smoke checks for linking, notification registration,
+  reminder opening, proof submission, review, withdrawal, and account deletion;
+- verify the current pilot consent version and the 35-day journey retention;
+- prepare the baseline and closing questions in `pilot-survey-template.md`;
+- define the cohort start, end, weekly review time, and stop authority;
+- record baseline targets only after the initial instrumented observations,
+  alongside cohort size and timeframe.
+
+## Participant session
+
+1. Explain the product boundary and show how to contact support or stop.
+2. Let the family install and link accounts without coaching where possible.
+3. Record only whether setup was independent, prompted, or blocked; do not copy
+   screen content, names, codes, or proof.
+4. Let each account make its own optional measurement choice in the app.
+5. Confirm notification permission using the built-in test.
+6. Complete one synthetic or ordinary routine loop and responsible review.
+7. Remind participants that they can withdraw from measurement or leave the
+   pilot without deleting the account, and can separately request deletion.
+
+## Four-week cadence
+
+| Moment | Activity |
+| --- | --- |
+| Before use | Baseline coordination questions and unassisted setup observation |
+| Week 1 | Check setup failures, notification reliability, and SEV-1/SEV-2 reports |
+| Week 2 | Review aggregate funnel gaps and repeated support causes |
+| Week 3 | Confirm continued voluntary participation; avoid coaching toward metrics |
+| Week 4 | Closing questions, aggregate measures, withdrawals, and unresolved incidents |
+| Within 5 working days after | Cohort review and a written continue/change/stop decision |
+
+## Measures and interpretation
+
+Use the definitions in `pilot-measurement.md`. Report cohort size, measurement
+opt-in count, platform mix, timeframe, and missing-data reasons beside every
+result. Keep declined and withdrawn accounts usable but exclude periods without
+active measurement consent from journey reporting.
+
+Qualitative notes should describe recurring friction, not individual behavior.
+Do not rank families, infer adherence motivation, or combine support messages
+with journey data to create individual profiles.
+
+## Stop and escalation rules
+
+Pause new enrollment immediately for suspected cross-profile access, proof
+exposure, account takeover, or a repeated inability to delete or revoke access.
+Follow `pilot-support-incident-playbook.md` and resume only after containment,
+validated correction, and an explicit decision by the pilot owner.
+
+Pause the affected family for a SEV-2 issue without a safe workaround. Ordinary
+support questions and isolated defects with a safe workaround do not require a
+cohort-wide pause but remain part of the weekly review.
+
+## Completion checklist
+
+- close or assign every open incident and support follow-up;
+- record completed, withdrawn, and stopped counts without identifying users;
+- calculate only aggregate measures for actively consenting periods;
+- compare baseline and closing answers without claiming clinical effect;
+- document the top three friction points and the evidence behind them;
+- choose one outcome: continue unchanged, change and repeat, or stop;
+- remove temporary contact and operating notes that are no longer required;
+- schedule the normal 35-day technical-record deletion verification.
+

--- a/docs/pilot-survey-template.md
+++ b/docs/pilot-survey-template.md
@@ -1,0 +1,44 @@
+# Pilot before-and-after survey template
+
+Use these short questions for the four-week family pilot. Participation in the
+survey is optional. Do not ask for health details, proof photos, treatment
+outcomes, diagnoses, or the contents of a participant's routine.
+
+## Baseline
+
+Ask the responsible person to answer for the previous seven days:
+
+1. How much effort did coordinating the routine require? `1 none` to `5 a lot`.
+2. How often did you need to send a manual reminder? `never`, `once`, `2–3
+   times`, `4 or more times`.
+3. How confident were you that the routine status was clear? `1 not at all` to
+   `5 completely`.
+4. What is the main coordination difficulty today? Optional free text; remind
+   the person not to include medical or identifying information.
+
+Ask the participant:
+
+1. How easy is it to know what action is expected and when? `1 very difficult`
+   to `5 very easy`.
+2. How often do reminders from another person feel disruptive? `never`,
+   `sometimes`, `often`, `always`.
+
+## Closing
+
+Repeat the scaled baseline questions with the same wording, then ask:
+
+1. Did Zadiag reduce, leave unchanged, or increase manual coordination?
+2. Which part was hardest: installation, linking, notifications, taking proof,
+   review, or something else?
+3. Was there a moment when the app's status or next action was unclear? Optional
+   free text without personal or medical information.
+4. Would you choose to continue using this workflow? `yes`, `not sure`, or `no`.
+5. What single change would make it more useful? Optional free text.
+
+## Reporting
+
+Report response count and missing responses. Compare distributions and paired
+changes descriptively; do not convert a small convenience cohort into
+effectiveness claims. Quote free text only with separate permission and after
+removing identifying details.
+

--- a/docs/product-brief.md
+++ b/docs/product-brief.md
@@ -71,7 +71,10 @@ first instrumented cohort, then recorded alongside cohort size and timeframe.
    prematurely building for every possible market.
 
 The operating procedure for milestone 2 is defined in the
-[pilot support and incident playbook](pilot-support-incident-playbook.md).
+[pilot support and incident playbook](pilot-support-incident-playbook.md). The
+[cohort runbook](pilot-cohort-runbook.md) and
+[before-and-after survey](pilot-survey-template.md) cover launch, observation,
+weekly review, stopping rules, and closure.
 
 ## Principal risks
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zadiag-pwa",
   "private": true,
-  "version": "0.9.36",
+  "version": "0.9.37",
   "type": "module",
   "packageManager": "pnpm@11.7.0",
   "engines": {


### PR DESCRIPTION
## Summary
- define a repeatable four-week pilot for a small family cohort
- add entry criteria, minimal pseudonymous register, launch and closure checklists, review cadence, and stop rules
- add short before-and-after surveys without medical or identifying questions
- link the cohort kit from the product brief and README
- bump the application patch version to 0.9.37

## Validation
- `npm run check`
- 252 client tests
- 12 Functions test suites
- architecture, design, production build, and bundle checks