### PR TITLE
Fix overlapping built-in routine cards on iPhone

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zadiag-pwa",
   "private": true,
-  "version": "0.9.61",
+  "version": "0.9.62",
   "type": "module",
   "packageManager": "pnpm@11.7.0",
   "engines": {

--- a/src/screens/RoutinesScreen.test.tsx
+++ b/src/screens/RoutinesScreen.test.tsx
@@ -93,6 +93,14 @@ describe('participant routines navigation', () => {
     expect(document.body.textContent).toContain('Validation: AI analysis');
     expect(document.body.textContent).toContain('Proof example');
     expect(document.body.textContent).toContain('visible glass');
+    const builtInCards = Array.from(document.body.querySelectorAll<HTMLElement>('.routine-catalog-item'));
+    expect(builtInCards).toHaveLength(4);
+    for (const card of builtInCards) {
+      const headingId = card.getAttribute('aria-labelledby');
+      expect(headingId).toBeTruthy();
+      expect(card.querySelectorAll(`#${headingId}`)).toHaveLength(1);
+      expect(card.querySelectorAll('.routine-catalog-add')).toHaveLength(1);
+    }
     const dock = document.body.querySelector('.routine-add-switcher');
     expect(dock?.querySelector('.routines-add-dock-button')?.textContent).toContain('Add a routine');
     expect(dock?.querySelector('.routine-catalog-popover')).not.toBeNull();

--- a/src/screens/RoutinesScreen.tsx
+++ b/src/screens/RoutinesScreen.tsx
@@ -603,7 +603,7 @@ export function RoutinesScreen({
               const assigned = assignedRoutineIds.has(routineId);
               const assigning = assigningRoutineId === routineId;
               return (
-                <article className="routine-catalog-item" style={visual.style} key={template.id}>
+                <article className="routine-catalog-item" style={visual.style} key={template.id} aria-labelledby={`routine-catalog-${routineId}`}>
                   <span className="settings-row-icon routine-icon" aria-hidden="true"><AppIcon name={routineIconName(visual.icon)} /></span>
                   <div className="routine-catalog-item-content">
                     <div className="routine-catalog-meta" aria-label={`${t(routineCategoryKey(visual.category))} · ${t(routineValidationModeKey(visual.recommendedValidationMode))}`}>
@@ -611,7 +611,7 @@ export function RoutinesScreen({
                       <span>{t(routineCategoryKey(visual.category))}</span>
                       <span>{t('routineCatalogValidationMode')}: {t(routineValidationModeKey(visual.recommendedValidationMode))}</span>
                     </div>
-                    <h3>{visual.name}</h3>
+                    <h3 id={`routine-catalog-${routineId}`}>{visual.name}</h3>
                     <p>{visual.description}</p>
                     <p className="routine-catalog-proof"><b>{t('routineCatalogProofExample')}:</b> {visual.proofExample}</p>
                   </div>

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -1297,8 +1297,9 @@ button:disabled { cursor: not-allowed; }
 .routine-catalog-add:disabled { background: #e8eeee; color: #7d8a92; }
 @media (max-width: 430px) {
   .routine-catalog-card { height: min(72dvh, 620px); min-height: min(440px, 66dvh); }
-  .routine-catalog-item { grid-template-columns: 36px minmax(0, 1fr) auto; align-items: start; gap: 8px; }
-  .routine-catalog-add { grid-column: 3; justify-self: end; align-self: start; padding-inline: 11px; }
+  .routine-catalog-item { grid-template-columns: 36px minmax(0, 1fr); align-items: start; gap: 8px; padding-block: 12px; }
+  .routine-catalog-item-content { overflow-wrap: anywhere; }
+  .routine-catalog-add { grid-column: 2; justify-self: start; align-self: start; padding-inline: 11px; }
   .routine-library-draft-heading { grid-template-columns: 36px minmax(0, 1fr); }
   .routine-library-draft-actions { grid-column: 2; }
   .routine-library-draft-detail { padding-left: 46px; }


### PR DESCRIPTION
Closes #175.

## Summary
- move each compact catalogue action below its routine content so text retains a stable readable width
- allow long routine copy to wrap safely inside its own card
- associate each built-in card explicitly with its own heading and action
- bump the application version to 0.9.62

## Impact
The built-in routine add block stays readable on iPhone and no longer visually mixes text between adjacent routines.

## Validation
- npm run check
- focused RoutinesScreen suite: 21 tests
- real-device retest will be recorded in #137 after production deployment