### PR TITLE
Add signed external routine registry cache

### DIFF
--- a/docs/external-routine-registry.md
+++ b/docs/external-routine-registry.md
@@ -1,0 +1,13 @@
+# External routine registry operations
+
+The external registry is optional. Installed assignments remain local snapshots and catalogue entries remain cached when synchronization fails.
+
+Configure `ROUTINE_REGISTRY_URL` with an HTTPS signed-index URL and `ROUTINE_REGISTRY_PUBLIC_KEYS` with a JSON object mapping key IDs to Ed25519 public keys. With either value absent, synchronization is disabled. The index and every package are bounded, packages require the Zadiag MIME type, HTTPS URLs, matching SHA-256 checksums, Package V1 validation, and matching routine IDs and versions.
+
+## Rotation and compromise recovery
+
+1. Add the new public key under a new key ID while the old key remains trusted.
+2. Publish and verify an index signed by the new key.
+3. Remove the old key after all deployments have received the new trust set.
+
+If a key or registry is compromised, remove its key or URL and redeploy. The next failed or disabled sync leaves the last-known-good cache and installed snapshots untouched. After publishing a clean index with a new key, re-enable synchronization; a successful full validation atomically revokes stale cached entries and replaces them. Check `routineRegistry/state` for `status`, `generatedAt`, `syncedAt`, and the last bounded error. Never restore cached data without re-running signature, checksum, schema, MIME, URL, size, and provenance validation.

--- a/functions/src/externalRoutineRegistry.test.ts
+++ b/functions/src/externalRoutineRegistry.test.ts
@@ -1,0 +1,11 @@
+import assert from 'node:assert/strict';
+import { generateKeyPairSync, sign } from 'node:crypto';
+import test from 'node:test';
+import { assertExternalPackageResponse, sha256Hex, verifyExternalRegistryIndex } from './externalRoutineRegistry.js';
+
+const keys = generateKeyPairSync('ed25519');
+const payload = JSON.stringify({ format: 'zadiag-routine-registry', version: 1, generatedAt: '2026-07-17T12:00:00.000Z', entries: [{ id: 'safe-routine', version: 1, packageUrl: 'https://registry.example/routine.json', sha256: 'a'.repeat(64), authorName: 'Publisher', license: 'CC-BY-4.0' }] });
+const index = (value = payload, keyId = 'current') => JSON.stringify({ keyId, payload: value, signature: sign(null, Buffer.from(value), keys.privateKey).toString('base64') });
+test('accepts a signed versioned index and supports key rotation', () => { assert.equal(verifyExternalRegistryIndex(index(), { current: keys.publicKey.export({ type: 'spki', format: 'pem' }).toString() }).entries[0].id, 'safe-routine'); });
+test('rejects tampering, unknown keys, insecure URLs and unsupported versions', () => { const pem = keys.publicKey.export({ type: 'spki', format: 'pem' }).toString(); const tampered = JSON.parse(index()); tampered.payload += ' '; assert.throws(() => verifyExternalRegistryIndex(JSON.stringify(tampered), { current: pem })); assert.throws(() => verifyExternalRegistryIndex(index(payload, 'old'), { current: pem })); for (const replacement of ['http://registry.example/routine.json', 'javascript:alert(1)']) { const changed = payload.replace('https://registry.example/routine.json', replacement); assert.throws(() => verifyExternalRegistryIndex(index(changed), { current: pem })); } assert.throws(() => verifyExternalRegistryIndex(index(payload.replace('"version":1', '"version":2')), { current: pem })); });
+test('verifies package MIME, size and checksum', () => { const content = '{}'; assert.doesNotThrow(() => assertExternalPackageResponse(content, 'application/vnd.zadiag.routine+json', sha256Hex(content))); assert.throws(() => assertExternalPackageResponse(content, 'text/html', sha256Hex(content))); assert.throws(() => assertExternalPackageResponse(content, 'application/vnd.zadiag.routine+json', '0'.repeat(64))); });

