### PR TITLE
Define Routine Package V1

### DIFF
--- a/docs/create-routine.md
+++ b/docs/create-routine.md
@@ -18,9 +18,21 @@ The validation contract lives in `routines/schema.json`.
 
 ## Routine Shape
 
-Each file describes a reusable `RoutineTemplate.routine`. The app snapshots this routine into a family-specific `RoutineAssignment` when a parent assigns it.
+Each file contains a Routine Package V1 envelope around a reusable `RoutineTemplate.routine`. The app snapshots only the nested routine into a family-specific `RoutineAssignment` when a responsible user assigns it.
 
-Required fields:
+```json
+{
+  "schemaVersion": 1,
+  "version": 1,
+  "defaultLocale": "en",
+  "availableLocales": ["en", "fr"],
+  "routine": {}
+}
+```
+
+Package V1 is limited to 64 KiB, English plus French, and two to four instruction steps. `routines/schema.json` contains the per-field limits. Declared locales must exactly match translations, and translated step IDs and order must match the default locale.
+
+Required fields inside `routine`:
 
 ```json
 {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zadiag-pwa",
   "private": true,
-  "version": "0.9.44",
+  "version": "0.9.45",
   "type": "module",
   "packageManager": "pnpm@11.7.0",
   "engines": {

--- a/routines/README.md
+++ b/routines/README.md
@@ -1,6 +1,6 @@
 # Routine Catalog
 
-This directory is the file-based source for routines that can later be imported into the app marketplace.
+This directory is the file-based source for versioned routine packages that can later be imported into the app marketplace.
 
 Use one file per routine:
 
@@ -21,9 +21,32 @@ routines/
 6. Keep `accentColor` as a hex color like `#2387c9`.
 7. Run `npm run generate:routines`, then `npm run check:routines` before opening a PR.
 
-`schema.json` defines the validation contract. CI validates every routine file except `template.json` and `schema.json`, then refuses stale generated catalogs.
+`schema.json` documents the validation contract. The generator is the executable validation source used by CI for the template and every routine package, and it refuses stale generated catalogues.
 
-## Required Fields
+## Package V1
+
+Every file is a data-only package with this envelope:
+
+```json
+{
+  "schemaVersion": 1,
+  "version": 1,
+  "defaultLocale": "en",
+  "availableLocales": ["en", "fr"],
+  "routine": {}
+}
+```
+
+- `schemaVersion` identifies the validation contract and is currently `1`.
+- `version` is a positive, immutable content version.
+- Package V1 uses English as its default locale to preserve existing assignment snapshots.
+- `availableLocales` must exactly describe the default locale and translations present.
+- Packages are limited to 64 KiB, two supported locales, four steps, and the field limits encoded in `schema.json`.
+- Unknown fields and executable content are rejected.
+
+The generator validates this envelope, then emits only `routine` into the client and Functions catalogues. Existing stored `Routine` snapshots therefore keep their current shape.
+
+## Required Routine Fields
 
 - `id`: stable unique id.
 - `name`: short display name.

