### PR TITLE
Audit release security and privacy controls

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -26,6 +26,11 @@ email. They are kept for at most seven days, and common user or family
 identifiers, codes, tokens, email addresses, and URL parameters are removed from
 generated reports.
 
+The release security and privacy control map, verified boundaries, retention
+periods, and known residual risks are recorded in
+[`docs/security-privacy-audit.md`](docs/security-privacy-audit.md). Incident
+handling follows [`docs/pilot-support-incident-playbook.md`](docs/pilot-support-incident-playbook.md).
+
 ## Scope
 
 Useful reports include authentication or authorization bypasses, cross-family

--- a/docs/pilot-support-incident-playbook.md
+++ b/docs/pilot-support-incident-playbook.md
@@ -46,6 +46,36 @@ These are pilot operating targets, not contractual service-level guarantees.
 8. Close with cause, timeline, affected scope, containment, correction, and one
    concrete prevention action.
 
+## Incident record and decision log
+
+Create one private record for the incident. Use opaque profile and account
+references; never paste a proof image, bearer code, push endpoint, email address,
+or raw production document. Keep these fields current throughout the response:
+
+| Field | Required content |
+| --- | --- |
+| Incident ID | `ZDI-YYYYMMDD-NN`, severity, owner and deputy |
+| Detection | UTC timestamp, reporting channel, first observed version |
+| Scope | Affected feature, deployment, estimated profiles and data categories |
+| Timeline | UTC timestamp, actor, action, evidence reference and outcome for every decision |
+| Containment | Access suspended, feature disabled, secret/code rotated or release reverted |
+| Data assessment | Confidentiality, integrity, availability and retention impact; confirmed versus suspected |
+| Recovery evidence | Commit/deployment, automated checks, synthetic smoke test and monitoring result |
+| Communication | Audience, approver, time sent and correction if later facts changed |
+| Closure | Root cause, contributing controls, prevention owner and due date |
+
+At each hand-off, the incident owner states the current facts, unresolved
+questions, next decision, and next update time. Preserve logs and audit records
+in place when possible. Any exceptional export must be approved by the incident
+owner, minimized, encrypted, access-limited, recorded in the timeline, and
+deleted when the investigation no longer needs it.
+
+Before closure, verify that temporary access, feature flags, exported evidence,
+test accounts, and rotated codes have been removed. Record why user or authority
+notification was or was not required, who made that determination, and the
+applicable deadline; obtain qualified legal or privacy advice rather than
+deriving that decision from this engineering playbook.
+
 ## Privacy or security escalation
 
 Treat any suspected unauthorized access, proof exposure, identifier leakage,

