### PR TITLE
Add privacy-safe pilot reporting

### DIFF
--- a/docs/pilot-cohort-runbook.md
+++ b/docs/pilot-cohort-runbook.md
@@ -67,6 +67,9 @@ Before inviting the first family:
 - define the cohort start, end, weekly review time, and stop authority;
 - record baseline targets only after the initial instrumented observations,
   alongside cohort size and timeframe.
+- confirm a designated operator can obtain an identifier-free
+  `getPilotAggregateReport` result with synthetic data, then remove any
+  temporary operator claim not required during the cohort;
 
 ## Participant session
 

--- a/docs/pilot-measurement.md
+++ b/docs/pilot-measurement.md
@@ -49,3 +49,17 @@ automatically after 35 days.
 All reporting must use cohorts of sufficient size and aggregate results. Raw
 journey records are operational pilot evidence, not individual performance or
 clinical evidence.
+
+## Operator report
+
+An authenticated operator with the `operationsRole=operator` or `admin` custom
+claim can call `getPilotAggregateReport` with ISO `from` and `to` values. The
+period must be complete, cannot exceed the 35-day retention window, and is
+limited to 5,000 audit records. The response contains only aggregate actor and
+profile counts, stage totals, and funnel rates. It never returns event rows,
+identifiers, routine content, contact details, or proof data.
+
+Reports with fewer than three distinct consenting actors return
+`insufficient_data` with no counts. Keep the generated aggregate alongside the
+cohort decision record, not the contact register. Remove the temporary operator
+claim when report access is no longer required.

--- a/functions/src/audit.ts
+++ b/functions/src/audit.ts
@@ -48,6 +48,11 @@ type AuditAction =
   | 'withdraw_pilot_participation';
 
 type AuditMetadataValue = string | number | boolean | null | undefined;