--- a/routines/daily-hydration.json
+++ b/routines/daily-hydration.json
@@ -1,73 +1,82 @@
 {
-  "id": "daily-hydration",
-  "name": "Hydration",
-  "description": "Daily water intake check.",
-  "instructions": "When requested, send a photo showing you drinking water or a clear hydration proof.",
-  "icon": "water",
-  "accentColor": "#2387c9",
-  "category": "wellness",
-  "proofType": "Photo",
-  "proofExample": "Photo of the participant drinking water, a visible glass, bottle, or hydration tracker.",
-  "recommendedValidationMode": "ai",
-  "responsibleName": "Care team",
-  "analysis": {
-    "expectedEvidence": "A photo showing the participant drinking water is sufficient. Also accept a clearly visible glass of water, water bottle, hydration tracker, or another clear sign of water intake.",
-    "detectedCriteria": "The photo clearly shows the participant drinking water, or another clear proof of water intake.",
-    "notDetectedCriteria": "The image is clear but does not show the participant drinking, water, a bottle, a glass, a tracker, or any hydration proof.",
-    "uncertaintyCriteria": "The action or proof is ambiguous, cropped, too dark, blurry, or could be unrelated to hydration."
-  },
-  "instructionSteps": [
-    {
-      "id": "prepare",
-      "icon": "water",
-      "title": "Keep water nearby",
-      "description": "Make it easy to drink regularly during the day."
-    },
-    {
-      "id": "track",
-      "icon": "camera",
-      "title": "Show hydration",
-      "description": "A photo of you drinking water is enough. A bottle, glass, or tracker also works."
-    },
-    {
-      "id": "send",
-      "icon": "send",
-      "title": "Send your proof",
-      "description": "Submit it so the responsible person can review it."
-    }
+  "schemaVersion": 1,
+  "version": 1,
+  "defaultLocale": "en",
+  "availableLocales": [
+    "en",
+    "fr"
   ],
-  "translations": {
-    "fr": {
-      "name": "Hydratation",
-      "description": "Contrôle quotidien de l'hydratation.",
-      "instructions": "Quand c'est demandé, envoie une photo où tu bois de l'eau ou une preuve claire d'hydratation.",
-      "proofExample": "Photo du participant qui boit de l'eau, verre, bouteille ou suivi d'hydratation visible.",
-      "analysis": {
-        "expectedEvidence": "Une photo montrant le participant en train de boire de l'eau suffit. Accepte aussi un verre d'eau, une bouteille d'eau, un suivi d'hydratation ou un autre signe clair de consommation d'eau.",
-        "detectedCriteria": "La photo montre clairement le participant en train de boire de l'eau, ou une autre preuve claire de consommation d'eau.",
-        "notDetectedCriteria": "L'image est claire mais ne montre pas le participant en train de boire, ni eau, ni bouteille, ni verre, ni suivi, ni preuve d'hydratation.",
-        "uncertaintyCriteria": "L'action ou la preuve est ambiguë, coupée, trop sombre, floue ou pourrait ne pas être liée à l'hydratation."
+  "routine": {
+    "id": "daily-hydration",
+    "name": "Hydration",
+    "description": "Daily water intake check.",
+    "instructions": "When requested, send a photo showing you drinking water or a clear hydration proof.",
+    "icon": "water",
+    "accentColor": "#2387c9",
+    "category": "wellness",
+    "proofType": "Photo",
+    "proofExample": "Photo of the participant drinking water, a visible glass, bottle, or hydration tracker.",
+    "recommendedValidationMode": "ai",
+    "responsibleName": "Care team",
+    "analysis": {
+      "expectedEvidence": "A photo showing the participant drinking water is sufficient. Also accept a clearly visible glass of water, water bottle, hydration tracker, or another clear sign of water intake.",
+      "detectedCriteria": "The photo clearly shows the participant drinking water, or another clear proof of water intake.",
+      "notDetectedCriteria": "The image is clear but does not show the participant drinking, water, a bottle, a glass, a tracker, or any hydration proof.",
+      "uncertaintyCriteria": "The action or proof is ambiguous, cropped, too dark, blurry, or could be unrelated to hydration."
+    },
+    "instructionSteps": [
+      {
+        "id": "prepare",
+        "icon": "water",
+        "title": "Keep water nearby",
+        "description": "Make it easy to drink regularly during the day."
       },
-      "instructionSteps": [
-        {
-          "id": "prepare",
-          "icon": "water",
-          "title": "Garde de l'eau à portée",
-          "description": "Rends l'hydratation simple pendant la journée."
+      {
+        "id": "track",
+        "icon": "camera",
+        "title": "Show hydration",
+        "description": "A photo of you drinking water is enough. A bottle, glass, or tracker also works."
+      },
+      {
+        "id": "send",
+        "icon": "send",
+        "title": "Send your proof",
+        "description": "Submit it so the responsible person can review it."
+      }
+    ],
+    "translations": {
+      "fr": {
+        "name": "Hydratation",
+        "description": "Contrôle quotidien de l'hydratation.",
+        "instructions": "Quand c'est demandé, envoie une photo où tu bois de l'eau ou une preuve claire d'hydratation.",
+        "proofExample": "Photo du participant qui boit de l'eau, verre, bouteille ou suivi d'hydratation visible.",
+        "analysis": {
+          "expectedEvidence": "Une photo montrant le participant en train de boire de l'eau suffit. Accepte aussi un verre d'eau, une bouteille d'eau, un suivi d'hydratation ou un autre signe clair de consommation d'eau.",
+          "detectedCriteria": "La photo montre clairement le participant en train de boire de l'eau, ou une autre preuve claire de consommation d'eau.",
+          "notDetectedCriteria": "L'image est claire mais ne montre pas le participant en train de boire, ni eau, ni bouteille, ni verre, ni suivi, ni preuve d'hydratation.",
+          "uncertaintyCriteria": "L'action ou la preuve est ambiguë, coupée, trop sombre, floue ou pourrait ne pas être liée à l'hydratation."
         },
-        {
-          "id": "track",
-          "icon": "camera",
-          "title": "Montre l'hydratation",
-          "description": "Une photo où tu bois de l'eau suffit. Une bouteille, un verre ou un suivi fonctionne aussi."
-        },
-        {
-          "id": "send",
-          "icon": "send",
-          "title": "Envoie ta preuve",
-          "description": "Le responsable pourra ensuite la vérifier."
-        }
-      ]
+        "instructionSteps": [
+          {
+            "id": "prepare",
+            "icon": "water",
+            "title": "Garde de l'eau à portée",
+            "description": "Rends l'hydratation simple pendant la journée."
+          },
+          {
+            "id": "track",
+            "icon": "camera",
+            "title": "Montre l'hydratation",
+            "description": "Une photo où tu bois de l'eau suffit. Une bouteille, un verre ou un suivi fonctionne aussi."
+          },
+          {
+            "id": "send",
+            "icon": "send",
+            "title": "Envoie ta preuve",
+            "description": "Le responsable pourra ensuite la vérifier."
+          }
+        ]
+      }
     }
   }
 }

--- a/routines/medication.json
+++ b/routines/medication.json
@@ -1,31 +1,82 @@
 {
-  "id": "medication", "name": "Medication", "description": "Medication adherence reminder.",
-  "instructions": "Take the medication as prescribed and send proof when requested.",
-  "icon": "medical", "accentColor": "#9468d7", "category": "medication", "proofType": "Photo",
-  "proofExample": "Photo of the medication box, pill organizer, or prepared prescribed dose.", "recommendedValidationMode": "ai", "responsibleName": "Care team",
-  "analysis": {
-    "expectedEvidence": "A clear medication adherence proof such as the medication package, pill organizer, prescribed dose, or other expected medication proof.",
-    "detectedCriteria": "The photo clearly shows medication-related proof consistent with taking or preparing the prescribed dose.",
-    "notDetectedCriteria": "The image is clear but contains no medication, package, pill organizer, dose, or medication proof.",
-    "uncertaintyCriteria": "The proof is ambiguous, the label or object is unclear, or the image quality prevents a reliable medication adherence decision."
-  },
-  "instructionSteps": [
-    { "id": "check", "icon": "medical", "title": "Check the dose", "description": "Follow the prescribed dose and timing." },
-    { "id": "photo", "icon": "camera", "title": "Take a clear photo", "description": "Show the expected proof clearly." },
-    { "id": "send", "icon": "send", "title": "Send your proof", "description": "Submit it so the responsible person can review it." }
+  "schemaVersion": 1,
+  "version": 1,
+  "defaultLocale": "en",
+  "availableLocales": [
+    "en",
+    "fr"
   ],
-  "translations": { "fr": {
-    "name": "Médicament", "description": "Rappel de prise de médicament.", "instructions": "Prends le médicament selon la prescription et envoie une preuve quand elle est demandée.", "proofExample": "Photo de la boîte, du pilulier ou de la dose préparée selon la prescription.",
+  "routine": {
+    "id": "medication",
+    "name": "Medication",
+    "description": "Medication adherence reminder.",
+    "instructions": "Take the medication as prescribed and send proof when requested.",
+    "icon": "medical",
+    "accentColor": "#9468d7",
+    "category": "medication",
+    "proofType": "Photo",
+    "proofExample": "Photo of the medication box, pill organizer, or prepared prescribed dose.",
+    "recommendedValidationMode": "ai",
+    "responsibleName": "Care team",
     "analysis": {
-      "expectedEvidence": "Une preuve claire de prise de médicament, comme la boîte, le pilulier, la dose prescrite ou une autre preuve attendue.",
-      "detectedCriteria": "La photo montre clairement une preuve liée au médicament et cohérente avec la prise ou la préparation de la dose.",
-      "notDetectedCriteria": "L’image est claire mais ne contient ni médicament, ni boîte, ni pilulier, ni dose, ni preuve liée au médicament.",
-      "uncertaintyCriteria": "La preuve est ambiguë, l’objet ou l’étiquette n’est pas clair, ou la qualité empêche une décision fiable."
+      "expectedEvidence": "A clear medication adherence proof such as the medication package, pill organizer, prescribed dose, or other expected medication proof.",
+      "detectedCriteria": "The photo clearly shows medication-related proof consistent with taking or preparing the prescribed dose.",
+      "notDetectedCriteria": "The image is clear but contains no medication, package, pill organizer, dose, or medication proof.",
+      "uncertaintyCriteria": "The proof is ambiguous, the label or object is unclear, or the image quality prevents a reliable medication adherence decision."
     },
     "instructionSteps": [
-      { "id": "check", "icon": "medical", "title": "Vérifie la dose", "description": "Suis la dose et l’horaire prescrits." },
-      { "id": "photo", "icon": "camera", "title": "Prends une photo claire", "description": "Montre clairement la preuve attendue." },
-      { "id": "send", "icon": "send", "title": "Envoie ta preuve", "description": "Le responsable pourra ensuite la vérifier." }
-    ]
-  }}
+      {
+        "id": "check",
+        "icon": "medical",
+        "title": "Check the dose",
+        "description": "Follow the prescribed dose and timing."
+      },
+      {
+        "id": "photo",
+        "icon": "camera",
+        "title": "Take a clear photo",
+        "description": "Show the expected proof clearly."
+      },
+      {
+        "id": "send",
+        "icon": "send",
+        "title": "Send your proof",
+        "description": "Submit it so the responsible person can review it."
+      }
+    ],
+    "translations": {
+      "fr": {
+        "name": "Médicament",
+        "description": "Rappel de prise de médicament.",
+        "instructions": "Prends le médicament selon la prescription et envoie une preuve quand elle est demandée.",
+        "proofExample": "Photo de la boîte, du pilulier ou de la dose préparée selon la prescription.",
+        "analysis": {
+          "expectedEvidence": "Une preuve claire de prise de médicament, comme la boîte, le pilulier, la dose prescrite ou une autre preuve attendue.",
+          "detectedCriteria": "La photo montre clairement une preuve liée au médicament et cohérente avec la prise ou la préparation de la dose.",
+          "notDetectedCriteria": "L’image est claire mais ne contient ni médicament, ni boîte, ni pilulier, ni dose, ni preuve liée au médicament.",
+          "uncertaintyCriteria": "La preuve est ambiguë, l’objet ou l’étiquette n’est pas clair, ou la qualité empêche une décision fiable."
+        },
+        "instructionSteps": [
+          {
+            "id": "check",
+            "icon": "medical",
+            "title": "Vérifie la dose",
+            "description": "Suis la dose et l’horaire prescrits."
+          },
+          {
+            "id": "photo",
+            "icon": "camera",
+            "title": "Prends une photo claire",
+            "description": "Montre clairement la preuve attendue."
+          },
+          {
+            "id": "send",
+            "icon": "send",
+            "title": "Envoie ta preuve",
+            "description": "Le responsable pourra ensuite la vérifier."
+          }
+        ]
+      }
+    }
+  }
 }

--- a/routines/mobility-exercise.json
+++ b/routines/mobility-exercise.json
@@ -1,31 +1,82 @@
 {
-  "id": "mobility-exercise", "name": "Exercise", "description": "Daily mobility or exercise check.",
-  "instructions": "Complete the planned exercise and send proof when requested.",
-  "icon": "fitness", "accentColor": "#c07a17", "category": "activity", "proofType": "Photo",
-  "proofExample": "Photo showing the completed position, equipment, or activity proof agreed for the routine.", "recommendedValidationMode": "ai", "responsibleName": "Care team",
-  "analysis": {
-    "expectedEvidence": "A clear proof that the planned mobility or exercise routine was performed, such as the participant in position, exercise equipment, or a completed activity proof.",
-    "detectedCriteria": "The photo clearly shows exercise or mobility activity proof matching the routine.",
-    "notDetectedCriteria": "The image is clear but shows no exercise, mobility activity, equipment, position, or completed activity proof.",
-    "uncertaintyCriteria": "The scene is ambiguous, too cropped, too dark, blurry, or does not show enough context to verify the exercise."
-  },
-  "instructionSteps": [
-    { "id": "prepare", "icon": "fitness", "title": "Prepare the session", "description": "Choose a safe space and follow the plan." },
-    { "id": "complete", "icon": "check", "title": "Complete the exercise", "description": "Do the routine as agreed with your responsible person." },
-    { "id": "send", "icon": "send", "title": "Send your proof", "description": "Submit it so the responsible person can review it." }
+  "schemaVersion": 1,
+  "version": 1,
+  "defaultLocale": "en",
+  "availableLocales": [
+    "en",
+    "fr"
   ],
-  "translations": { "fr": {
-    "name": "Exercice", "description": "Contrôle quotidien d’exercice ou de mobilité.", "instructions": "Réalise l’exercice prévu et envoie une preuve quand elle est demandée.", "proofExample": "Photo montrant la position, le matériel ou la preuve d’activité prévue pour la routine.",
+  "routine": {
+    "id": "mobility-exercise",
+    "name": "Exercise",
+    "description": "Daily mobility or exercise check.",
+    "instructions": "Complete the planned exercise and send proof when requested.",
+    "icon": "fitness",
+    "accentColor": "#c07a17",
+    "category": "activity",
+    "proofType": "Photo",
+    "proofExample": "Photo showing the completed position, equipment, or activity proof agreed for the routine.",
+    "recommendedValidationMode": "ai",
+    "responsibleName": "Care team",
     "analysis": {
-      "expectedEvidence": "Une preuve claire que l’exercice ou la routine de mobilité prévue a été réalisée, comme le participant en position, du matériel d’exercice ou une preuve d’activité terminée.",
-      "detectedCriteria": "La photo montre clairement une preuve d’exercice ou de mobilité correspondant à la routine.",
-      "notDetectedCriteria": "L’image est claire mais ne montre ni exercice, ni mobilité, ni matériel, ni position, ni preuve d’activité terminée.",
-      "uncertaintyCriteria": "La scène est ambiguë, trop coupée, trop sombre, floue ou ne montre pas assez de contexte pour vérifier l’exercice."
+      "expectedEvidence": "A clear proof that the planned mobility or exercise routine was performed, such as the participant in position, exercise equipment, or a completed activity proof.",
+      "detectedCriteria": "The photo clearly shows exercise or mobility activity proof matching the routine.",
+      "notDetectedCriteria": "The image is clear but shows no exercise, mobility activity, equipment, position, or completed activity proof.",
+      "uncertaintyCriteria": "The scene is ambiguous, too cropped, too dark, blurry, or does not show enough context to verify the exercise."
     },
     "instructionSteps": [
-      { "id": "prepare", "icon": "fitness", "title": "Prépare la séance", "description": "Choisis un espace adapté et suis le plan." },
-      { "id": "complete", "icon": "check", "title": "Fais l’exercice", "description": "Réalise la routine convenue avec ton responsable." },
-      { "id": "send", "icon": "send", "title": "Envoie ta preuve", "description": "Le responsable pourra ensuite la vérifier." }
-    ]
-  }}
+      {
+        "id": "prepare",
+        "icon": "fitness",
+        "title": "Prepare the session",
+        "description": "Choose a safe space and follow the plan."
+      },
+      {
+        "id": "complete",
+        "icon": "check",
+        "title": "Complete the exercise",
+        "description": "Do the routine as agreed with your responsible person."
+      },
+      {
+        "id": "send",
+        "icon": "send",
+        "title": "Send your proof",
+        "description": "Submit it so the responsible person can review it."
+      }
+    ],
+    "translations": {
+      "fr": {
+        "name": "Exercice",
+        "description": "Contrôle quotidien d’exercice ou de mobilité.",
+        "instructions": "Réalise l’exercice prévu et envoie une preuve quand elle est demandée.",
+        "proofExample": "Photo montrant la position, le matériel ou la preuve d’activité prévue pour la routine.",
+        "analysis": {
+          "expectedEvidence": "Une preuve claire que l’exercice ou la routine de mobilité prévue a été réalisée, comme le participant en position, du matériel d’exercice ou une preuve d’activité terminée.",
+          "detectedCriteria": "La photo montre clairement une preuve d’exercice ou de mobilité correspondant à la routine.",
+          "notDetectedCriteria": "L’image est claire mais ne montre ni exercice, ni mobilité, ni matériel, ni position, ni preuve d’activité terminée.",
+          "uncertaintyCriteria": "La scène est ambiguë, trop coupée, trop sombre, floue ou ne montre pas assez de contexte pour vérifier l’exercice."
+        },
+        "instructionSteps": [
+          {
+            "id": "prepare",
+            "icon": "fitness",
+            "title": "Prépare la séance",
+            "description": "Choisis un espace adapté et suis le plan."
+          },
+          {
+            "id": "complete",
+            "icon": "check",
+            "title": "Fais l’exercice",
+            "description": "Réalise la routine convenue avec ton responsable."
+          },
+          {
+            "id": "send",
+            "icon": "send",
+            "title": "Envoie ta preuve",
+            "description": "Le responsable pourra ensuite la vérifier."
+          }
+        ]
+      }
+    }
+  }
 }

--- a/routines/orthodontic-elastics.json
+++ b/routines/orthodontic-elastics.json
@@ -1,33 +1,82 @@
 {
-  "id": "orthodontic-elastics", "name": "Orthodontic Elastics", "description": "Daily orthodontic elastic wear checks.",
-  "instructions": "Wear your elastics as prescribed. When a check is ready, take a clear photo in good light.",
-  "icon": "tooth", "accentColor": "#0d927d", "category": "dental", "proofType": "Photo",
-  "proofExample": "Mouth photo with the elastics visible in good light.", "recommendedValidationMode": "ai", "responsibleName": "Care team",
-  "analysis": {
-    "expectedEvidence": "A clear view of the mouth showing whether orthodontic elastics are being worn.",
-    "detectedCriteria": "Orthodontic elastics are clearly visible on the teeth or braces.",
-    "notDetectedCriteria": "The mouth or teeth are visible and orthodontic elastics are clearly absent.",
-    "uncertaintyCriteria": "The mouth is not visible enough, the image is blurry or dark, or it is impossible to tell whether elastics are present."
-  },
-  "instructionSteps": [
-    { "id": "wear", "icon": "tooth", "title": "Wear your elastics", "description": "Follow the instructions from your healthcare professional." },
-    { "id": "photo", "icon": "camera", "title": "Take a clear photo", "description": "Use good light and keep your mouth centered." },
-    { "id": "send", "icon": "send", "title": "Send your proof", "description": "Submit it so the responsible person can review it." }
+  "schemaVersion": 1,
+  "version": 1,
+  "defaultLocale": "en",
+  "availableLocales": [
+    "en",
+    "fr"
   ],
-  "translations": { "fr": {
-    "name": "Élastiques orthodontiques", "description": "Contrôles quotidiens du port des élastiques orthodontiques.",
-    "instructions": "Porte tes élastiques selon les consignes de ton praticien et envoie une photo claire pour chaque contrôle.",
-    "proofExample": "Photo de la bouche avec les élastiques visibles, en bonne lumière.",
+  "routine": {
+    "id": "orthodontic-elastics",
+    "name": "Orthodontic Elastics",
+    "description": "Daily orthodontic elastic wear checks.",
+    "instructions": "Wear your elastics as prescribed. When a check is ready, take a clear photo in good light.",
+    "icon": "tooth",
+    "accentColor": "#0d927d",
+    "category": "dental",
+    "proofType": "Photo",
+    "proofExample": "Mouth photo with the elastics visible in good light.",
+    "recommendedValidationMode": "ai",
+    "responsibleName": "Care team",
     "analysis": {
-      "expectedEvidence": "Une vue claire de la bouche montrant si les élastiques orthodontiques sont portés.",
-      "detectedCriteria": "Les élastiques orthodontiques sont clairement visibles sur les dents ou l’appareil.",
-      "notDetectedCriteria": "La bouche ou les dents sont visibles et les élastiques orthodontiques sont clairement absents.",
-      "uncertaintyCriteria": "La bouche n’est pas assez visible, l’image est floue ou sombre, ou il est impossible de savoir si les élastiques sont présents."
+      "expectedEvidence": "A clear view of the mouth showing whether orthodontic elastics are being worn.",
+      "detectedCriteria": "Orthodontic elastics are clearly visible on the teeth or braces.",
+      "notDetectedCriteria": "The mouth or teeth are visible and orthodontic elastics are clearly absent.",
+      "uncertaintyCriteria": "The mouth is not visible enough, the image is blurry or dark, or it is impossible to tell whether elastics are present."
     },
     "instructionSteps": [
-      { "id": "wear", "icon": "tooth", "title": "Mets tes élastiques", "description": "Suis les consignes de ton praticien." },
-      { "id": "photo", "icon": "camera", "title": "Prends une photo", "description": "Cadre bien ta bouche avec une lumière claire." },
-      { "id": "send", "icon": "send", "title": "Envoie ta preuve", "description": "Le responsable pourra ensuite la vérifier." }
-    ]
-  }}
+      {
+        "id": "wear",
+        "icon": "tooth",
+        "title": "Wear your elastics",
+        "description": "Follow the instructions from your healthcare professional."
+      },
+      {
+        "id": "photo",
+        "icon": "camera",
+        "title": "Take a clear photo",
+        "description": "Use good light and keep your mouth centered."
+      },
+      {
+        "id": "send",
+        "icon": "send",
+        "title": "Send your proof",
+        "description": "Submit it so the responsible person can review it."
+      }
+    ],
+    "translations": {
+      "fr": {
+        "name": "Élastiques orthodontiques",
+        "description": "Contrôles quotidiens du port des élastiques orthodontiques.",
+        "instructions": "Porte tes élastiques selon les consignes de ton praticien et envoie une photo claire pour chaque contrôle.",
+        "proofExample": "Photo de la bouche avec les élastiques visibles, en bonne lumière.",
+        "analysis": {
+          "expectedEvidence": "Une vue claire de la bouche montrant si les élastiques orthodontiques sont portés.",
+          "detectedCriteria": "Les élastiques orthodontiques sont clairement visibles sur les dents ou l’appareil.",
+          "notDetectedCriteria": "La bouche ou les dents sont visibles et les élastiques orthodontiques sont clairement absents.",
+          "uncertaintyCriteria": "La bouche n’est pas assez visible, l’image est floue ou sombre, ou il est impossible de savoir si les élastiques sont présents."
+        },
+        "instructionSteps": [
+          {
+            "id": "wear",
+            "icon": "tooth",
+            "title": "Mets tes élastiques",
+            "description": "Suis les consignes de ton praticien."
+          },
+          {
+            "id": "photo",
+            "icon": "camera",
+            "title": "Prends une photo",
+            "description": "Cadre bien ta bouche avec une lumière claire."
+          },
+          {
+            "id": "send",
+            "icon": "send",
+            "title": "Envoie ta preuve",
+            "description": "Le responsable pourra ensuite la vérifier."
+          }
+        ]
+      }
+    }
+  }
 }

--- a/routines/schema.json
+++ b/routines/schema.json
@@ -1,160 +1,95 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://zadiag.app/schemas/routine.schema.json",
-  "title": "Zadiag Routine",
+  "$id": "https://zadiag.app/schemas/routine-package-v1.schema.json",
+  "title": "Zadiag Routine Package V1",
   "type": "object",
   "additionalProperties": false,
-  "required": [
-    "id",
-    "name",
-    "description",
-    "instructions",
-    "icon",
-    "accentColor",
-    "category",
-    "proofType",
-    "proofExample",
-    "recommendedValidationMode",
-    "responsibleName",
-    "analysis",
-    "instructionSteps",
-    "translations"
-  ],
+  "required": ["schemaVersion", "version", "defaultLocale", "availableLocales", "routine"],
   "properties": {
+    "schemaVersion": { "const": 1 },
+    "version": { "type": "integer", "minimum": 1 },
+    "defaultLocale": { "const": "en" },
+    "availableLocales": {
+      "type": "array",
+      "minItems": 1,
+      "maxItems": 2,
+      "uniqueItems": true,
+      "prefixItems": [{ "const": "en" }],
+      "items": { "type": "string", "enum": ["en", "fr"] }
+    },
+    "routine": { "$ref": "#/$defs/routine" }
+  },
+  "$defs": {
+    "routine": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "name", "description", "instructions", "icon", "accentColor", "category", "proofType", "proofExample", "recommendedValidationMode", "responsibleName", "analysis", "instructionSteps", "translations"],
+      "properties": {
+        "id": { "$ref": "#/$defs/id" },
+        "name": { "type": "string", "minLength": 2, "maxLength": 120 },
+        "description": { "type": "string", "minLength": 10, "maxLength": 500 },
+        "instructions": { "type": "string", "minLength": 10, "maxLength": 2000 },
+        "icon": { "type": "string", "minLength": 1, "maxLength": 32 },
+        "accentColor": { "type": "string", "pattern": "^#[0-9a-fA-F]{6}$" },
+        "category": { "type": "string", "enum": ["dental", "wellness", "medication", "activity", "custom"] },
+        "proofType": { "type": "string", "minLength": 1, "maxLength": 50 },
+        "proofExample": { "type": "string", "minLength": 10, "maxLength": 500 },
+        "recommendedValidationMode": { "type": "string", "enum": ["ai", "auto"] },
+        "responsibleName": { "type": "string", "minLength": 1, "maxLength": 120 },
+        "analysis": { "$ref": "#/$defs/analysis" },
+        "instructionSteps": { "$ref": "#/$defs/instructionSteps" },
+        "translations": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": { "fr": { "$ref": "#/$defs/localizedContent" } }
+        }
+      }
+    },
     "id": {
       "type": "string",
+      "minLength": 1,
+      "maxLength": 64,
       "pattern": "^[a-z0-9]+(?:-[a-z0-9]+)*$"
     },
-    "name": {
-      "type": "string",
-      "minLength": 2
-    },
-    "description": {
-      "type": "string",
-      "minLength": 10
-    },
-    "instructions": {
-      "type": "string",
-      "minLength": 10
-    },
-    "icon": {
-      "type": "string"
-    },
-    "accentColor": {
-      "type": "string",
-      "pattern": "^#[0-9a-fA-F]{6}$"
-    },
-    "category": { "type": "string", "enum": ["dental", "wellness", "medication", "activity", "custom"] },
-    "proofType": {
-      "type": "string"
-    },
-    "proofExample": { "type": "string", "minLength": 10 },
-    "recommendedValidationMode": { "type": "string", "enum": ["ai", "auto"] },
-    "responsibleName": {
-      "type": "string"
-    },
     "analysis": {
-      "$ref": "#/$defs/analysis"
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["expectedEvidence", "detectedCriteria", "notDetectedCriteria", "uncertaintyCriteria"],
+      "properties": {
+        "expectedEvidence": { "type": "string", "minLength": 20, "maxLength": 2000 },
+        "detectedCriteria": { "type": "string", "minLength": 20, "maxLength": 2000 },
+        "notDetectedCriteria": { "type": "string", "minLength": 20, "maxLength": 2000 },
+        "uncertaintyCriteria": { "type": "string", "minLength": 20, "maxLength": 2000 }
+      }
     },
     "instructionSteps": {
       "type": "array",
       "minItems": 2,
       "maxItems": 4,
-      "items": {
-        "$ref": "#/$defs/instructionStep"
-      }
-    },
-    "translations": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "fr": {
-          "$ref": "#/$defs/localizedContent"
-        },
-        "en": {
-          "$ref": "#/$defs/localizedContent"
-        }
-      }
-    }
-  },
-  "$defs": {
-    "analysis": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "expectedEvidence",
-        "detectedCriteria",
-        "notDetectedCriteria"
-      ],
-      "properties": {
-        "expectedEvidence": {
-          "type": "string",
-          "minLength": 20
-        },
-        "detectedCriteria": {
-          "type": "string",
-          "minLength": 20
-        },
-        "notDetectedCriteria": {
-          "type": "string",
-          "minLength": 20
-        },
-        "uncertaintyCriteria": {
-          "type": "string",
-          "minLength": 20
-        }
-      }
+      "items": { "$ref": "#/$defs/instructionStep" }
     },
     "instructionStep": {
       "type": "object",
       "additionalProperties": false,
-      "required": [
-        "id",
-        "icon",
-        "title",
-        "description"
-      ],
+      "required": ["id", "icon", "title", "description"],
       "properties": {
-        "id": {
-          "type": "string",
-          "pattern": "^[a-z0-9]+(?:-[a-z0-9]+)*$"
-        },
-        "icon": {
-          "type": "string"
-        },
-        "title": {
-          "type": "string",
-          "minLength": 2
-        },
-        "description": {
-          "type": "string",
-          "minLength": 10
-        }
+        "id": { "$ref": "#/$defs/id" },
+        "icon": { "type": "string", "minLength": 1, "maxLength": 32 },
+        "title": { "type": "string", "minLength": 2, "maxLength": 120 },
+        "description": { "type": "string", "minLength": 10, "maxLength": 500 }
       }
     },
     "localizedContent": {
       "type": "object",
       "additionalProperties": false,
+      "required": ["name", "description", "instructions", "proofExample", "analysis", "instructionSteps"],
       "properties": {
-        "name": {
-          "type": "string"
-        },
-        "description": {
-          "type": "string"
-        },
-        "instructions": {
-          "type": "string"
-        },
-        "proofExample": { "type": "string" },
-        "analysis": {
-          "$ref": "#/$defs/analysis"
-        },
-        "instructionSteps": {
-          "type": "array",
-          "items": {
-            "$ref": "#/$defs/instructionStep"
-          }
-        }
+        "name": { "type": "string", "minLength": 2, "maxLength": 120 },
+        "description": { "type": "string", "minLength": 10, "maxLength": 500 },
+        "instructions": { "type": "string", "minLength": 10, "maxLength": 2000 },
+        "proofExample": { "type": "string", "minLength": 10, "maxLength": 500 },
+        "analysis": { "$ref": "#/$defs/analysis" },
+        "instructionSteps": { "$ref": "#/$defs/instructionSteps" }
       }
     }
   }