--- a/docs/security-privacy-audit.md
+++ b/docs/security-privacy-audit.md
@@ -1,0 +1,54 @@
+# Release security and privacy audit
+
+Last reviewed: 2026-07-17. Scope: the web client, Firestore rules, callable and
+scheduled Functions, proof storage, relationship invitations, account recovery,
+and operational audit data in the release built from `main`.
+
+This is an internal engineering review backed by emulator and unit tests. It is
+not an external penetration test, legal privacy assessment, or certification.
+
+## Trust boundaries and controls
+
+| Boundary | Enforced control | Independent verification | Retention or deletion |
+| --- | --- | --- | --- |
+| Firestore profile data | Authenticated, non-suspended family membership or active participant membership with `view`; all client writes denied | `rules-tests/firestore.rules.test.ts` exercises allowed members, outsiders, suspended members, cross-profile isolation and write denial in the Firestore emulator | Profile deletion recursively deletes participant data and related indexes |
+| Membership and permissions | Sensitive changes use App Check-protected callable Functions and server-side permission helpers; the last owner cannot leave or be removed | Relationship domain tests cover role defaults, delegation, suspension and last-owner invariants; emulator tests deny direct mutation | Removed memberships are suspended and their push registration is deleted |
+| Invitations | Random code returned once; only its hash is used as the document ID; App Check, authentication, expiry, single consumption and per-account attempt throttling apply | Function tests cover code format and relationship invariants; emulator tests prove invitation and attempt documents cannot be read or written by clients | Expired invitations are deleted daily; consumed invitations are deleted after 24 hours |
+| Recovery | Bearer code is hashed at rest, expires, rotates after use, transfers membership transactionally and suspends the previous account | Relationship and cleanup unit tests plus emulator denial of all recovery documents | Expired codes and attempts older than 24 hours are deleted daily |
+| Proof images | Upload and access occur only through App Check-protected Functions after membership checks; access URLs expire after five minutes; bucket paths are never client-writable | Callable authorization is kept server-side; Firestore emulator denies direct check mutation and cross-profile reads | Image removed immediately after responsible review or after at most 30 days; deletion failures raise an operational alert |
+| Push endpoints | Registration and fan-out use server functions; a client may read only its own registration document | Emulator tests deny another member's endpoint and collection listing in both current and legacy aggregates | Endpoint deleted when membership is removed, recovered or account data is reset |
+| Audit events | Server-created records contain action, actor, aggregate identifiers and allow-listed scalar metadata; no client access rule exists | Audit unit tests validate metadata filtering; emulator tests deny reads, writes and deletes | Deleted daily after 35 days |
+| Local diagnostics | Redacted on device and attached only with explicit user consent | Client tests cover report redaction and consent flow | Local entries expire after seven days |
+
+## Findings and disposition
+
+The review found one release-blocking privacy issue: any authorized member could
+read every push subscription in the same aggregate. Firestore now restricts a
+member to the document whose ID matches their authenticated UID, while server
+fan-out remains unchanged. Adversarial emulator coverage prevents regression.
+
+No direct client path was found to invitation hashes, recovery hashes, recovery
+attempts, audit events, membership mutations, check mutations, or proof bucket
+operations. All exported callable Functions enforce authentication and App
+Check; sensitive relationship actions additionally re-read membership state on
+the server.
+
+## Residual risks and release gates
+
+- Bearer invitation and recovery links remain transferable by design. A leaked,
+  unexpired code can be used by an authenticated, App Check-verified account;
+  short expiry, single use, hashing, throttling and rotation reduce but do not
+  eliminate that risk.
+- The temporary `notSuspended` compatibility branch permits accounts without a
+  `userAccess` document during rollout. Remove it after every deployed account
+  has a registered access document; until then, suspension depends on creating
+  that document before access must be blocked.
+- Proof deletion is asynchronous on storage failure. Operational alerts must be
+  monitored and retried; the Firestore reference is retained on immediate
+  deletion failure so the scheduled cleanup can try again.
+- This review does not replace a qualified privacy/legal assessment or an
+  independent human penetration test before a wider public launch.
+
+A release is eligible only when `pnpm check:full` passes (including emulator
+rules tests), `pnpm check:security` reports no high-severity production
+dependency finding, and the incident procedure has an assigned operator.

--- a/firebase.json
+++ b/firebase.json
@@ -32,7 +32,7 @@
   "emulators": {
     "auth": { "port": 9099 },
     "functions": { "port": 5001 },
-    "firestore": { "port": 8080 },
+    "firestore": { "port": 8180 },
     "ui": { "enabled": true }
   }
 }

--- a/firestore.rules
+++ b/firestore.rules
@@ -63,7 +63,9 @@ service cloud.firestore {
       }
 
       match /pushSubscriptions/{subscriptionId} {
-        allow read: if familyMember(familyId);
+        // A subscription contains a device endpoint. Members only need their
+        // own registration state; notification fan-out stays server-side.
+        allow read: if familyMember(familyId) && subscriptionId == request.auth.uid;
         allow create, update, delete: if false;
       }
     }
@@ -88,7 +90,7 @@ service cloud.firestore {
       }
 
       match /pushSubscriptions/{subscriptionId} {
-        allow read: if canViewParticipant(participantId);
+        allow read: if canViewParticipant(participantId) && subscriptionId == request.auth.uid;
         allow write: if false;
       }
     }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zadiag-pwa",
   "private": true,
