### PR TITLE
Define operational alert thresholds and ownership

### DIFF
--- a/docs/pilot-support-incident-playbook.md
+++ b/docs/pilot-support-incident-playbook.md
@@ -27,6 +27,79 @@ identifiers into the working notes.
 
 These are pilot operating targets, not contractual service-level guarantees.
 
+## Operational alert definitions
+
+The [canonical alert definitions](../functions/src/observability.ts) are the
+source for thresholds, owner roles, recovery windows, deduplication keys, and
+runbook links. Before a pilot
+starts, each owner role below must be assigned to a named primary and deputy in
+the private on-call rota. Configure log-based policies from `operational_alert`
+records, group incidents by `dedupeKey`, and route them to that role. A matching
+`operational_recovery` record uses the same key; close the incident only after
+the configured recovery window remains healthy.
+
+| Signal | Threshold | Severity | Owner role | Healthy recovery |
+| --- | --- | --- | --- | --- |
+| Push dispatch failure | 5 failures in 10 minutes | SEV-2 | `pilot-operations` | Successful dispatches for 15 minutes |
+| Invalid push subscription | 10 invalidations in 60 minutes | SEV-3 | `pilot-operations` | No invalidation for 60 minutes |
+| Synthetic push not confirmed | 2 failures in 20 minutes | SEV-2 | `pilot-operations` | Received/opened receipt for 20 minutes |
+| Scheduled check dispatch | 1 failed run in 10 minutes | SEV-2 | `backend-operations` | Successful run for 10 minutes |
+| Analysis failure | 3 failures in 15 minutes | SEV-2 | `ai-reliability` | Successful AI analysis for 15 minutes |
+| Proof cleanup failure | 1 failure in 30 minutes | SEV-2 | `privacy-operations` | Successful cleanup for 30 minutes |
+| App Check rejection | 20 rejected requests in 10 minutes | SEV-2 | `security-operations` | Rejections below threshold for 20 minutes |
+
+App Check rejects requests before callable code executes. Its policy therefore
+uses the Firebase/App Check platform rejection logs and attaches the canonical
+`app_check_rejected` definition when notifying the security owner. It must not
+copy request bodies, tokens, participant identifiers, or proof data.
+
+### Push delivery
+
+Inspect the dispatch summary and provider status. Remove invalid subscriptions
+only through the existing invalidation path; do not copy push endpoints into an
+incident record. Confirm recovery with a synthetic dispatch.
+
+### Synthetic monitor
+
+Check the last expected and received synthetic receipt timestamps. A received
+or opened synthetic receipt emits recovery without participant or proof
+content. Ask the test device to renew its subscription if the heartbeat says so.
+
+### Scheduled jobs
+
+Inspect the scheduler summary and distinguish an invalid plan from an aggregate
+or transaction failure. Re-run only with synthetic data after correcting the
+cause; confirm that the next summary has no failures or invalid plans.
+
+### Analysis
+
+The user flow falls back to responsible-person review when analysis is
+unavailable. Verify provider availability and configuration without inspecting
+the submitted proof. Recovery requires a successful AI-backed analysis, not a
+self-validation or fallback result.
+
+### Proof cleanup
+
+Treat retained proof as a privacy incident until scoped. Confirm the storage
+deletion and Firestore metadata cleanup using synthetic data, then verify a
+successful scheduled cleanup run.
+
+### App Check
+
+Separate a release/configuration regression from abusive traffic using only
+aggregate platform logs. Roll back a bad enforcement/configuration change or
+contain abusive traffic, then observe the threshold for 20 minutes.
+
+### Test alert
+
+An authenticated account with the custom claim `operationsRole=operator` (or
+`admin`) can call `triggerOperationalTestAlert` with `{}` to emit an alert and
+with `{ "phase": "recovery" }` to emit its correlated recovery. The payload
+contains only `source=manual_test`, static routing metadata, and the
+`operational:operational_test` deduplication key. Run this drill before the
+pilot and after notification routing changes; remove the temporary claim when
+the operator does not otherwise need it.
+
 ## Incident procedure
 
 1. Assign an incident owner and record start time, deployed version, reporter

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -15,7 +15,7 @@ import { buildCheckNotificationPayload, buildReviewNotificationPayload, buildTes
 import { isCheckRequestRateLimited } from './reminders.js';
 import { recordAuditEvent, recordJourneyEvent, type JourneyStage } from './audit.js';
 import { expiredPendingCheckCleanupUpdate, shouldDeleteProofAfterReview, staleCleanupCutoffs } from './cleanup.js';
-import { reportOperationalAlert, reportOperationalEvent } from './observability.js';
+import { reportOperationalAlert, reportOperationalEvent, reportOperationalRecovery } from './observability.js';
 import { shouldRecoverSyntheticPush } from './syntheticMonitor.js';
 import { canLeaveMembership, canRemoveMembership, createMembership, hasParticipantPermission, isCompatibleLegacyContentTarget, isCompatibleMembershipMigration, isCompatibleParticipantMigration, isCompatibleParticipantRefMigration, isProfileColorKey, membershipRoles, migrateLegacyFamilyRelationships, scheduledAggregatePaths, type MembershipRole } from './relationships.js';
 import { assertRoutineDraftRevision, createRoutineDraftDocument, RoutineDraftConflictError, RoutineDraftInputError, updateRoutineDraftDocument, type PublishedRoutineVersionDocument, type RoutineDraftDocument } from './routineDrafts.js';
@@ -667,6 +667,7 @@ const dispatchPushNotifications = async (
     routineId: context.routineId,
     details: { notificationType: context.notificationType, ...summary },
   });
