### PR TITLE
Enforce AI authoring readiness approval

### DIFF
--- a/docs/ai-authoring-controls.md
+++ b/docs/ai-authoring-controls.md
@@ -2,7 +2,7 @@
 
 AI-assisted authoring is optional and separate from proof analysis. Both authoring capabilities default to disabled. The existing private routine editor and manual translation workflow remain canonical and require no provider.
 
-`AI_AUTHORING_CONFIG` is a server environment JSON value with `globalEnabled`, a non-empty `privacyApprovalId`, and per-capability booleans for `prescriptionExtraction` and `routineTranslation`. All three conditions must be true before the reusable server guard permits a capability. Missing or malformed configuration fails closed. Production configuration must remain disabled until #167 records privacy and regulatory approval.
+`AI_AUTHORING_CONFIG` is a server environment JSON value with `globalEnabled`, per-capability booleans, and a scoped approval record. The approval must be `approved`, name the DPO/privacy, legal/regulatory and security approvers, identify the provider contract and data residency, include the capability, and be within its approval/expiry dates. Missing, malformed, incomplete, out-of-scope or expired records fail closed.
 
 The server registry pins provider, model and prompt versions. Operational metrics may contain only capability, bounded status/latency, provider, model and prompt version. They must never contain prompts, outputs, prescriptions, routine text, participant data or proofs.
 

