### PR TITLE
Add private routine draft domain model

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zadiag-pwa",
   "private": true,
-  "version": "0.9.45",
+  "version": "0.9.46",
   "type": "module",
   "packageManager": "pnpm@11.7.0",
   "engines": {

--- a/src/domain/routineDraft.test.ts
+++ b/src/domain/routineDraft.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, it } from 'vitest';
+import type { Routine } from './models';
+import {
+  archiveRoutineDraft,
+  createRoutineDraft,
+  createRoutineDraftSnapshot,
+  restoreRoutineDraft,
+  RoutineDraftError,
+  routineDraftIsAssignable,
+  routineDraftIsComplete,
+  routineDraftIsPublishable,
+  updateRoutineDraft,
+  type RoutineDraftValidation,
+  type RoutinePackageV1,
+} from './routineDraft';
+
+const routine: Routine = {
+  id: 'custom-routine',
+  name: 'Custom routine',
+  description: 'A private routine draft.',
+};
+
+const packageV1 = (): RoutinePackageV1 => ({
+  schemaVersion: 1,
+  version: 1,
+  defaultLocale: 'en',
+  availableLocales: ['en'],
+  routine: structuredClone(routine),
+});
+
+const valid: RoutineDraftValidation = { status: 'valid', issues: [] };
+const incomplete: RoutineDraftValidation = {
+  status: 'incomplete',
+  issues: [{ code: 'required_field', path: 'routine.instructions' }],
+};
+const overLimit: RoutineDraftValidation = {
+  status: 'invalid',
+  issues: [{ code: 'limit_exceeded', path: 'routine.instructions' }],
+};
+
+const draft = (validation = valid) => createRoutineDraft({
+  id: 'draft-1',
+  ownerId: 'owner-1',
+  package: packageV1(),
+  validation,
+  createdAt: '2026-07-17T12:00:00.000Z',
+});
+
+describe('private routine draft domain', () => {
+  it('creates an owned active draft at revision one without retaining mutable input', () => {
+    const sourcePackage = packageV1();
+    const created = createRoutineDraft({
+      id: 'draft-1', ownerId: 'owner-1', package: sourcePackage, validation: valid, createdAt: '2026-07-17T12:00:00.000Z',
+    });
+    sourcePackage.routine.name = 'Changed outside';
+
+    expect(created).toMatchObject({ id: 'draft-1', ownerId: 'owner-1', revision: 1, state: 'active' });
+    expect(created.package.routine.name).toBe('Custom routine');
+  });
+
+  it('classifies incomplete, invalid, assignable, and publishable drafts from validation', () => {
+    expect(routineDraftIsComplete(draft(incomplete))).toBe(false);
+    expect(routineDraftIsAssignable(draft(incomplete))).toBe(false);
+    expect(routineDraftIsComplete(draft(overLimit))).toBe(true);
+    expect(routineDraftIsAssignable(draft(overLimit))).toBe(false);
+    expect(routineDraftIsAssignable(draft())).toBe(true);
+    expect(routineDraftIsPublishable(draft())).toBe(true);
+  });
+
+  it('updates content with optimistic revision control while preserving identity', () => {
+    const current = draft(incomplete);
+    const nextPackage = packageV1();
+    nextPackage.routine.name = 'Completed routine';
+    const updated = updateRoutineDraft(current, {
+      expectedRevision: 1, package: nextPackage, validation: valid, updatedAt: '2026-07-17T12:10:00.000Z',
+    });
+
+    expect(updated).toMatchObject({ id: current.id, ownerId: current.ownerId, revision: 2, state: 'active' });
+    expect(updated.package.routine.name).toBe('Completed routine');
+    expect(current.package.routine.name).toBe('Custom routine');
+    expect(() => updateRoutineDraft(updated, {
+      expectedRevision: 1, package: nextPackage, validation: valid, updatedAt: '2026-07-17T12:11:00.000Z',
+    })).toThrowError(expect.objectContaining({ code: 'stale_revision' }));
+  });
+
+  it('rejects package identity changes through ordinary updates', () => {
+    const nextPackage = packageV1();
+    nextPackage.routine.id = 'another-routine';
+
+    expect(() => updateRoutineDraft(draft(), {
+      expectedRevision: 1, package: nextPackage, validation: valid, updatedAt: '2026-07-17T12:10:00.000Z',
+    })).toThrowError(expect.objectContaining({ code: 'immutable_identity' }));
+  });
+
+  it('enforces archive and restore transitions', () => {
+    const archived = archiveRoutineDraft(draft(), 1, '2026-07-17T12:10:00.000Z');
+    expect(archived).toMatchObject({ revision: 2, state: 'archived' });
+    expect(routineDraftIsAssignable(archived)).toBe(false);
+    expect(() => archiveRoutineDraft(archived, 2, '2026-07-17T12:11:00.000Z')).toThrowError(expect.objectContaining({ code: 'invalid_transition' }));
+
+    const restored = restoreRoutineDraft(archived, 2, '2026-07-17T12:12:00.000Z');
+    expect(restored).toMatchObject({ revision: 3, state: 'active' });
+  });
+
+  it('creates an independent snapshot only from an active valid draft', () => {
+    const source = draft();
+    const snapshot = createRoutineDraftSnapshot(source);
+    source.package.routine.name = 'Changed later';
+
+    expect(snapshot.name).toBe('Custom routine');
+    expect(() => createRoutineDraftSnapshot(draft(incomplete))).toThrowError(RoutineDraftError);
+  });
+
+  it('rejects contradictory validation results', () => {
+    expect(() => draft({ status: 'valid', issues: [{ code: 'invalid_package', path: 'routine' }] })).toThrowError(
+      expect.objectContaining({ code: 'invalid_validation' }),
+    );
+    expect(() => draft({ status: 'invalid', issues: [] })).toThrowError(expect.objectContaining({ code: 'invalid_validation' }));
+  });
+
+  it('rejects invalid or backwards lifecycle timestamps', () => {
+    expect(() => createRoutineDraft({
+      id: 'draft-1', ownerId: 'owner-1', package: packageV1(), validation: valid, createdAt: 'not-a-date',
+    })).toThrowError(expect.objectContaining({ code: 'invalid_timestamp' }));
+    expect(() => archiveRoutineDraft(draft(), 1, '2026-07-17T11:59:00.000Z')).toThrowError(
+      expect.objectContaining({ code: 'invalid_timestamp' }),
+    );
+  });
+});