+  if (summary.success > 0 && summary.failed === 0) reportOperationalRecovery('push_send_failed');
   return summary;
 };
 
@@ -1826,6 +1827,7 @@ export const recordSyntheticPushReceipt = onRequest({ region }, async (request, 
       ...(typeof body.kind === 'string' ? { notificationType: body.kind.slice(0, 64) } : {}),
     },
   });
+  if (stage === 'received' || stage === 'opened') reportOperationalRecovery('push_delivery_unconfirmed');
   if (renewPushSubscription) {
     reportOperationalAlert({
       kind: 'push_delivery_unconfirmed',
@@ -2685,6 +2687,7 @@ export const dispatchPlannedChecks = onSchedule({
       kind: 'scheduler_run_summary',
       details: { ...stats, durationMs: Date.now() - startedAt },
     });
+    if (stats.failures === 0 && stats.invalidPlans === 0) reportOperationalRecovery('scheduler_dispatch_failed');
   }
 });
 
@@ -2896,6 +2899,7 @@ export const analyzeCheck = onCall({
       durationMs: Date.now() - requestStartedAt,
     },
   });
+  if (analysisUpdate.analysisSource === 'ai') reportOperationalRecovery('analysis_failed');
   return response;
 });
 
@@ -3040,8 +3044,11 @@ export const cleanupExpiredProofImages = onSchedule({
     .where('proofImageExpiresAt', '<', new Date().toISOString())
     .limit(200)
     .get();
-  if (expired.empty) return;
-  await Promise.allSettled(expired.docs.map(async (check) => {
+  if (expired.empty) {
+    reportOperationalRecovery('storage_cleanup_failed');
+    return;
+  }
+  const results = await Promise.allSettled(expired.docs.map(async (check) => {
     const proofImagePath = check.data().proofImagePath;
     if (typeof proofImagePath === 'string' && proofImagePath) {
       try {
@@ -3062,6 +3069,21 @@ export const cleanupExpiredProofImages = onSchedule({
       proofImageExpiresAt: FieldValue.delete(),
     });
   }));
+  if (results.every((result) => result.status === 'fulfilled')) reportOperationalRecovery('storage_cleanup_failed');
+});
+
+export const triggerOperationalTestAlert = onCall({ region, cors, enforceAppCheck: true }, async (request) => {
+  await requireUid(request.auth);
+  const operationsRole = request.auth?.token.operationsRole;
+  if (operationsRole !== 'operator' && operationsRole !== 'admin') {
+    throw new HttpsError('permission-denied', 'An operations role is required.');
+  }
+  if (request.data?.phase === 'recovery') {
+    reportOperationalRecovery('operational_test');
+    return { success: true, phase: 'recovery' as const };
+  }
+  reportOperationalAlert({ kind: 'operational_test', details: { source: 'manual_test' } });
+  return { success: true, phase: 'alert' as const };
 });
 
 export const cleanupStaleOperationalData = onSchedule({

--- a/functions/src/observability.test.ts
+++ b/functions/src/observability.test.ts
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
-import { operationalAlertPayload, operationalEventPayload } from './observability.js';
+import { operationalAlertDefinitions, operationalAlertPayload, operationalEventPayload, operationalRecoveryPayload } from './observability.js';
 
 test('builds a structured operational alert payload', () => {
   const payload = operationalAlertPayload({
@@ -14,6 +14,12 @@ test('builds a structured operational alert payload', () => {
   assert.deepEqual(payload, {
     alert: 'operational_alert',
     kind: 'push_send_failed',
+    severity: 'SEV-2',
+    owner: 'pilot-operations',
+    thresholdOccurrences: 5,
+    thresholdWindowMinutes: 10,
+    runbook: 'docs/pilot-support-incident-playbook.md#push-delivery',
+    dedupeKey: 'operational:push_send_failed',
     familyId: 'family-1',
     checkId: 'check-1',
     details: { statusCode: 500, retryable: true },
@@ -35,8 +41,31 @@ test('drops non-scalar operational alert details', () => {
   assert.deepEqual(payload, {
     alert: 'operational_alert',
     kind: 'analysis_failed',
+    severity: 'SEV-2',
+    owner: 'ai-reliability',
+    thresholdOccurrences: 3,
+    thresholdWindowMinutes: 15,
+    runbook: 'docs/pilot-support-incident-playbook.md#analysis',
+    dedupeKey: 'operational:analysis_failed',
     details: { model: 'gemini' },
   });
+});
+
+test('defines every required threshold and a correlated recovery event', () => {
+  for (const kind of ['push_send_failed', 'analysis_failed', 'app_check_rejected', 'storage_cleanup_failed', 'scheduler_dispatch_failed', 'push_delivery_unconfirmed'] as const) {
+    assert.ok(operationalAlertDefinitions[kind].occurrences > 0);
+    assert.ok(operationalAlertDefinitions[kind].windowMinutes > 0);
+    assert.ok(operationalAlertDefinitions[kind].owner);
+  }
+  assert.deepEqual(operationalRecoveryPayload('analysis_failed'), { event: 'operational_recovery', kind: 'analysis_failed', owner: 'ai-reliability', dedupeKey: 'operational:analysis_failed', recoveryWindowMinutes: 15 });
+});
+
+test('builds a synthetic test alert without participant or proof fields', () => {
+  const payload = operationalAlertPayload({ kind: 'operational_test', details: { source: 'manual_test' } });
+  assert.equal(payload.severity, 'TEST');
+  assert.equal('familyId' in payload, false);
+  assert.equal('checkId' in payload, false);
+  assert.equal(JSON.stringify(payload).includes('proof'), false);
 });
 
 test('builds a correlated operational event without nested sensitive details', () => {

--- a/functions/src/observability.ts
+++ b/functions/src/observability.ts
@@ -1,12 +1,14 @@
 import * as logger from 'firebase-functions/logger';
 
-type OperationalAlertKind =
+export type OperationalAlertKind =
   | 'push_send_failed'
   | 'push_subscription_invalidated'
   | 'push_delivery_unconfirmed'
   | 'scheduler_dispatch_failed'
   | 'analysis_failed'
-  | 'storage_cleanup_failed';
+  | 'storage_cleanup_failed'
+  | 'app_check_rejected'
+  | 'operational_test';
 
 type OperationalEventKind =
   | 'push_dispatch_summary'
@@ -16,6 +18,17 @@ type OperationalEventKind =
   | 'synthetic_push_receipt';
 
 type AlertValue = string | number | boolean | null | undefined;
+
+export const operationalAlertDefinitions = {
+  push_send_failed: { severity: 'SEV-2', owner: 'pilot-operations', occurrences: 5, windowMinutes: 10, recoveryMinutes: 15, runbook: 'docs/pilot-support-incident-playbook.md#push-delivery' },
+  push_subscription_invalidated: { severity: 'SEV-3', owner: 'pilot-operations', occurrences: 10, windowMinutes: 60, recoveryMinutes: 60, runbook: 'docs/pilot-support-incident-playbook.md#push-delivery' },
+  push_delivery_unconfirmed: { severity: 'SEV-2', owner: 'pilot-operations', occurrences: 2, windowMinutes: 20, recoveryMinutes: 20, runbook: 'docs/pilot-support-incident-playbook.md#synthetic-monitor' },
+  scheduler_dispatch_failed: { severity: 'SEV-2', owner: 'backend-operations', occurrences: 1, windowMinutes: 10, recoveryMinutes: 10, runbook: 'docs/pilot-support-incident-playbook.md#scheduled-jobs' },
+  analysis_failed: { severity: 'SEV-2', owner: 'ai-reliability', occurrences: 3, windowMinutes: 15, recoveryMinutes: 15, runbook: 'docs/pilot-support-incident-playbook.md#analysis' },
+  storage_cleanup_failed: { severity: 'SEV-2', owner: 'privacy-operations', occurrences: 1, windowMinutes: 30, recoveryMinutes: 30, runbook: 'docs/pilot-support-incident-playbook.md#proof-cleanup' },
+  app_check_rejected: { severity: 'SEV-2', owner: 'security-operations', occurrences: 20, windowMinutes: 10, recoveryMinutes: 20, runbook: 'docs/pilot-support-incident-playbook.md#app-check' },
+  operational_test: { severity: 'TEST', owner: 'pilot-operations', occurrences: 1, windowMinutes: 5, recoveryMinutes: 5, runbook: 'docs/pilot-support-incident-playbook.md#test-alert' },
+} as const satisfies Record<OperationalAlertKind, { severity: string; owner: string; occurrences: number; windowMinutes: number; recoveryMinutes: number; runbook: string }>;
 
 interface OperationalAlertInput {
   kind: OperationalAlertKind;
@@ -43,6 +56,7 @@ const errorMessage = (error: unknown) => {
 };
 
 export const operationalAlertPayload = (input: OperationalAlertInput) => {
+  const definition = operationalAlertDefinitions[input.kind];
   const details = Object.fromEntries(
     Object.entries(input.details ?? {})
       .filter(([, value]) => ['string', 'number', 'boolean'].includes(typeof value) || value === null),
@@ -50,6 +64,12 @@ export const operationalAlertPayload = (input: OperationalAlertInput) => {
   return {
     alert: 'operational_alert',
     kind: input.kind,
+    severity: definition.severity,
+    owner: definition.owner,
+    thresholdOccurrences: definition.occurrences,
+    thresholdWindowMinutes: definition.windowMinutes,
+    runbook: definition.runbook,
+    dedupeKey: `operational:${input.kind}`,
     ...(input.familyId ? { familyId: input.familyId } : {}),
     ...(input.checkId ? { checkId: input.checkId } : {}),
     ...(input.routineId ? { routineId: input.routineId } : {}),
@@ -58,6 +78,13 @@ export const operationalAlertPayload = (input: OperationalAlertInput) => {
     ...(errorMessage(input.error) ? { error: errorMessage(input.error) } : {}),
   };
 };
+
+export const operationalRecoveryPayload = (kind: OperationalAlertKind) => ({
+  event: 'operational_recovery', kind, owner: operationalAlertDefinitions[kind].owner,
+  dedupeKey: `operational:${kind}`, recoveryWindowMinutes: operationalAlertDefinitions[kind].recoveryMinutes,
+});
+
+export const reportOperationalRecovery = (kind: OperationalAlertKind) => logger.info('operational_recovery', operationalRecoveryPayload(kind));
 
 export const reportOperationalAlert = (input: OperationalAlertInput) => {
   logger.error('operational_alert', operationalAlertPayload(input));

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zadiag-pwa",
   "private": true,
-  "version": "0.9.60",
+  "version": "0.9.61",
   "type": "module",
   "packageManager": "pnpm@11.7.0",
   "engines": {


### PR DESCRIPTION
Closes #138.

## Summary
- centralize measurable alert thresholds, severity, owner roles, recovery windows, runbook links, and deduplication keys
- emit correlated recovery signals for push, synthetic monitoring, scheduled dispatch, AI analysis, and proof cleanup
- add an operator-only test alert that contains no participant or proof data
- document response and recovery procedures in the pilot incident playbook
- bump the application version to 0.9.61

## Impact
Operational failures can be routed and handled consistently, tested safely, and closed from observable recovery signals. App Check rejection remains sourced from platform logs because enforcement happens before callable code executes.

## Validation
- npm run check
- npm --prefix functions test
- git diff --check