### PR TITLE
Expose private routine repository methods

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zadiag-pwa",
   "private": true,
-  "version": "0.9.52",
+  "version": "0.9.53",
   "type": "module",
   "packageManager": "pnpm@11.7.0",
   "engines": {

--- a/src/services/repositoryFactory.test.ts
+++ b/src/services/repositoryFactory.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import type { AppRepository } from './contracts';
 import type { AppState, Locale, MonitoringPlan, Role, VerificationEvent } from '../domain/models';
+import { createBlankRoutinePackage, type RoutineDraft } from '../domain/routineDraft';
 
 const configuredFirebaseEnv = {
   VITE_FIREBASE_API_KEY: 'api-key',
@@ -52,6 +53,8 @@ class FakeFirebaseRepository implements AppRepository {
   async regenerateLinkCode() {}
   async assignRoutine() {}
   async deleteRoutine() {}
+  async listRoutineDrafts(): Promise<RoutineDraft[]> { return []; }
+  async createRoutineDraft(_participantId: string, routinePackage: RoutineDraft['package']): Promise<RoutineDraft> { return { id: 'draft-1', ownerId: 'owner', revision: 1, state: 'active', package: routinePackage, validation: { status: 'incomplete', issues: [{ code: 'required_field', path: 'routine.name' }] }, createdAt: '2026-07-17T00:00:00.000Z', updatedAt: '2026-07-17T00:00:00.000Z' }; }
   async requestCheckNow() {}
   async updateRoutine(_routineId: string, _plan: MonitoringPlan) {}
   async savePushSubscription() {}
@@ -94,5 +97,7 @@ describe('repository factory', () => {
     expect(listener).toHaveBeenCalled();
     await expect(repository.inviteParticipantMember?.('participant-1', 'caregiver')).resolves.toMatchObject({ code: 'ZI-123456' });
     await expect(repository.createRelationshipRecovery?.('participant-1')).resolves.toMatchObject({ recoveryCode: 'PR-2345-6789-ABCD' });
+    expect(repository.listRoutineDrafts).toBeTypeOf('function');
+    await expect(repository.createRoutineDraft?.('participant-1', createBlankRoutinePackage('en', 'private-test'))).resolves.toMatchObject({ id: 'draft-1' });
   });
 });

--- a/src/services/repositoryFactory.ts
+++ b/src/services/repositoryFactory.ts
@@ -4,6 +4,7 @@ import { type AppPreferences, type Locale, type MembershipRole, type MonitoringP
 import { firebaseEnabled } from './firebaseConfig';
 import { isLocalDemoEnvironment } from './browserEnvironment';
 import { initialRemoteState } from './appStateDefaults';
+import type { RoutinePackageV1 } from '../domain/routineDraft';
 
 class LazyFirebaseRepository implements AppRepository {
   private delegate?: AppRepository;
@@ -128,6 +129,16 @@ class LazyFirebaseRepository implements AppRepository {
   async deleteRoutine(routineId: string) {
     return (await this.load()).deleteRoutine(routineId);
   }
+
+  async listRoutineDrafts(participantId: string) { const repository = await this.load(); if (!repository.listRoutineDrafts) throw new Error('routine_drafts_unavailable'); return repository.listRoutineDrafts(participantId); }
+  async createRoutineDraft(participantId: string, routinePackage: RoutinePackageV1) { const repository = await this.load(); if (!repository.createRoutineDraft) throw new Error('routine_drafts_unavailable'); return repository.createRoutineDraft(participantId, routinePackage); }
+  async updateRoutineDraft(participantId: string, draftId: string, expectedRevision: number, routinePackage: RoutinePackageV1) { const repository = await this.load(); if (!repository.updateRoutineDraft) throw new Error('routine_drafts_unavailable'); return repository.updateRoutineDraft(participantId, draftId, expectedRevision, routinePackage); }
+  async deleteRoutineDraft(participantId: string, draftId: string, expectedRevision: number) { const repository = await this.load(); if (!repository.deleteRoutineDraft) throw new Error('routine_drafts_unavailable'); return repository.deleteRoutineDraft(participantId, draftId, expectedRevision); }
+  async assignRoutineDraft(participantId: string, draftId: string, expectedRevision: number) { const repository = await this.load(); if (!repository.assignRoutineDraft) throw new Error('routine_drafts_unavailable'); return repository.assignRoutineDraft(participantId, draftId, expectedRevision); }
+  async publishRoutineDraft(participantId: string, draftId: string, expectedRevision: number) { const repository = await this.load(); if (!repository.publishRoutineDraft) throw new Error('routine_publication_unavailable'); return repository.publishRoutineDraft(participantId, draftId, expectedRevision); }
+  async listPublishedRoutineVersions(participantId: string) { const repository = await this.load(); if (!repository.listPublishedRoutineVersions) throw new Error('routine_publication_unavailable'); return repository.listPublishedRoutineVersions(participantId); }
+  async upgradeRoutineAssignment(participantId: string, routineId: string, targetVersion: number) { const repository = await this.load(); if (!repository.upgradeRoutineAssignment) throw new Error('routine_publication_unavailable'); return repository.upgradeRoutineAssignment(participantId, routineId, targetVersion); }
+  async createNextRoutineDraft(participantId: string, routineId: string, sourceVersion: number) { const repository = await this.load(); if (!repository.createNextRoutineDraft) throw new Error('routine_publication_unavailable'); return repository.createNextRoutineDraft(participantId, routineId, sourceVersion); }
 
   async requestCheckNow(routineId?: string) {
     return (await this.load()).requestCheckNow(routineId);


### PR DESCRIPTION
## Summary
- proxy all private routine draft, publication, and upgrade methods through the lazy Firebase repository
- restore the hidden private-draft library and editor actions in production
- add a regression test proving draft creation is available through the production repository factory
- bump the application version to 0.9.53

## Root cause
The production app injects `LazyFirebaseRepository` into React. Its interface had not been extended with the new optional routine methods, so App received undefined callbacks and intentionally hid the entire private-routine UI.

## Validation
- `corepack pnpm check`
- 277 web tests
- 69 Functions tests

Closes the production visibility regression reported after #147.