--- a/routines/template.json
+++ b/routines/template.json
@@ -1,73 +1,82 @@
 {
-  "id": "your-routine-id",
-  "name": "Routine name",
-  "description": "One sentence describing what is tracked.",
-  "instructions": "Tell the participant exactly what to do when a check is requested.",
-  "icon": "star",
-  "accentColor": "#2387c9",
-  "category": "custom",
-  "proofType": "Photo",
-  "proofExample": "Describe the concrete proof shown in the photo.",
-  "recommendedValidationMode": "ai",
-  "responsibleName": "Care team",
-  "analysis": {
-    "expectedEvidence": "Describe the visible proof that should be accepted.",
-    "detectedCriteria": "The photo clearly shows the expected proof.",
-    "notDetectedCriteria": "The photo is clear but does not show the expected proof.",
-    "uncertaintyCriteria": "The proof is ambiguous, cropped, too dark, blurry, or unrelated."
-  },
-  "instructionSteps": [
-    {
-      "id": "prepare",
-      "icon": "star",
-      "title": "Prepare",
-      "description": "Prepare what is needed for the routine."
-    },
-    {
-      "id": "proof",
-      "icon": "camera",
-      "title": "Show proof",
-      "description": "Take a clear live photo of the expected proof."
-    },
-    {
-      "id": "send",
-      "icon": "send",
-      "title": "Send",
-      "description": "Submit the proof so the responsible person can review it."
-    }
+  "schemaVersion": 1,
+  "version": 1,
+  "defaultLocale": "en",
+  "availableLocales": [
+    "en",
+    "fr"
   ],
-  "translations": {
-    "fr": {
-      "name": "Nom de la routine",
-      "description": "Une phrase qui décrit ce qui est suivi.",
-      "instructions": "Explique au participant quoi faire quand un contrôle est demandé.",
-      "proofExample": "Décris la preuve concrète visible sur la photo.",
-      "analysis": {
-        "expectedEvidence": "Décris la preuve visible qui doit être acceptée.",
-        "detectedCriteria": "La photo montre clairement la preuve attendue.",
-        "notDetectedCriteria": "La photo est claire mais ne montre pas la preuve attendue.",
-        "uncertaintyCriteria": "La preuve est ambiguë, coupée, trop sombre, floue ou sans rapport."
+  "routine": {
+    "id": "your-routine-id",
+    "name": "Routine name",
+    "description": "One sentence describing what is tracked.",
+    "instructions": "Tell the participant exactly what to do when a check is requested.",
+    "icon": "star",
+    "accentColor": "#2387c9",
+    "category": "custom",
+    "proofType": "Photo",
+    "proofExample": "Describe the concrete proof shown in the photo.",
+    "recommendedValidationMode": "ai",
+    "responsibleName": "Care team",
+    "analysis": {
+      "expectedEvidence": "Describe the visible proof that should be accepted.",
+      "detectedCriteria": "The photo clearly shows the expected proof.",
+      "notDetectedCriteria": "The photo is clear but does not show the expected proof.",
+      "uncertaintyCriteria": "The proof is ambiguous, cropped, too dark, blurry, or unrelated."
+    },
+    "instructionSteps": [
+      {
+        "id": "prepare",
+        "icon": "star",
+        "title": "Prepare",
+        "description": "Prepare what is needed for the routine."
       },
-      "instructionSteps": [
-        {
-          "id": "prepare",
-          "icon": "star",
-          "title": "Prépare",
-          "description": "Prépare ce qui est nécessaire pour la routine."
+      {
+        "id": "proof",
+        "icon": "camera",
+        "title": "Show proof",
+        "description": "Take a clear live photo of the expected proof."
+      },
+      {
+        "id": "send",
+        "icon": "send",
+        "title": "Send",
+        "description": "Submit the proof so the responsible person can review it."
+      }
+    ],
+    "translations": {
+      "fr": {
+        "name": "Nom de la routine",
+        "description": "Une phrase qui décrit ce qui est suivi.",
+        "instructions": "Explique au participant quoi faire quand un contrôle est demandé.",
+        "proofExample": "Décris la preuve concrète visible sur la photo.",
+        "analysis": {
+          "expectedEvidence": "Décris la preuve visible qui doit être acceptée.",
+          "detectedCriteria": "La photo montre clairement la preuve attendue.",
+          "notDetectedCriteria": "La photo est claire mais ne montre pas la preuve attendue.",
+          "uncertaintyCriteria": "La preuve est ambiguë, coupée, trop sombre, floue ou sans rapport."
         },
-        {
-          "id": "proof",
-          "icon": "camera",
-          "title": "Montre la preuve",
-          "description": "Prends une photo claire en direct de la preuve attendue."
-        },
-        {
-          "id": "send",
-          "icon": "send",
-          "title": "Envoie",
-          "description": "Envoie la preuve pour que le responsable puisse la vérifier."
-        }
-      ]
+        "instructionSteps": [
+          {
+            "id": "prepare",
+            "icon": "star",
+            "title": "Prépare",
+            "description": "Prépare ce qui est nécessaire pour la routine."
+          },
+          {
+            "id": "proof",
+            "icon": "camera",
+            "title": "Montre la preuve",
+            "description": "Prends une photo claire en direct de la preuve attendue."
+          },
+          {
+            "id": "send",
+            "icon": "send",
+            "title": "Envoie",
+            "description": "Envoie la preuve pour que le responsable puisse la vérifier."
+          }
+        ]
+      }
     }
   }
 }

--- a/scripts/generate-routine-catalog.mjs
+++ b/scripts/generate-routine-catalog.mjs
@@ -1,37 +1,17 @@
 import { readFile, readdir, mkdir, writeFile } from 'node:fs/promises';
 import { resolve } from 'node:path';
+import { validateRoutinePackage } from './routine-package.mjs';
 
 const root = resolve(import.meta.dirname, '..');
 const routineDir = resolve(root, 'routines');
 const files = (await readdir(routineDir)).filter((file) => file.endsWith('.json') && !['schema.json', 'template.json'].includes(file)).sort();
-const requiredStrings = ['id', 'name', 'description', 'instructions', 'icon', 'accentColor', 'category', 'proofType', 'proofExample', 'recommendedValidationMode', 'responsibleName'];
-const allowedFields = new Set([...requiredStrings, 'analysis', 'instructionSteps', 'translations']);
-const analysisStrings = ['expectedEvidence', 'detectedCriteria', 'notDetectedCriteria', 'uncertaintyCriteria'];
 const fail = (file, message) => { throw new Error(`${file}: ${message}`); };
 const routines = [];
+validateRoutinePackage('template.json', JSON.parse(await readFile(resolve(routineDir, 'template.json'), 'utf8')));
 for (const file of files) {
-  const routine = JSON.parse(await readFile(resolve(routineDir, file), 'utf8'));
-  requiredStrings.forEach((field) => { if (typeof routine[field] !== 'string' || !routine[field].trim()) fail(file, `${field} is required`); });
-  Object.keys(routine).forEach((field) => { if (!allowedFields.has(field)) fail(file, `unknown field ${field}`); });
+  const routinePackage = JSON.parse(await readFile(resolve(routineDir, file), 'utf8'));
+  const routine = validateRoutinePackage(file, routinePackage);
   if (file !== `${routine.id}.json`) fail(file, 'filename must match the routine id');
-  if (!/^[a-z0-9]+(?:-[a-z0-9]+)*$/.test(routine.id)) fail(file, 'id must be kebab-case');
-  if (!/^#[0-9a-fA-F]{6}$/.test(routine.accentColor)) fail(file, 'accentColor must be a six-digit hex color');
-  if (!['dental', 'wellness', 'medication', 'activity', 'custom'].includes(routine.category)) fail(file, 'category is invalid');
-  if (!['ai', 'auto'].includes(routine.recommendedValidationMode)) fail(file, 'recommendedValidationMode is invalid');
-  analysisStrings.forEach((field) => { if (typeof routine.analysis?.[field] !== 'string' || routine.analysis[field].length < 20) fail(file, `analysis.${field} is invalid`); });
-  if (!Array.isArray(routine.instructionSteps) || routine.instructionSteps.length < 2 || routine.instructionSteps.length > 4) fail(file, 'instructionSteps must contain 2 to 4 steps');
-  const stepIds = new Set();
-  routine.instructionSteps.forEach((step) => {
-    if (!step?.id || !step.icon || !step.title || !step.description) fail(file, 'every instruction step must be complete');
-    if (stepIds.has(step.id)) fail(file, `duplicate instruction step ${step.id}`);
-    stepIds.add(step.id);
-  });
-  if (!routine.translations?.fr) fail(file, 'translations.fr is required');
-  ['name', 'description', 'instructions', 'proofExample'].forEach((field) => {
-    if (typeof routine.translations.fr[field] !== 'string' || !routine.translations.fr[field].trim()) fail(file, `translations.fr.${field} is required`);
-  });
-  analysisStrings.forEach((field) => { if (typeof routine.translations.fr.analysis?.[field] !== 'string') fail(file, `translations.fr.analysis.${field} is required`); });
-  if (!Array.isArray(routine.translations.fr.instructionSteps) || routine.translations.fr.instructionSteps.length !== routine.instructionSteps.length) fail(file, 'translated instruction steps must match the source steps');
   routines.push(routine);
 }
 const ids = new Set();

--- a/scripts/routine-package.mjs
+++ b/scripts/routine-package.mjs
@@ -1,0 +1,115 @@
+const supportedLocales = ['en', 'fr'];
+const requiredRoutineStrings = ['id', 'name', 'description', 'instructions', 'icon', 'accentColor', 'category', 'proofType', 'proofExample', 'recommendedValidationMode', 'responsibleName'];
+const allowedRoutineFields = new Set([...requiredRoutineStrings, 'analysis', 'instructionSteps', 'translations']);
+const localizedFields = ['name', 'description', 'instructions', 'proofExample'];
+const analysisFields = ['expectedEvidence', 'detectedCriteria', 'notDetectedCriteria', 'uncertaintyCriteria'];
+const stepFields = ['id', 'icon', 'title', 'description'];
+const minimumLengths = Object.freeze({
+  id: 1,
+  name: 2,
+  description: 10,
+  instructions: 10,
+  icon: 1,
+  proofType: 1,
+  proofExample: 10,
+  responsibleName: 1,
+});
+
+export const ROUTINE_PACKAGE_SCHEMA_VERSION = 1;
+export const routinePackageLimits = Object.freeze({
+  packageBytes: 64 * 1024,
+  locales: 2,
+  steps: 4,
+  id: 64,
+  name: 120,
+  description: 500,
+  instructions: 2_000,
+  icon: 32,
+  proofType: 50,
+  proofExample: 500,
+  responsibleName: 120,
+  analysis: 2_000,
+  stepTitle: 120,
+  stepDescription: 500,
+});
+
+const byteLength = (value) => Buffer.byteLength(JSON.stringify(value), 'utf8');
+const ownKeysEqual = (actual, expected) => actual.length === expected.length && actual.every((value, index) => value === expected[index]);
+
+export function validateRoutinePackage(file, routinePackage) {
+  const fail = (message) => { throw new Error(`${file}: ${message}`); };
+  const expectObject = (value, path) => {
+    if (!value || typeof value !== 'object' || Array.isArray(value)) fail(`${path} must be an object`);
+  };
+  const expectKeys = (value, allowed, path) => {
+    Object.keys(value).forEach((field) => { if (!allowed.has(field)) fail(`${path} has unknown field ${field}`); });
+  };
+  const expectString = (value, path, { min = 1, max } = {}) => {
+    if (typeof value !== 'string' || value.trim().length < min) fail(`${path} is required`);
+    if (max && value.length > max) fail(`${path} exceeds ${max} characters`);
+  };
+  const validateAnalysis = (analysis, path) => {
+    expectObject(analysis, path);
+    expectKeys(analysis, new Set(analysisFields), path);
+    analysisFields.forEach((field) => expectString(analysis[field], `${path}.${field}`, { min: 20, max: routinePackageLimits.analysis }));
+  };
+  const validateSteps = (steps, path, expectedIds) => {
+    if (!Array.isArray(steps) || steps.length < 2 || steps.length > routinePackageLimits.steps) fail(`${path} must contain 2 to ${routinePackageLimits.steps} steps`);
+    const ids = new Set();
+    steps.forEach((step, index) => {
+      const stepPath = `${path}[${index}]`;
+      expectObject(step, stepPath);
+      expectKeys(step, new Set(stepFields), stepPath);
+      expectString(step.id, `${stepPath}.id`, { max: routinePackageLimits.id });
+      if (!/^[a-z0-9]+(?:-[a-z0-9]+)*$/.test(step.id)) fail(`${stepPath}.id must be kebab-case`);
+      if (ids.has(step.id)) fail(`${path} has duplicate step ${step.id}`);
+      ids.add(step.id);
+      expectString(step.icon, `${stepPath}.icon`, { max: routinePackageLimits.icon });
+      expectString(step.title, `${stepPath}.title`, { min: 2, max: routinePackageLimits.stepTitle });
+      expectString(step.description, `${stepPath}.description`, { min: 10, max: routinePackageLimits.stepDescription });
+    });
+    const orderedIds = [...ids];
+    if (expectedIds && !ownKeysEqual(orderedIds, expectedIds)) fail(`${path} step ids and order must match the default locale`);
+    return orderedIds;
+  };
+
+  expectObject(routinePackage, 'package');
+  expectKeys(routinePackage, new Set(['schemaVersion', 'version', 'defaultLocale', 'availableLocales', 'routine']), 'package');
+  if (routinePackage.schemaVersion !== ROUTINE_PACKAGE_SCHEMA_VERSION) fail(`schemaVersion must be ${ROUTINE_PACKAGE_SCHEMA_VERSION}`);
+  if (!Number.isSafeInteger(routinePackage.version) || routinePackage.version < 1) fail('version must be a positive integer');
+  if (routinePackage.defaultLocale !== 'en') fail('defaultLocale must be en for schema version 1');
+  if (!Array.isArray(routinePackage.availableLocales) || routinePackage.availableLocales.length < 1 || routinePackage.availableLocales.length > routinePackageLimits.locales) fail(`availableLocales must contain 1 to ${routinePackageLimits.locales} locales`);
+  if (new Set(routinePackage.availableLocales).size !== routinePackage.availableLocales.length) fail('availableLocales must not contain duplicates');
+  routinePackage.availableLocales.forEach((locale) => { if (!supportedLocales.includes(locale)) fail(`unsupported locale ${locale}`); });
+  if (routinePackage.availableLocales[0] !== routinePackage.defaultLocale) fail('availableLocales must start with defaultLocale');
+
+  const routine = routinePackage.routine;
+  expectObject(routine, 'routine');
+  expectKeys(routine, allowedRoutineFields, 'routine');
+  requiredRoutineStrings.forEach((field) => expectString(routine[field], `routine.${field}`, { min: minimumLengths[field], max: routinePackageLimits[field] }));
+  if (!/^[a-z0-9]+(?:-[a-z0-9]+)*$/.test(routine.id)) fail('routine.id must be kebab-case');
+  if (!/^#[0-9a-fA-F]{6}$/.test(routine.accentColor)) fail('routine.accentColor must be a six-digit hex color');
+  if (!['dental', 'wellness', 'medication', 'activity', 'custom'].includes(routine.category)) fail('routine.category is invalid');
+  if (!['ai', 'auto'].includes(routine.recommendedValidationMode)) fail('routine.recommendedValidationMode is invalid');
+  validateAnalysis(routine.analysis, 'routine.analysis');
+  const stepIds = validateSteps(routine.instructionSteps, 'routine.instructionSteps');
+
+  expectObject(routine.translations, 'routine.translations');
+  expectKeys(routine.translations, new Set(supportedLocales.filter((locale) => locale !== routinePackage.defaultLocale)), 'routine.translations');
+  const translationLocales = Object.keys(routine.translations).sort();
+  const declaredLocales = routinePackage.availableLocales.filter((locale) => locale !== routinePackage.defaultLocale).sort();
+  if (!ownKeysEqual(translationLocales, declaredLocales)) fail('availableLocales must exactly match the default locale and translations');
+  translationLocales.forEach((locale) => {
+    const localized = routine.translations[locale];
+    const path = `routine.translations.${locale}`;
+    expectObject(localized, path);
+    expectKeys(localized, new Set([...localizedFields, 'analysis', 'instructionSteps']), path);
+    localizedFields.forEach((field) => expectString(localized[field], `${path}.${field}`, { min: minimumLengths[field], max: routinePackageLimits[field] }));
+    validateAnalysis(localized.analysis, `${path}.analysis`);
+    validateSteps(localized.instructionSteps, `${path}.instructionSteps`, stepIds);
+  });
+
+  const size = byteLength(routinePackage);
+  if (size > routinePackageLimits.packageBytes) fail(`package is ${size} bytes; limit is ${routinePackageLimits.packageBytes}`);
+  return routine;
+}

--- a/scripts/routine-package.test.mjs
+++ b/scripts/routine-package.test.mjs
@@ -1,0 +1,72 @@
+import { describe, expect, it } from 'vitest';
+import { ROUTINE_PACKAGE_SCHEMA_VERSION, routinePackageLimits, validateRoutinePackage } from './routine-package.mjs';
+
+const validPackage = () => ({
+  schemaVersion: ROUTINE_PACKAGE_SCHEMA_VERSION,
+  version: 1,
+  defaultLocale: 'en',
+  availableLocales: ['en', 'fr'],
+  routine: {
+    id: 'test-routine', name: 'Test routine', description: 'A complete test routine description.',
+    instructions: 'Complete the routine and provide the expected proof.', icon: 'star', accentColor: '#2387c9',
+    category: 'custom', proofType: 'Photo', proofExample: 'A clear photo showing the completed routine.',
+    recommendedValidationMode: 'ai', responsibleName: 'Care team',
+    analysis: {
+      expectedEvidence: 'A clear photo showing the expected test evidence.',
+      detectedCriteria: 'The expected evidence is clearly visible in the photo.',
+      notDetectedCriteria: 'The photo is clear but the expected evidence is absent.',
+      uncertaintyCriteria: 'The photo is too dark, blurry, cropped, or ambiguous.',
+    },
+    instructionSteps: [
+      { id: 'prepare', icon: 'star', title: 'Prepare', description: 'Prepare everything needed for the routine.' },
+      { id: 'send', icon: 'send', title: 'Send proof', description: 'Send a clear photo of the expected proof.' },
+    ],
+    translations: { fr: {
+      name: 'Routine de test', description: 'Une description complète de la routine de test.',
+      instructions: 'Réalise la routine et fournis la preuve attendue.', proofExample: 'Une photo claire montrant la routine terminée.',
+      analysis: {
+        expectedEvidence: 'Une photo claire montrant la preuve de test attendue.',
+        detectedCriteria: 'La preuve attendue est clairement visible sur la photo.',
+        notDetectedCriteria: 'La photo est claire mais la preuve attendue est absente.',
+        uncertaintyCriteria: 'La photo est trop sombre, floue, coupée ou ambiguë.',
+      },
+      instructionSteps: [
+        { id: 'prepare', icon: 'star', title: 'Prépare', description: 'Prépare tout le nécessaire pour la routine.' },
+        { id: 'send', icon: 'send', title: 'Envoie', description: 'Envoie une photo claire de la preuve attendue.' },
+      ],
+    } },
+  },
+});
+
+describe('Routine Package V1 validation', () => {
+  it('returns only the compatible routine payload', () => {
+    const routinePackage = validPackage();
+    expect(validateRoutinePackage('test.json', routinePackage)).toBe(routinePackage.routine);
+  });
+
+  it('rejects unsupported schema versions and undeclared translations', () => {
+    const wrongVersion = validPackage();
+    wrongVersion.schemaVersion = 2;
+    expect(() => validateRoutinePackage('test.json', wrongVersion)).toThrow('schemaVersion must be 1');
+
+    const missingLocale = validPackage();
+    missingLocale.availableLocales = ['en'];
+    expect(() => validateRoutinePackage('test.json', missingLocale)).toThrow('availableLocales must exactly match');
+  });
+
+  it('rejects translated steps that diverge from the default locale', () => {
+    const routinePackage = validPackage();
+    routinePackage.routine.translations.fr.instructionSteps.reverse();
+    expect(() => validateRoutinePackage('test.json', routinePackage)).toThrow('step ids and order must match');
+  });
+
+  it('rejects unknown executable fields and oversized packages', () => {
+    const executable = validPackage();
+    executable.routine.script = 'alert(1)';
+    expect(() => validateRoutinePackage('test.json', executable)).toThrow('unknown field script');
+
+    const oversized = validPackage();
+    oversized.routine.instructions = 'x'.repeat(routinePackageLimits.packageBytes);
+    expect(() => validateRoutinePackage('test.json', oversized)).toThrow(/exceeds|package is/);
+  });
+});


### PR DESCRIPTION
## Outcome

- Wrap every authored built-in routine in a versioned Package V1 envelope.
- Add strict validation for schema version, content version, locales, field/package size limits, step consistency, and unknown fields.
- Keep generated client and Functions catalogues on the existing `Routine` shape so persisted assignment snapshots remain compatible.
- Document the package contract and bump the application version to 0.9.45.

Closes #140.

## Impact

This is an architectural foundation with no intended user-visible behavior change. It gives future draft, editor, translation, import, and marketplace work one validated data contract while preserving offline built-ins and existing assignments.

## Validation

- `corepack pnpm check`
- `corepack pnpm check:routines`
- `corepack pnpm exec vitest run scripts/routine-package.test.mjs`
- `git diff --check`