--- a/functions/src/externalRoutineRegistry.ts
+++ b/functions/src/externalRoutineRegistry.ts
@@ -1,0 +1,40 @@
+import { createHash, verify } from 'node:crypto';
+import { z } from 'zod';
+
+export const EXTERNAL_REGISTRY_MAX_INDEX_BYTES = 256 * 1024;
+export const EXTERNAL_REGISTRY_MAX_PACKAGE_BYTES = 96 * 1024;
+
+const entrySchema = z.strictObject({
+  id: z.string().regex(/^[a-z0-9]+(?:-[a-z0-9]+)*$/).max(80),
+  version: z.number().int().positive(),
+  packageUrl: z.string().url().refine((value) => new URL(value).protocol === 'https:'),
+  sha256: z.string().regex(/^[a-f0-9]{64}$/),
+  authorName: z.string().min(1).max(120),
+  license: z.string().min(1).max(80),
+});
+const payloadSchema = z.strictObject({ format: z.literal('zadiag-routine-registry'), version: z.literal(1), generatedAt: z.iso.datetime(), entries: z.array(entrySchema).max(200) });
+const signedIndexSchema = z.strictObject({ keyId: z.string().min(1).max(80), payload: z.string(), signature: z.string().base64() });
+export type ExternalRegistryPayload = z.infer<typeof payloadSchema>;
+
+export const sha256Hex = (content: string) => createHash('sha256').update(content, 'utf8').digest('hex');
+
+export const verifyExternalRegistryIndex = (content: string, publicKeys: Record<string, string>): ExternalRegistryPayload => {
+  if (Buffer.byteLength(content, 'utf8') > EXTERNAL_REGISTRY_MAX_INDEX_BYTES) throw new Error('registry_index_too_large');
+  let input: unknown;
+  try { input = JSON.parse(content); } catch { throw new Error('registry_index_invalid'); }
+  const signed = signedIndexSchema.safeParse(input);
+  if (!signed.success) throw new Error('registry_index_invalid');
+  const publicKey = publicKeys[signed.data.keyId];
+  if (!publicKey || !verify(null, Buffer.from(signed.data.payload), publicKey, Buffer.from(signed.data.signature, 'base64'))) throw new Error('registry_signature_invalid');
+  let payload: unknown;
+  try { payload = JSON.parse(signed.data.payload); } catch { throw new Error('registry_payload_invalid'); }
+  const parsed = payloadSchema.safeParse(payload);
+  if (!parsed.success || new Set(parsed.data.entries.map((entry) => `${entry.id}:${entry.version}`)).size !== parsed.data.entries.length) throw new Error('registry_payload_invalid');
+  return parsed.data;
+};
+
+export const assertExternalPackageResponse = (content: string, contentType: string | null, expectedSha256: string) => {
+  if (contentType?.split(';')[0] !== 'application/vnd.zadiag.routine+json') throw new Error('registry_package_mime_invalid');
+  if (Buffer.byteLength(content, 'utf8') > EXTERNAL_REGISTRY_MAX_PACKAGE_BYTES) throw new Error('registry_package_too_large');
+  if (sha256Hex(content) !== expectedSha256) throw new Error('registry_package_checksum_invalid');
+};

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -20,6 +20,7 @@ import { shouldRecoverSyntheticPush } from './syntheticMonitor.js';
 import { canLeaveMembership, canRemoveMembership, createMembership, hasParticipantPermission, isCompatibleLegacyContentTarget, isCompatibleMembershipMigration, isCompatibleParticipantMigration, isCompatibleParticipantRefMigration, isProfileColorKey, membershipRoles, migrateLegacyFamilyRelationships, scheduledAggregatePaths, type MembershipRole } from './relationships.js';
 import { assertRoutineDraftRevision, createRoutineDraftDocument, RoutineDraftConflictError, RoutineDraftInputError, updateRoutineDraftDocument, type PublishedRoutineVersionDocument, type RoutineDraftDocument } from './routineDrafts.js';
 import { ROUTINE_PACKAGE_MIME, parseRoutinePackageEnvelope, serializeRoutinePackage } from './routinePackages.js';
+import { assertExternalPackageResponse, verifyExternalRegistryIndex } from './externalRoutineRegistry.js';
 
 const storageBucket = process.env.FIREBASE_STORAGE_BUCKET
   ?? (process.env.GCLOUD_PROJECT ? `${process.env.GCLOUD_PROJECT}.firebasestorage.app` : undefined);
@@ -46,6 +47,42 @@ const cors = [
   'http://localhost:5173',
   /^http:\/\/localhost:\d+$/,
 ];
