### PR TITLE
Compact the dashboard weekly summary

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zadiag-pwa",
   "private": true,
-  "version": "0.9.37",
+  "version": "0.9.38",
   "type": "module",
   "packageManager": "pnpm@11.7.0",
   "engines": {

--- a/src/screens/ParentDashboard.test.tsx
+++ b/src/screens/ParentDashboard.test.tsx
@@ -170,7 +170,11 @@ describe('ParentDashboard', () => {
     };
 
     act(() => root.render(<ParentDashboard state={state} regenerateCode={vi.fn()} t={(key) => translate('en', key)} />));
-    expect(container.querySelector('.weekly-insight-card')?.textContent).toContain('The week at a glance');
+    const weeklyInsight = container.querySelector<HTMLDetailsElement>('.weekly-insight-card');
+    expect(weeklyInsight?.textContent).toContain('The week at a glance');
+    expect(weeklyInsight?.open).toBe(false);
+    act(() => weeklyInsight?.querySelector('summary')?.click());
+    expect(weeklyInsight?.open).toBe(true);
     act(() => Array.from(container.querySelectorAll<HTMLButtonElement>('button')).find((button) => button.textContent === 'Open the 7-day report')?.click());
     expect(Array.from(container.querySelectorAll<HTMLButtonElement>('.summary-range-toggle button')).find((button) => button.textContent === '7 days')?.getAttribute('aria-pressed')).toBe('true');
     expect(container.querySelector<HTMLDetailsElement>('.detailed-reporting')?.open).toBe(true);

--- a/src/screens/ParentDashboard.tsx
+++ b/src/screens/ParentDashboard.tsx
@@ -358,28 +358,6 @@ export function ParentDashboard({
         </section>
       ) : null}
 
-      {!setupStep && weekly && weeklyPriorityKey ? (
-        <section className="card weekly-insight-card" aria-labelledby="weekly-insight-title">
-          <header>
-            <div><span className="eyebrow">{t('weeklyInsightEyebrow')}</span><h2 id="weekly-insight-title">{t('weeklyInsightTitle')}</h2></div>
-            <strong>{Math.round(weekly.rate * 100)}%</strong>
-          </header>
-          <p className="weekly-insight-evolution">{weekly.rateDelta === undefined
-            ? t('summaryNoPreviousBaseline')
-            : weekly.rateDelta === 0
-              ? t('summaryComparedStable')
-              : `${t(weekly.rateDelta > 0 ? 'weeklyInsightUp' : 'weeklyInsightDown')} ${Math.abs(Math.round(weekly.rateDelta * 100))} ${t('summaryPoints')}`}</p>
-          <div className="weekly-insight-metrics">
-            {weekly.strongestRoutineId && weekly.strongestRoutineId !== weekly.watchRoutineId ? <span><small>{t('weeklyInsightStrongest')}</small><strong>{routinePresentationsById.get(weekly.strongestRoutineId)?.name ?? t('routine')}</strong></span> : null}
-            {weekly.watchRoutineId ? <span><small>{t('weeklyInsightWatch')}</small><strong>{routinePresentationsById.get(weekly.watchRoutineId)?.name ?? t('routine')}</strong></span> : null}
-            {weekly.bestWindow ? <span><small>{t('weeklyInsightBestWindow')}</small><strong>{weekly.bestWindow.start}–{weekly.bestWindow.end}</strong></span> : null}
-            <span><small>{t('weeklyInsightResponsibleActions')}</small><strong>{weekly.responsibleActions.length ? weekly.responsibleActions.map((actor) => `${actor.actorName} · ${actor.count}`).join(', ') : weekly.responsibleActionCount}</strong></span>
-          </div>
-          <div className="weekly-insight-priority"><AppIcon name="sparkles" /><p><small>{t('weeklyInsightPriority')}</small><strong>{t(weeklyPriorityKey)}</strong></p></div>
-          <button type="button" onClick={() => { setSummaryRange('week'); setWeeklyReportOpenSignal((current) => current + 1); }}>{t('weeklyInsightOpenReport')}</button>
-        </section>
-      ) : null}
-
       {(responsibleEmptyState || (expandedStatus === 'active' && currentCheckCount) || (!state.family.childLinked && state.family.linkingCode) || (!state.routineAssignments.length && onCreateRoutine)) ? (
         <section className="settings-section parent-setup-section" aria-labelledby="parent-setup-title">
           <h2 id="parent-setup-title">{currentCheckCount ? `${currentCheckCount} ${t(currentCheckCount === 1 ? 'checkToComplete' : 'checksToComplete')}` : t('responsibleCurrentChecksTitle')}</h2>
@@ -479,6 +457,30 @@ export function ParentDashboard({
 
           </div>
         </section>
+      ) : null}
+
+      {!setupStep && weekly && weeklyPriorityKey ? (
+        <details className="card weekly-insight-card">
+          <summary aria-labelledby="weekly-insight-title">
+            <div><span className="eyebrow">{t('weeklyInsightEyebrow')}</span><h2 id="weekly-insight-title">{t('weeklyInsightTitle')}</h2></div>
+            <span className="weekly-insight-rate"><strong>{Math.round(weekly.rate * 100)}%</strong><AppIcon name="chevron-forward" /></span>
+          </summary>
+          <div className="weekly-insight-content">
+            <p className="weekly-insight-evolution">{weekly.rateDelta === undefined
+              ? t('summaryNoPreviousBaseline')
+              : weekly.rateDelta === 0
+                ? t('summaryComparedStable')
+                : `${t(weekly.rateDelta > 0 ? 'weeklyInsightUp' : 'weeklyInsightDown')} ${Math.abs(Math.round(weekly.rateDelta * 100))} ${t('summaryPoints')}`}</p>
+            <div className="weekly-insight-metrics">
+              {weekly.strongestRoutineId && weekly.strongestRoutineId !== weekly.watchRoutineId ? <span><small>{t('weeklyInsightStrongest')}</small><strong>{routinePresentationsById.get(weekly.strongestRoutineId)?.name ?? t('routine')}</strong></span> : null}
+              {weekly.watchRoutineId ? <span><small>{t('weeklyInsightWatch')}</small><strong>{routinePresentationsById.get(weekly.watchRoutineId)?.name ?? t('routine')}</strong></span> : null}
+              {weekly.bestWindow ? <span><small>{t('weeklyInsightBestWindow')}</small><strong>{weekly.bestWindow.start}–{weekly.bestWindow.end}</strong></span> : null}
+              <span><small>{t('weeklyInsightResponsibleActions')}</small><strong>{weekly.responsibleActions.length ? weekly.responsibleActions.map((actor) => `${actor.actorName} · ${actor.count}`).join(', ') : weekly.responsibleActionCount}</strong></span>
+            </div>
+            <div className="weekly-insight-priority"><AppIcon name="sparkles" /><p><small>{t('weeklyInsightPriority')}</small><strong>{t(weeklyPriorityKey)}</strong></p></div>
+            <button type="button" onClick={() => { setSummaryRange('week'); setWeeklyReportOpenSignal((current) => current + 1); }}>{t('weeklyInsightOpenReport')}</button>
+          </div>
+        </details>
       ) : null}
 
       {expandedStatus === 'review' && reviewEvents.length ? (

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -772,11 +772,17 @@ button:disabled { cursor: not-allowed; }
 .planning-recommendation .planning-recommendation-note { color: var(--color-text-muted); font-size: 11px; }
 .planning-recommendation > button { justify-self: start; min-height: var(--height-action); padding: 8px 12px; border: 0; border-radius: 12px; background: var(--color-primary); color: var(--color-surface-solid); font-size: 11px; font-weight: 850; }
 .planning-recommendation .request-feedback { margin: 0; }
-.weekly-insight-card { display: grid; gap: 10px; padding: var(--block-padding-lg); }
-.weekly-insight-card > header { display: flex; align-items: flex-start; justify-content: space-between; gap: 12px; }
-.weekly-insight-card > header .eyebrow { padding: 0; background: transparent; color: var(--color-primary); font-size: 10px; }
-.weekly-insight-card > header h2 { margin: 3px 0 0; font-size: 18px; }
-.weekly-insight-card > header > strong { color: var(--color-primary); font-size: 26px; line-height: 1; }
+.weekly-insight-card { padding: 0; overflow: hidden; }
+.weekly-insight-card > summary { display: flex; align-items: flex-start; justify-content: space-between; gap: 12px; padding: var(--block-padding); cursor: pointer; list-style: none; }
+.weekly-insight-card > summary::-webkit-details-marker { display: none; }
+.weekly-insight-card > summary:focus-visible { outline: 3px solid color-mix(in srgb, var(--color-primary) 35%, transparent); outline-offset: -3px; }
+.weekly-insight-card > summary .eyebrow { padding: 0; background: transparent; color: var(--color-primary); font-size: 10px; }
+.weekly-insight-card > summary h2 { margin: 3px 0 0; font-size: 16px; }
+.weekly-insight-rate { flex: 0 0 auto; display: flex; align-items: center; gap: 8px; color: var(--color-primary); }
+.weekly-insight-rate strong { font-size: 22px; line-height: 1; }
+.weekly-insight-rate .app-icon { font-size: 18px; transition: transform .2s ease; }
+.weekly-insight-card[open] .weekly-insight-rate .app-icon { transform: rotate(90deg); }
+.weekly-insight-content { display: grid; gap: 10px; padding: 0 var(--block-padding) var(--block-padding); }
 .weekly-insight-evolution { margin: 0; color: var(--color-text-muted); font-size: 12px; font-weight: 750; }
 .weekly-insight-metrics { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 7px; }
 .weekly-insight-metrics > span { display: grid; gap: 3px; padding: 9px 10px; border-radius: 12px; background: var(--color-canvas-elevated); }
@@ -786,7 +792,7 @@ button:disabled { cursor: not-allowed; }
 .weekly-insight-priority > .app-icon { margin-top: 2px; font-size: 22px; }
 .weekly-insight-priority p { display: grid; gap: 2px; margin: 0; }
 .weekly-insight-priority strong { color: var(--color-text); font-size: 12px; line-height: 1.35; }
-.weekly-insight-card > button { justify-self: start; min-height: var(--height-action); padding: 8px 12px; border: 0; border-radius: 12px; background: var(--color-text); color: var(--color-surface-solid); font-size: 11px; font-weight: 850; }
+.weekly-insight-content > button { justify-self: start; min-height: var(--height-action); padding: 8px 12px; border: 0; border-radius: 12px; background: var(--color-text); color: var(--color-surface-solid); font-size: 11px; font-weight: 850; }
 @media (max-width: 560px) {
   .routine-anomaly-card { grid-template-columns: 40px minmax(0, 1fr); }
   .routine-anomaly-action { grid-column: 2; width: 100%; margin: 0; }


### PR DESCRIPTION
## Summary
- move the weekly summary below the controls to complete
- keep the summary collapsed by default with its title, rate, and chevron visible
- reveal metrics, priority, and the detailed report action on expansion
- preserve accessible keyboard focus and native details behavior
- bump the application patch version to 0.9.38

## Validation
- `npm run check`
- 252 client tests
- 12 Functions test suites
- architecture, design, production build, and bundle checks