-  "version": "0.9.42",
+  "version": "0.9.43",
   "type": "module",
   "packageManager": "pnpm@11.7.0",
   "engines": {

--- a/rules-tests/firestore.rules.test.ts
+++ b/rules-tests/firestore.rules.test.ts
@@ -6,7 +6,7 @@ import {
   initializeTestEnvironment,
   type RulesTestEnvironment,
 } from '@firebase/rules-unit-testing';
-import { collection, doc, getDoc, getDocs, orderBy, query, setDoc, updateDoc } from 'firebase/firestore';
+import { collection, deleteDoc, doc, getDoc, getDocs, orderBy, query, setDoc, updateDoc } from 'firebase/firestore';
 import { afterAll, beforeAll, beforeEach, describe, test } from 'vitest';
 
 const projectId = 'zadiag-rules-test';
@@ -55,6 +55,8 @@ beforeEach(async () => {
     });
     await setDoc(doc(db, 'participants/participant-1/checks/check-1'), { status: 'pending' });
     await setDoc(doc(db, 'participants/participant-1/routineAssignments/routine-1'), { status: 'active' });
+    await setDoc(doc(db, 'participants/participant-1/pushSubscriptions/parent'), { endpoint: 'parent-device' });
+    await setDoc(doc(db, 'participants/participant-1/pushSubscriptions/coparent'), { endpoint: 'coparent-device' });
     await setDoc(doc(db, 'users/parent/participantRefs/participant-1'), {
       participantId: 'participant-1', role: 'owner', status: 'active',
     });
@@ -63,6 +65,12 @@ beforeEach(async () => {
       uid: 'jordan', role: 'owner', label: 'self', status: 'active', permissions: { view: true },
     });
     await setDoc(doc(db, 'relationshipInvitations/private-invitation'), { participantId: 'participant-1' });
+    await setDoc(doc(db, 'relationshipRecoveryCodes/private-recovery'), { participantId: 'participant-1' });
+    await setDoc(doc(db, 'parentRecoveryCodes/private-parent-recovery'), { familyId: 'family-1' });
+    await setDoc(doc(db, 'recoveryAttempts/parent'), { attempts: 2 });
+    await setDoc(doc(db, 'auditEvents/private-audit'), { action: 'accept_relationship_invitation', actorUid: 'parent' });
+    await setDoc(doc(db, 'families/family-1/pushSubscriptions/parent'), { endpoint: 'legacy-parent-device' });
+    await setDoc(doc(db, 'families/family-1/pushSubscriptions/child'), { endpoint: 'legacy-child-device' });
   });
 });
 
@@ -103,6 +111,29 @@ describe('participant relationship isolation', () => {
     await assertFails(updateDoc(doc(parentDb, 'participants/participant-1/memberships/coparent'), { role: 'owner' }));
     await assertFails(getDoc(doc(parentDb, 'relationshipInvitations/private-invitation')));
   });
+
+  test('keeps every bearer code, recovery attempt, and audit event server-only', async () => {
+    const parentDb = environment.authenticatedContext('parent').firestore();
+    for (const path of [
+      'linkCodes/private-hash',
+      'parentRecoveryCodes/private-parent-recovery',
+      'relationshipInvitations/private-invitation',
+      'relationshipRecoveryCodes/private-recovery',
+      'recoveryAttempts/parent',
+      'auditEvents/private-audit',
+    ]) {
+      await assertFails(getDoc(doc(parentDb, path)));
+      await assertFails(setDoc(doc(parentDb, path), { tampered: true }));
+      await assertFails(deleteDoc(doc(parentDb, path)));
+    }
+  });
+
+  test('exposes only the signed-in member own push registration', async () => {
+    const parentDb = environment.authenticatedContext('parent').firestore();
+    await assertSucceeds(getDoc(doc(parentDb, 'participants/participant-1/pushSubscriptions/parent')));
+    await assertFails(getDoc(doc(parentDb, 'participants/participant-1/pushSubscriptions/coparent')));
+    await assertFails(getDocs(collection(parentDb, 'participants/participant-1/pushSubscriptions')));
+  });
 });
 
 afterAll(async () => environment.cleanup());
@@ -140,6 +171,13 @@ describe('family isolation', () => {
     const suspendedDb = environment.authenticatedContext('suspended-account').firestore();
     await assertSucceeds(getDoc(doc(suspendedDb, 'userAccess/suspended-account')));
     await assertFails(getDoc(doc(suspendedDb, 'families/family-1')));
+  });
+
+  test('keeps legacy family device endpoints private to their owner', async () => {
+    const parentDb = environment.authenticatedContext('parent').firestore();
+    await assertSucceeds(getDoc(doc(parentDb, 'families/family-1/pushSubscriptions/parent')));
+    await assertFails(getDoc(doc(parentDb, 'families/family-1/pushSubscriptions/child')));
+    await assertFails(getDocs(collection(parentDb, 'families/family-1/pushSubscriptions')));
   });
 });
 


### PR DESCRIPTION
## Summary
- document the release security/privacy trust boundaries, retention controls, findings, and residual risks
- restrict push subscription reads to the authenticated owner of each device endpoint
- add adversarial Firestore coverage for invitations, recovery data, audit events, and push endpoints
- make the incident decision log and evidence-handling procedure operationally precise
- move the local Firestore emulator to a dedicated port to keep rule verification reproducible
- bump the application patch version to 0.9.43

## Root cause
Push subscription documents were readable by every authorized member of an aggregate even though only the owning client and server-side notification fan-out need the endpoint.

## Validation
- npm run check
- npm run test:rules (15 passed)
- npm run check:security (0 known vulnerabilities)
- git diff --check