--- a/src/domain/routineDraft.ts
+++ b/src/domain/routineDraft.ts
@@ -1,0 +1,155 @@
+import type { Routine } from './models';
+
+export interface RoutinePackageV1 {
+  schemaVersion: 1;
+  version: number;
+  defaultLocale: 'en';
+  availableLocales: ['en'] | ['en', 'fr'];
+  routine: Routine;
+}
+
+export type RoutineDraftValidationIssueCode = 'required_field' | 'limit_exceeded' | 'invalid_package';
+
+export interface RoutineDraftValidationIssue {
+  code: RoutineDraftValidationIssueCode;
+  path: string;
+}
+
+export interface RoutineDraftValidation {
+  status: 'incomplete' | 'invalid' | 'valid';
+  issues: RoutineDraftValidationIssue[];
+}
+
+export interface RoutineDraft {
+  readonly id: string;
+  readonly ownerId: string;
+  revision: number;
+  state: 'active' | 'archived';
+  package: RoutinePackageV1;
+  validation: RoutineDraftValidation;
+  readonly createdAt: string;
+  updatedAt: string;
+}
+
+type RoutineDraftErrorCode =
+  | 'invalid_identity'
+  | 'invalid_revision'
+  | 'invalid_timestamp'
+  | 'invalid_validation'
+  | 'immutable_identity'
+  | 'stale_revision'
+  | 'invalid_transition'
+  | 'not_assignable';
+
+export class RoutineDraftError extends Error {
+  constructor(readonly code: RoutineDraftErrorCode) {
+    super(code);
+    this.name = 'RoutineDraftError';
+  }
+}
+
+const assertIdentity = (value: string) => {
+  if (!value.trim()) throw new RoutineDraftError('invalid_identity');
+};
+
+const assertRevision = (revision: number) => {
+  if (!Number.isSafeInteger(revision) || revision < 1) throw new RoutineDraftError('invalid_revision');
+};
+
+const assertTimestamp = (timestamp: string, earliest?: string) => {
+  const time = Date.parse(timestamp);
+  if (!Number.isFinite(time) || (earliest && time < Date.parse(earliest))) throw new RoutineDraftError('invalid_timestamp');
+};
+
+const assertValidation = (validation: RoutineDraftValidation) => {
+  const validIssueCount = validation.status === 'valid' ? validation.issues.length === 0 : validation.issues.length > 0;
+  if (!validIssueCount) throw new RoutineDraftError('invalid_validation');
+};
+
+const assertExpectedRevision = (draft: RoutineDraft, expectedRevision: number) => {
+  assertRevision(expectedRevision);
+  if (draft.revision !== expectedRevision) throw new RoutineDraftError('stale_revision');
+};
+
+const assertState = (draft: RoutineDraft, expected: RoutineDraft['state']) => {
+  if (draft.state !== expected) throw new RoutineDraftError('invalid_transition');
+};
+
+const clonePackage = (routinePackage: RoutinePackageV1) => structuredClone(routinePackage);
+const cloneValidation = (validation: RoutineDraftValidation) => structuredClone(validation);
+
+export const createRoutineDraft = (input: {
+  id: string;
+  ownerId: string;
+  package: RoutinePackageV1;
+  validation: RoutineDraftValidation;
+  createdAt: string;
+}): RoutineDraft => {
+  assertIdentity(input.id);
+  assertIdentity(input.ownerId);
+  assertValidation(input.validation);
+  assertTimestamp(input.createdAt);
+  return {
+    id: input.id,
+    ownerId: input.ownerId,
+    revision: 1,
+    state: 'active',
+    package: clonePackage(input.package),
+    validation: cloneValidation(input.validation),
+    createdAt: input.createdAt,
+    updatedAt: input.createdAt,
+  };
+};
+
+export const updateRoutineDraft = (
+  draft: RoutineDraft,
+  input: {
+    expectedRevision: number;
+    package: RoutinePackageV1;
+    validation: RoutineDraftValidation;
+    updatedAt: string;
+  },
+): RoutineDraft => {
+  assertExpectedRevision(draft, input.expectedRevision);
+  assertState(draft, 'active');
+  assertValidation(input.validation);
+  assertTimestamp(input.updatedAt, draft.updatedAt);
+  if (
+    input.package.schemaVersion !== draft.package.schemaVersion
+    || input.package.version !== draft.package.version
+    || input.package.routine.id !== draft.package.routine.id
+  ) throw new RoutineDraftError('immutable_identity');
+  return {
+    ...draft,
+    revision: draft.revision + 1,
+    package: clonePackage(input.package),
+    validation: cloneValidation(input.validation),
+    updatedAt: input.updatedAt,
+  };
+};
+
+export const archiveRoutineDraft = (draft: RoutineDraft, expectedRevision: number, updatedAt: string): RoutineDraft => {
+  assertExpectedRevision(draft, expectedRevision);
+  assertState(draft, 'active');
+  assertTimestamp(updatedAt, draft.updatedAt);
+  return { ...draft, revision: draft.revision + 1, state: 'archived', updatedAt };
+};
+
+export const restoreRoutineDraft = (draft: RoutineDraft, expectedRevision: number, updatedAt: string): RoutineDraft => {
+  assertExpectedRevision(draft, expectedRevision);
+  assertState(draft, 'archived');
+  assertTimestamp(updatedAt, draft.updatedAt);
+  return { ...draft, revision: draft.revision + 1, state: 'active', updatedAt };
+};
+
+export const routineDraftIsComplete = (draft: RoutineDraft) => draft.validation.status !== 'incomplete';
+
+export const routineDraftIsAssignable = (draft: RoutineDraft) =>
+  draft.state === 'active' && draft.validation.status === 'valid';
+
+export const routineDraftIsPublishable = routineDraftIsAssignable;
+
+export const createRoutineDraftSnapshot = (draft: RoutineDraft): Routine => {
+  if (!routineDraftIsAssignable(draft)) throw new RoutineDraftError('not_assignable');
+  return structuredClone(draft.package.routine);
+};


### PR DESCRIPTION
## Outcome

- Add the framework-independent private routine draft model.
- Centralize immutable identity, ownership, optimistic revisions, validation state, timestamps, and archive/restore transitions.
- Gate assignment and publication on an active, valid draft.
- Create deep assignment snapshots without retaining mutable draft content.
- Bump the application version to 0.9.46.

Closes #141.

## Coherence

Package validation remains owned by Routine Package V1. The draft domain consumes its explicit validation result instead of duplicating package-schema rules.

## Validation

- `corepack pnpm check`
- `corepack pnpm exec vitest run src/domain/routineDraft.test.ts`
- `corepack pnpm exec tsc -b --pretty false`
- `git diff --check`