+
+const syncExternalRoutineRegistryCache = async () => {
+  const registryUrl = process.env.ROUTINE_REGISTRY_URL;
+  const publicKeys = JSON.parse(process.env.ROUTINE_REGISTRY_PUBLIC_KEYS ?? '{}') as Record<string, string>;
+  if (!registryUrl || new URL(registryUrl).protocol !== 'https:' || !Object.keys(publicKeys).length) return { status: 'disabled' as const };
+  try {
+    const indexResponse = await fetch(registryUrl, { signal: AbortSignal.timeout(10_000) });
+    if (!indexResponse.ok) throw new Error(`registry_http_${indexResponse.status}`);
+    const payload = verifyExternalRegistryIndex(await indexResponse.text(), publicKeys);
+    const resolved = await Promise.all(payload.entries.map(async (entry) => {
+      const response = await fetch(entry.packageUrl, { signal: AbortSignal.timeout(10_000) });
+      if (!response.ok) throw new Error(`registry_package_http_${response.status}`);
+      const content = await response.text();
+      assertExternalPackageResponse(content, response.headers.get('content-type'), entry.sha256);
+      const envelope = parseRoutinePackageEnvelope(content, ROUTINE_PACKAGE_MIME);
+      if (envelope.package.routine.id !== entry.id || envelope.package.version !== entry.version) throw new Error('registry_package_provenance_invalid');
+      return { entry, package: envelope.package };
+    }));
+    const now = new Date().toISOString();
+    const previous = await db.collection('routineCatalogEntries').where('source', '==', 'external').get();
+    const batch = db.batch();
+    previous.docs.forEach((doc) => batch.update(doc.ref, { revokedAt: now, visibility: 'unlisted' }));
+    resolved.forEach(({ entry, package: routinePackage }) => {
+      const id = `external-${hashLinkCode(`${entry.id}:${entry.version}`)}`;
+      batch.set(db.collection('routineCatalogEntries').doc(id), { source: 'external', ownerId: 'external-registry', authorName: entry.authorName, routineId: entry.id, version: entry.version, visibility: 'listed', package: routinePackage, publishedAt: payload.generatedAt, sharedAt: now, license: entry.license, registryUrl, checksum: entry.sha256 });
+    });
+    batch.set(db.collection('routineRegistry').doc('state'), { status: 'healthy', registryUrl, generatedAt: payload.generatedAt, syncedAt: now, entries: resolved.length });
+    await batch.commit();
+    return { status: 'healthy' as const, entries: resolved.length };
+  } catch (error) {
+    await db.collection('routineRegistry').doc('state').set({ status: 'degraded', lastAttemptAt: new Date().toISOString(), error: error instanceof Error ? error.message.slice(0, 160) : 'unknown' }, { merge: true });
+    throw error;
+  }
+};
+
+export const syncExternalRoutineRegistry = onSchedule({ region, schedule: 'every 6 hours', timeoutSeconds: 300 }, async () => { await syncExternalRoutineRegistryCache(); });
 
 interface RoutineNotificationNames {
   routineName: string;
@@ -2212,6 +2249,9 @@ const publicCatalogEntry = (id: string, data: FirebaseFirestore.DocumentData) =>
   package: data.package,
   publishedAt: data.publishedAt,
   sharedAt: data.sharedAt,
+  source: data.source,
+  license: data.license,
+  checksum: data.checksum,
 });
 
 export const searchRoutineCatalog = onCall({ region, cors, enforceAppCheck: true }, async (request) => {
@@ -2220,6 +2260,12 @@ export const searchRoutineCatalog = onCall({ region, cors, enforceAppCheck: true
   const snapshot = await db.collection('routineCatalogEntries').where('visibility', '==', 'listed').limit(100).get();
   const entries = snapshot.docs.filter((doc) => !doc.data().revokedAt).map((doc) => publicCatalogEntry(doc.id, doc.data())).filter((entry) => !query || JSON.stringify(entry).toLocaleLowerCase().includes(query)).slice(0, 30);
   return { entries };
+});
+
+export const getExternalRoutineRegistryStatus = onCall({ region, cors, enforceAppCheck: true }, async (request) => {
+  await requireUid(request.auth);
+  const state = await db.collection('routineRegistry').doc('state').get();
+  return state.exists ? state.data() : { status: process.env.ROUTINE_REGISTRY_URL ? 'pending' : 'disabled' };
 });
 
 export const resolveSharedRoutine = onCall({ region, cors, enforceAppCheck: true }, async (request) => {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zadiag-pwa",
   "private": true,
-  "version": "0.9.55",
+  "version": "0.9.56",
   "type": "module",
   "packageManager": "pnpm@11.7.0",
   "engines": {

--- a/src/domain/routineDraft.ts
+++ b/src/domain/routineDraft.ts
@@ -35,6 +35,7 @@ export interface PublishedRoutineVersion {
 }
 export interface RoutineCatalogEntry extends PublishedRoutineVersion {
   id: string; routineId: string; authorName: string; visibility: 'listed' | 'unlisted'; sharedAt: string; revokedAt?: string;
+  source?: 'external'; license?: string; checksum?: string;
 }
 
 export const DEFAULT_PRIVATE_ROUTINE_ACCENT = '#2563EB';


### PR DESCRIPTION
## Summary
- verify versioned Ed25519-signed registry indexes with rotatable trust keys
- verify HTTPS package URLs, MIME, size, SHA-256, schema and provenance before caching
- atomically retain the last-known-good catalogue when any sync input fails
- expose bounded health state and document rotation and compromise recovery

## Validation
- `npm run check`
- registry signature, tamper, URL, version, MIME, size and checksum tests

Closes #150.