### PR TITLE
Add AI authoring safety controls

### DIFF
--- a/docs/ai-authoring-controls.md
+++ b/docs/ai-authoring-controls.md
@@ -1,0 +1,11 @@
+# AI authoring controls
+
+AI-assisted authoring is optional and separate from proof analysis. Both authoring capabilities default to disabled. The existing private routine editor and manual translation workflow remain canonical and require no provider.
+
+`AI_AUTHORING_CONFIG` is a server environment JSON value with `globalEnabled`, a non-empty `privacyApprovalId`, and per-capability booleans for `prescriptionExtraction` and `routineTranslation`. All three conditions must be true before the reusable server guard permits a capability. Missing or malformed configuration fails closed. Production configuration must remain disabled until #167 records privacy and regulatory approval.
+
+The server registry pins provider, model and prompt versions. Operational metrics may contain only capability, bounded status/latency, provider, model and prompt version. They must never contain prompts, outputs, prescriptions, routine text, participant data or proofs.
+
+Every future provider call must invoke the guard before preparing provider input, validate output server-side, and store suggestions only as `pending_human_review` drafts with publishing, assignment and activation disabled. Provider failure, invalid output or a kill switch returns the user to the existing manual workflow without modifying their draft.
+
+Emergency shutdown: set `globalEnabled` to false or remove `AI_AUTHORING_CONFIG`, deploy Functions, verify `getAiAuthoringCapabilities` reports both capabilities disabled, and confirm manual draft creation/editing still passes its smoke test.

--- a/functions/src/aiAuthoring.test.ts
+++ b/functions/src/aiAuthoring.test.ts
@@ -1,0 +1,22 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { AiAuthoringDisabledError, aiAuthoringCapabilityEnabled, aiAuthoringMetric, parseAiAuthoringConfig, requireAiAuthoringCapability, unapprovedAiDraft } from './aiAuthoring.js';
+
+test('defaults every provider path to disabled and requires privacy approval', () => {
+  assert.equal(aiAuthoringCapabilityEnabled(undefined, 'routineTranslation'), false);
+  assert.equal(aiAuthoringCapabilityEnabled({ globalEnabled: true, capabilities: { routineTranslation: true } }, 'routineTranslation'), false);
+  assert.throws(() => requireAiAuthoringCapability({ globalEnabled: false, privacyApprovalId: 'approval', capabilities: { routineTranslation: true } }, 'routineTranslation'), AiAuthoringDisabledError);
+  assert.equal(requireAiAuthoringCapability({ globalEnabled: true, privacyApprovalId: 'approval-1', capabilities: { routineTranslation: true } }, 'routineTranslation').promptVersion, 'routine-translation-v1');
+});
+
+test('fails closed on malformed configuration', () => { assert.deepEqual(parseAiAuthoringConfig('{'), {}); assert.deepEqual(parseAiAuthoringConfig(undefined), {}); });
+
+test('keeps AI output pending review and impossible to publish assign or activate', () => {
+  const draft = unapprovedAiDraft('routineTranslation', { name: 'Suggestion' });
+  assert.equal(draft.approvalStatus, 'pending_human_review'); assert.equal(draft.publishable, false); assert.equal(draft.assignable, false); assert.equal(draft.activatable, false);
+});
+
+test('records only bounded operational dimensions', () => {
+  assert.deepEqual(Object.keys(aiAuthoringMetric('prescriptionExtraction', 'provider_failure', 999_999)).sort(), ['capability', 'latencyMs', 'model', 'promptVersion', 'provider', 'status']);
+  assert.equal(aiAuthoringMetric('prescriptionExtraction', 'invalid_output', 999_999).latencyMs, 120_000);
+});