+const pilotMeasuredActions = new Set<AuditAction>([
+  'request_check',
+  'submit_proof',
+  'review_proof',
+]);
 
 interface AuditEventInput {
   action: AuditAction;
@@ -77,7 +82,14 @@ export const auditEventDocument = (input: AuditEventInput) => {
 
 export const recordAuditEvent = async (db: Firestore, input: AuditEventInput) => {
   try {
-    await db.collection('auditEvents').add(auditEventDocument(input));
+    let metadata = input.metadata;
+    if (pilotMeasuredActions.has(input.action)) {
+      const participation = (await db.collection('users').doc(input.actorUid).get()).data()?.pilotParticipation;
+      if (participation?.status === 'accepted' && typeof participation.version === 'string') {
+        metadata = { ...metadata, pilotConsentVersion: participation.version };
+      }
+    }
+    await db.collection('auditEvents').add(auditEventDocument({ ...input, metadata }));
   } catch (error) {
     console.error('Unable to record audit event', { action: input.action, familyId: input.familyId, error });
   }

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -23,6 +23,7 @@ import { ROUTINE_PACKAGE_MIME, parseRoutinePackageEnvelope, serializeRoutinePack
 import { assertExternalPackageResponse, verifyExternalRegistryIndex } from './externalRoutineRegistry.js';
 import { marketplaceEntryInstallable, marketplaceRole, moderateMarketplaceStatus, type ModerationAction, type ModerationStatus } from './routineMarketplaceGovernance.js';
 import { aiAuthoringCapabilityEnabled, aiAuthoringRegistry, parseAiAuthoringConfig } from './aiAuthoring.js';
+import { aggregatePilotReport, pilotReportPeriod } from './pilotReport.js';
 
 const storageBucket = process.env.FIREBASE_STORAGE_BUCKET
   ?? (process.env.GCLOUD_PROJECT ? `${process.env.GCLOUD_PROJECT}.firebasestorage.app` : undefined);
@@ -373,7 +374,7 @@ export const recordClientJourney = onCall({ region, cors, enforceAppCheck: true 
     ...(aggregateRef.parent.id === 'participants' ? { participantId: aggregateId } : { familyId: aggregateId }),
     role: role === 'child' ? 'child' as const : 'parent' as const,
     contextId,
-    metadata: { source, ...(contextId ? { contextId } : {}) },
+    metadata: { source, pilotConsentVersion, ...(contextId ? { contextId } : {}) },
   });
 });
 
@@ -402,6 +403,32 @@ export const updatePilotParticipation = onCall({ region, cors, enforceAppCheck: 
     metadata: { version: pilotConsentVersion },
   });
   return pilotParticipation;
+});
+
+export const getPilotAggregateReport = onCall({ region, cors, enforceAppCheck: true }, async (request) => {
+  await requireUid(request.auth);
+  const operationsRole = request.auth?.token.operationsRole;
+  if (operationsRole !== 'operator' && operationsRole !== 'admin') {
+    throw new HttpsError('permission-denied', 'Pilot operator access is required.');
+  }
+  let period: ReturnType<typeof pilotReportPeriod>;
+  try {
+    period = pilotReportPeriod(request.data?.from, request.data?.to);
+  } catch {
+    throw new HttpsError('invalid-argument', 'A completed period of at most 35 days is required.');
+  }
+  const snapshot = await db.collection('auditEvents')
+    .where('createdAt', '>=', Timestamp.fromDate(period.start))
+    .where('createdAt', '<', Timestamp.fromDate(period.end))
+    .orderBy('createdAt')
+    .limit(5001)
+    .get();
+  if (snapshot.size > 5000) throw new HttpsError('resource-exhausted', 'The pilot period contains too many records. Use a shorter period.');
+  return {
+    from: period.start.toISOString(),
+    to: period.end.toISOString(),
+    ...aggregatePilotReport(snapshot.docs.map((document) => document.data())),
+  };
 });
 
 const imageExtensionFor = (mimeType: string) => {

--- a/functions/src/pilotReport.test.ts
+++ b/functions/src/pilotReport.test.ts
@@ -1,0 +1,44 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { aggregatePilotReport, pilotReportPeriod } from './pilotReport.js';
+
+test('builds an identifier-free aggregate pilot funnel', () => {
+  const events = ['one', 'two', 'three'].flatMap((actorUid) => [
+    { action: 'app_ready', actorUid, participantId: `profile-${actorUid}`, metadata: { pilotConsentVersion: '2026-07-17' } },
+    { action: 'request_check', actorUid, participantId: `profile-${actorUid}`, metadata: { pilotConsentVersion: '2026-07-17' } },
+    { action: 'notification_opened', actorUid, participantId: `profile-${actorUid}`, metadata: { pilotConsentVersion: '2026-07-17' } },
+    { action: 'check_opened', actorUid, participantId: `profile-${actorUid}`, metadata: { pilotConsentVersion: '2026-07-17' } },
+    { action: 'submit_proof', actorUid, participantId: `profile-${actorUid}`, metadata: { pilotConsentVersion: '2026-07-17' } },
+  ]);
+  const report = aggregatePilotReport(events);
+  assert.equal(report.status, 'ready');
+  assert.equal(report.actors, 3);
+  assert.equal(report.profiles, 3);
+  assert.equal(report.rates.completion, 1);
+  assert.doesNotMatch(JSON.stringify(report), /profile-one|\bone\b/);
+});
+
+test('suppresses small cohorts instead of returning identifiable cells', () => {
+  assert.deepEqual(aggregatePilotReport([
+    { action: 'app_ready', actorUid: 'one', familyId: 'family-one', metadata: { pilotConsentVersion: '2026-07-17' } },
+    { action: 'app_ready', actorUid: 'two', familyId: 'family-two', metadata: { pilotConsentVersion: '2026-07-17' } },
+  ]), { status: 'insufficient_data', minimumActors: 3 });
+});
+
+test('excludes events without active measurement consent', () => {
+  assert.deepEqual(aggregatePilotReport([
+    { action: 'app_ready', actorUid: 'one', metadata: { pilotConsentVersion: 'previous' } },
+    { action: 'app_ready', actorUid: 'two' },
+    { action: 'app_ready', actorUid: 'three', metadata: { pilotConsentVersion: '2026-07-17' } },
+  ]), { status: 'insufficient_data', minimumActors: 3 });
+});
+
+test('limits reports to a valid completed 35-day period', () => {
+  const now = new Date('2026-07-18T12:00:00.000Z');
+  assert.deepEqual(pilotReportPeriod('2026-07-01T00:00:00.000Z', '2026-07-18T00:00:00.000Z', now), {
+    start: new Date('2026-07-01T00:00:00.000Z'),
+    end: new Date('2026-07-18T00:00:00.000Z'),
+  });
+  assert.throws(() => pilotReportPeriod('2026-06-01T00:00:00.000Z', '2026-07-18T00:00:00.000Z', now));
+  assert.throws(() => pilotReportPeriod('2026-07-18T00:00:00.000Z', '2026-07-19T00:00:00.000Z', now));
+});

--- a/functions/src/pilotReport.ts
+++ b/functions/src/pilotReport.ts
@@ -1,0 +1,73 @@
+const reportActions = [
+  'app_ready',
+  'accept_relationship_invitation',
+  'notifications_enabled',
+  'notification_opened',
+  'check_opened',
+  'request_check',
+  'submit_proof',
+  'review_proof',
+  'accept_pilot_participation',
+] as const;
+
+type ReportAction = typeof reportActions[number];
+
+export interface PilotReportEvent {
+  action?: unknown;
+  actorUid?: unknown;
+  familyId?: unknown;
+  participantId?: unknown;
+  metadata?: unknown;
+}
+
+const ratio = (numerator: number, denominator: number) => denominator
+  ? Math.round((numerator / denominator) * 1000) / 1000
+  : null;
+
+export const pilotReportPeriod = (from: unknown, to: unknown, now = new Date()) => {
+  if (typeof from !== 'string' || typeof to !== 'string') throw new Error('invalid_period');
+  const start = new Date(from);
+  const end = new Date(to);
+  if (!Number.isFinite(start.getTime()) || !Number.isFinite(end.getTime()) || start >= end) throw new Error('invalid_period');
+  if (end > now || end.getTime() - start.getTime() > 35 * 86_400_000) throw new Error('invalid_period');
+  return { start, end };
+};
+
+export const aggregatePilotReport = (events: PilotReportEvent[], minimumActors = 3) => {
+  const actors = new Set<string>();
+  const aggregates = new Set<string>();
+  const stages = Object.fromEntries(reportActions.map((action) => [action, 0])) as Record<ReportAction, number>;
+
+  events.forEach((event) => {
+    const metadata = event.metadata && typeof event.metadata === 'object'
+      ? event.metadata as Record<string, unknown>
+      : undefined;
+    if (metadata?.pilotConsentVersion !== '2026-07-17') return;
+    const action = typeof event.action === 'string' && reportActions.includes(event.action as ReportAction)
+      ? event.action as ReportAction
+      : undefined;
+    if (!action || typeof event.actorUid !== 'string' || !event.actorUid) return;
+    actors.add(event.actorUid);
+    const aggregateId = typeof event.participantId === 'string' && event.participantId
+      ? `participant:${event.participantId}`
+      : typeof event.familyId === 'string' && event.familyId
+        ? `family:${event.familyId}`
+        : undefined;
+    if (aggregateId) aggregates.add(aggregateId);
+    stages[action] += 1;
+  });
+
+  if (actors.size < minimumActors) return { status: 'insufficient_data' as const, minimumActors };
+  return {
+    status: 'ready' as const,
+    actors: actors.size,
+    profiles: aggregates.size,
+    stages,
+    rates: {
+      notificationEngagement: ratio(stages.notification_opened, stages.request_check),
+      checkStart: ratio(stages.check_opened, stages.request_check),
+      completion: ratio(stages.submit_proof, stages.check_opened),
+      responsibleReview: ratio(stages.review_proof, stages.submit_proof),
+    },
+  };
+};

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zadiag-pwa",
   "private": true,
-  "version": "0.9.64",
+  "version": "0.9.65",
   "type": "module",
   "packageManager": "pnpm@11.7.0",
   "engines": {


### PR DESCRIPTION
## Summary
- add an operator-only aggregate report for the 35-day pilot measurement window
- return only stage counts, profile/account totals, and funnel rates
- suppress reports with fewer than three consenting actors
- mark measured server events with the active consent version and exclude refused or withdrawn activity
- document operator access, limits, and launch verification
- bump the patch version to 0.9.65

## Why
The pilot runbook defined aggregate measures but had no safe operational path to calculate them without manually reading Firestore audit rows.

## Privacy boundary
The callable never returns event rows or identifiers. It requires App Check, authentication, an operator/admin custom claim, an ended period of at most 35 days, and active consent on each included event.

## Validation
- npm run check
- 278 client tests passed
- 18 Functions suites passed
- production build and bundle guard passed
- git diff --check