--- a/docs/ai-authoring-privacy-readiness.md
+++ b/docs/ai-authoring-privacy-readiness.md
@@ -1,0 +1,64 @@
+# AI authoring privacy and regulatory readiness gate
+
+Status: **NOT APPROVED — all production provider paths must remain disabled.**
+
+Last engineering review: 2026-07-18. This is a readiness checklist, not legal advice, an AIPD, an HDS certification, or a medical-device classification decision.
+
+## Processing scope and boundaries
+
+| Capability | Data considered | Purpose | Prohibited use | Proposed maximum retention |
+| --- | --- | --- | --- | --- |
+| Prescription extraction | Explicitly consented prescription image and bounded extracted fields | Prepare an editable private draft for human transcription | Diagnosis, prescription validation, dose calculation, treatment substitution, publishing, assignment, training | Original: deletion on confirm/cancel and hard maximum 24 hours; derived extraction: deletion after copy/cancel and hard maximum 7 days |
+| Routine translation | User-selected private routine text | Suggest a reviewable translation diff | Silent replacement, publishing, assignment, participant/proof/prescription processing, training | Provider payload/output transient and hard maximum 24 hours; only explicitly approved text becomes ordinary private draft content |
+
+Data controller, processors/subprocessors, lawful basis under GDPR Article 6, special-category condition under Article 9, contractual purpose limitation, transfer mechanism and exact retention jobs remain **undecided**. Consent UX alone is not treated as sufficient legal approval.
+
+## Mandatory decisions before approval
+
+- DPO/privacy owner completes and signs an AIPD covering necessity, proportionality, data flows, rights, security risks, minors/participants and residual risk. CNIL explains that an AIPD is required for processing likely to create high risk and specifically discusses AI documentation.
+- Legal owner records the Article 6 and Article 9 bases, controller/processor roles, Article 28 terms, subprocessors, international transfers and data-subject request handling.
+- Security owner verifies encryption, tenant isolation, access logging, deletion evidence, incident notification, prompt/output logging disabled, no provider training, and EU/approved residency.
+- Hosting owner determines the exact HDS scope and provides evidence that every relevant hosting/provider activity meets the current HDS V2 requirements before prescription data leaves the approved boundary.
+- Regulatory owner documents the intended purpose and obtains a qualified decision on MDR and AI Act classification. Product copy and behavior must preserve the non-diagnostic, preparatory, mandatory-human-review boundary.
+- Product owner validates explicit scoped consent, withdrawal, manual fallback and user information in French and English.
+
+## Approval record enforced by Functions
+
+Production activation requires an `AI_AUTHORING_CONFIG.approval` record containing an ID, `approved` status, approval and expiry timestamps, named DPO, legal and security approvers, provider contract identifier, data residency, and exact approved capabilities. The server rejects missing names, expired records and capability mismatch even when kill switches are enabled.
+
+Example structure (not an approval):
+
+```json
+{
+  "globalEnabled": false,
+  "capabilities": { "prescriptionExtraction": false, "routineTranslation": false },
+  "approval": {
+    "id": "REPLACE_AFTER_FORMAL_REVIEW",
+    "status": "pending",
+    "approvedAt": "",
+    "expiresAt": "",
+    "dpoApprovedBy": "",
+    "legalApprovedBy": "",
+    "securityApprovedBy": "",
+    "provider": "",
+    "dataResidency": "",
+    "capabilities": []
+  }
+}
+```
+
+## Rights, withdrawal and deletion acceptance
+
+Before activation, implementation must prove access/information, correction during review, deletion, consent withdrawal without loss of manual drafts, export where applicable, and bounded non-sensitive deletion receipts. A withdrawal immediately blocks new provider calls and deletes pending original/derived prescription data. Provider unavailability or contract termination invokes the same kill switch and deletion procedure.
+
+## Official references reviewed
+
+- [CNIL — AIPD](https://www.cnil.fr/fr/RGPD-analyse-impact-protection-des-donnees-aipd)
+- [CNIL — IA : réaliser une analyse d’impact si nécessaire](https://www.cnil.fr/fr/realiser-une-analyse-dimpact-si-necessaire)
+- [ANS — référentiels de certification HDS](https://esante.gouv.fr/services/hebergeurs-de-donnees-de-sante/les-referentiels-de-la-procedure-de-certification)
+- [Règlement européen sur l’IA 2024/1689](https://eur-lex.europa.eu/eli/reg/2024/1689/oj?locale=fr)
+- [Règlement européen relatif aux dispositifs médicaux 2017/745](https://eur-lex.europa.eu/eli/reg/2017/745/oj?locale=fr)
+
+## Exit criteria
+
+This document may move to **APPROVED** only when the decisions and evidence above are linked, the named approval record is reviewed, deletion/security tests pass, and a production smoke test first confirms both capabilities disabled. Approval is capability-specific; translation approval cannot activate prescription extraction.

--- a/functions/src/aiAuthoring.test.ts
+++ b/functions/src/aiAuthoring.test.ts
@@ -1,12 +1,22 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
-import { AiAuthoringDisabledError, aiAuthoringCapabilityEnabled, aiAuthoringMetric, parseAiAuthoringConfig, requireAiAuthoringCapability, unapprovedAiDraft } from './aiAuthoring.js';
+import { AiAuthoringDisabledError, aiAuthoringApprovalValid, aiAuthoringCapabilityEnabled, aiAuthoringMetric, parseAiAuthoringConfig, requireAiAuthoringCapability, unapprovedAiDraft } from './aiAuthoring.js';
+
+const approval = { id: 'approval-1', status: 'approved' as const, approvedAt: '2026-07-01T00:00:00.000Z', expiresAt: '2027-01-01T00:00:00.000Z', dpoApprovedBy: 'DPO Name', legalApprovedBy: 'Legal Name', securityApprovedBy: 'Security Name', provider: 'provider-contract-1', dataResidency: 'eu', capabilities: ['routineTranslation' as const] };
 
 test('defaults every provider path to disabled and requires privacy approval', () => {
   assert.equal(aiAuthoringCapabilityEnabled(undefined, 'routineTranslation'), false);
   assert.equal(aiAuthoringCapabilityEnabled({ globalEnabled: true, capabilities: { routineTranslation: true } }, 'routineTranslation'), false);
-  assert.throws(() => requireAiAuthoringCapability({ globalEnabled: false, privacyApprovalId: 'approval', capabilities: { routineTranslation: true } }, 'routineTranslation'), AiAuthoringDisabledError);
-  assert.equal(requireAiAuthoringCapability({ globalEnabled: true, privacyApprovalId: 'approval-1', capabilities: { routineTranslation: true } }, 'routineTranslation').promptVersion, 'routine-translation-v1');
+  assert.throws(() => requireAiAuthoringCapability({ globalEnabled: false, approval, capabilities: { routineTranslation: true } }, 'routineTranslation'), AiAuthoringDisabledError);
+  assert.equal(requireAiAuthoringCapability({ globalEnabled: true, approval, capabilities: { routineTranslation: true } }, 'routineTranslation').promptVersion, 'routine-translation-v1');
+});
+
+test('requires named unexpired approvals scoped to the capability', () => {
+  const now = new Date('2026-07-18T00:00:00.000Z');
+  assert.equal(aiAuthoringApprovalValid({ approval }, 'routineTranslation', now), true);
+  assert.equal(aiAuthoringApprovalValid({ approval }, 'prescriptionExtraction', now), false);
+  assert.equal(aiAuthoringApprovalValid({ approval: { ...approval, dpoApprovedBy: '' } }, 'routineTranslation', now), false);
+  assert.equal(aiAuthoringApprovalValid({ approval: { ...approval, expiresAt: '2026-07-17T00:00:00.000Z' } }, 'routineTranslation', now), false);
 });
 
 test('fails closed on malformed configuration', () => { assert.deepEqual(parseAiAuthoringConfig('{'), {}); assert.deepEqual(parseAiAuthoringConfig(undefined), {}); });

--- a/functions/src/aiAuthoring.ts
+++ b/functions/src/aiAuthoring.ts
@@ -3,8 +3,19 @@ export type AiAuthoringMetricStatus = 'success' | 'provider_failure' | 'invalid_
 
 export interface AiAuthoringControlConfig {
   globalEnabled?: boolean;
-  privacyApprovalId?: string;
   capabilities?: Partial<Record<AiAuthoringCapability, boolean>>;
+  approval?: {
+    id?: string;
+    status?: 'approved' | 'rejected' | 'pending';
+    approvedAt?: string;
+    expiresAt?: string;
+    dpoApprovedBy?: string;
+    legalApprovedBy?: string;
+    securityApprovedBy?: string;
+    provider?: string;
+    dataResidency?: string;
+    capabilities?: AiAuthoringCapability[];
+  };
 }
 
 export const aiAuthoringRegistry = {
@@ -14,8 +25,19 @@ export const aiAuthoringRegistry = {
 
 export class AiAuthoringDisabledError extends Error { constructor() { super('ai_authoring_disabled'); } }
 
-export const aiAuthoringCapabilityEnabled = (config: AiAuthoringControlConfig | undefined, capability: AiAuthoringCapability) => Boolean(
-  config?.globalEnabled && config.privacyApprovalId?.trim() && config.capabilities?.[capability],
+const nonEmpty = (value: unknown) => typeof value === 'string' && value.trim().length > 0;
+
+export const aiAuthoringApprovalValid = (config: AiAuthoringControlConfig | undefined, capability: AiAuthoringCapability, now = new Date()) => {
+  const approval = config?.approval;
+  if (!approval || approval.status !== 'approved' || !approval.capabilities?.includes(capability)) return false;
+  if (![approval.id, approval.dpoApprovedBy, approval.legalApprovedBy, approval.securityApprovedBy, approval.provider, approval.dataResidency].every(nonEmpty)) return false;
+  const approvedAt = Date.parse(String(approval.approvedAt));
+  const expiresAt = Date.parse(String(approval.expiresAt));
+  return Number.isFinite(approvedAt) && Number.isFinite(expiresAt) && approvedAt <= now.getTime() && expiresAt > now.getTime();
+};
+
+export const aiAuthoringCapabilityEnabled = (config: AiAuthoringControlConfig | undefined, capability: AiAuthoringCapability, now = new Date()) => Boolean(
+  config?.globalEnabled && config.capabilities?.[capability] && aiAuthoringApprovalValid(config, capability, now),
 );
 
 export const requireAiAuthoringCapability = (config: AiAuthoringControlConfig | undefined, capability: AiAuthoringCapability) => {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zadiag-pwa",
   "private": true,
-  "version": "0.9.58",
+  "version": "0.9.59",
   "type": "module",
   "packageManager": "pnpm@11.7.0",
   "engines": {


### PR DESCRIPTION
## Summary
- require named DPO, legal and security approval records scoped by capability and expiry
- fail closed for incomplete, expired or mismatched readiness evidence
- document GDPR/AIPD, HDS, retention, deletion, transfer and regulatory decisions required before activation
- keep the readiness status explicitly not approved and all provider paths disabled

## Validation
- `npm run check`
- named approval, scope and expiry gate tests

Implements the technical readiness gate for #167; formal human approval remains outstanding.