--- a/functions/src/aiAuthoring.ts
+++ b/functions/src/aiAuthoring.ts
@@ -1,0 +1,45 @@
+export type AiAuthoringCapability = 'prescriptionExtraction' | 'routineTranslation';
+export type AiAuthoringMetricStatus = 'success' | 'provider_failure' | 'invalid_output' | 'disabled';
+
+export interface AiAuthoringControlConfig {
+  globalEnabled?: boolean;
+  privacyApprovalId?: string;
+  capabilities?: Partial<Record<AiAuthoringCapability, boolean>>;
+}
+
+export const aiAuthoringRegistry = {
+  prescriptionExtraction: { provider: 'gemini', model: 'gemini-2.5-flash', promptVersion: 'prescription-extraction-v1' },
+  routineTranslation: { provider: 'gemini', model: 'gemini-2.5-flash', promptVersion: 'routine-translation-v1' },
+} as const;
+
+export class AiAuthoringDisabledError extends Error { constructor() { super('ai_authoring_disabled'); } }
+
+export const aiAuthoringCapabilityEnabled = (config: AiAuthoringControlConfig | undefined, capability: AiAuthoringCapability) => Boolean(
+  config?.globalEnabled && config.privacyApprovalId?.trim() && config.capabilities?.[capability],
+);
+
+export const requireAiAuthoringCapability = (config: AiAuthoringControlConfig | undefined, capability: AiAuthoringCapability) => {
+  if (!aiAuthoringCapabilityEnabled(config, capability)) throw new AiAuthoringDisabledError();
+  return aiAuthoringRegistry[capability];
+};
+
+export const parseAiAuthoringConfig = (raw: string | undefined): AiAuthoringControlConfig => {
+  if (!raw) return {};
+  try {
+    const value = JSON.parse(raw) as AiAuthoringControlConfig;
+    return typeof value === 'object' && value !== null ? value : {};
+  } catch { return {}; }
+};
+
+export const aiAuthoringMetric = (capability: AiAuthoringCapability, status: AiAuthoringMetricStatus, latencyMs: number) => ({
+  capability,
+  status,
+  latencyMs: Number.isFinite(latencyMs) ? Math.max(0, Math.min(120_000, Math.round(latencyMs))) : 0,
+  provider: aiAuthoringRegistry[capability].provider,
+  model: aiAuthoringRegistry[capability].model,
+  promptVersion: aiAuthoringRegistry[capability].promptVersion,
+});
+
+export const unapprovedAiDraft = <T>(capability: AiAuthoringCapability, output: T) => ({
+  capability, output, approvalStatus: 'pending_human_review' as const, publishable: false as const, assignable: false as const, activatable: false as const,
+});

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -22,6 +22,7 @@ import { assertRoutineDraftRevision, createRoutineDraftDocument, RoutineDraftCon
 import { ROUTINE_PACKAGE_MIME, parseRoutinePackageEnvelope, serializeRoutinePackage } from './routinePackages.js';
 import { assertExternalPackageResponse, verifyExternalRegistryIndex } from './externalRoutineRegistry.js';
 import { marketplaceEntryInstallable, marketplaceRole, moderateMarketplaceStatus, type ModerationAction, type ModerationStatus } from './routineMarketplaceGovernance.js';
+import { aiAuthoringCapabilityEnabled, aiAuthoringRegistry, parseAiAuthoringConfig } from './aiAuthoring.js';
 
 const storageBucket = process.env.FIREBASE_STORAGE_BUCKET
   ?? (process.env.GCLOUD_PROJECT ? `${process.env.GCLOUD_PROJECT}.firebasestorage.app` : undefined);
@@ -2269,6 +2270,16 @@ export const getExternalRoutineRegistryStatus = onCall({ region, cors, enforceAp
   await requireUid(request.auth);
   const state = await db.collection('routineRegistry').doc('state').get();
   return state.exists ? state.data() : { status: process.env.ROUTINE_REGISTRY_URL ? 'pending' : 'disabled' };
+});
+
+export const getAiAuthoringCapabilities = onCall({ region, cors, enforceAppCheck: true }, async (request) => {
+  await requireUid(request.auth);
+  const config = parseAiAuthoringConfig(process.env.AI_AUTHORING_CONFIG);
+  return {
+    prescriptionExtraction: { enabled: aiAuthoringCapabilityEnabled(config, 'prescriptionExtraction'), promptVersion: aiAuthoringRegistry.prescriptionExtraction.promptVersion },
+    routineTranslation: { enabled: aiAuthoringCapabilityEnabled(config, 'routineTranslation'), promptVersion: aiAuthoringRegistry.routineTranslation.promptVersion },
+    manualFallback: true,
+  };
 });
 
 export const resolveSharedRoutine = onCall({ region, cors, enforceAppCheck: true }, async (request) => {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zadiag-pwa",
   "private": true,
-  "version": "0.9.57",
+  "version": "0.9.58",
   "type": "module",
   "packageManager": "pnpm@11.7.0",
   "engines": {


### PR DESCRIPTION
## Summary
- add server-side provider/model/prompt registry for isolated AI authoring capabilities
- enforce global, per-capability and privacy-approval gates that default disabled
- constrain operational metrics to bounded non-sensitive dimensions
- mark every future output as pending human review and non-publishable/non-assignable

## Validation
- `npm run check`
- disabled path, malformed config, bypass and output-state tests

Closes #166.