### PR TITLE
Isolate built-in routine cards on iPhone

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zadiag-pwa",
   "private": true,
-  "version": "0.9.62",
+  "version": "0.9.63",
   "type": "module",
   "packageManager": "pnpm@11.7.0",
   "engines": {

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -1297,9 +1297,20 @@ button:disabled { cursor: not-allowed; }
 .routine-catalog-add:disabled { background: #e8eeee; color: #7d8a92; }
 @media (max-width: 430px) {
   .routine-catalog-card { height: min(72dvh, 620px); min-height: min(440px, 66dvh); }
-  .routine-catalog-item { grid-template-columns: 36px minmax(0, 1fr); align-items: start; gap: 8px; padding-block: 12px; }
+  .routine-catalog-item {
+    grid-template-columns: 36px minmax(0, 1fr);
+    align-items: start;
+    gap: 8px;
+    margin-block: 8px;
+    padding: 12px;
+    border: 1px solid color-mix(in srgb, var(--routine-accent, var(--color-primary)) 18%, var(--color-border));
+    border-radius: 16px;
+    background: color-mix(in srgb, var(--routine-accent, var(--color-primary)) 5%, var(--color-surface-solid));
+  }
   .routine-catalog-item-content { overflow-wrap: anywhere; }
-  .routine-catalog-add { grid-column: 2; justify-self: start; align-self: start; padding-inline: 11px; }
+  .routine-catalog-item p,
+  .routine-catalog-item .routine-catalog-proof { display: block; overflow: visible; -webkit-line-clamp: unset; }
+  .routine-catalog-add { grid-column: 1 / -1; width: 100%; justify-self: stretch; align-self: start; padding-inline: 11px; }
   .routine-library-draft-heading { grid-template-columns: 36px minmax(0, 1fr); }
   .routine-library-draft-actions { grid-column: 2; }
   .routine-library-draft-detail { padding-left: 46px; }


### PR DESCRIPTION
Closes #175.

## Summary
- render every built-in routine as a distinct bordered mobile card
- remove WebKit line clamping on compact screens so copy cannot overlap visually
- move each add action to a full-width row owned by its card
- bump production to 0.9.63

## Validation
- npm run check
- focused RoutinesScreen suite: 21 tests
- real-device retest required on iPhone 16 Pro / iOS 26.5.2 after deployment