### PR TITLE
Fix Nemu proof routing for Pi health checks

### DIFF
--- a/ops/pi-synthetic-monitor/supervisor.mjs
+++ b/ops/pi-synthetic-monitor/supervisor.mjs
@@ -29,6 +29,7 @@ const log = (event, details = {}) => {
 const context = await chromium.launchPersistentContext(profileDir, {
   executablePath: chromiumPath,
   headless: false,
+  locale: 'fr-FR',
   viewport: { width: 430, height: 820 },
   args: [
     '--disable-gpu',
@@ -38,6 +39,17 @@ const context = await chromium.launchPersistentContext(profileDir, {
     '--no-first-run',
     '--no-default-browser-check',
   ],
+});
+
+await context.addInitScript(() => {
+  const key = 'zadiag.preferences.v1';
+  let preferences = {};
+  try {
+    preferences = JSON.parse(localStorage.getItem(key) ?? '{}');
+  } catch {
+    // Replace malformed local preferences with the monitor defaults.
+  }
+  localStorage.setItem(key, JSON.stringify({ ...preferences, locale: 'fr' }));
 });
 
 if (appCheckDebugToken) {

--- a/ops/pi-synthetic-monitor/synthetic-proof.mjs
+++ b/ops/pi-synthetic-monitor/synthetic-proof.mjs
@@ -5,6 +5,7 @@ import { promisify } from 'node:util';
 
 const execFileAsync = promisify(execFile);
 const PI_HEALTH_ROUTINE_IDS = new Set(['nemu-health', 'raspberry-pi-health']);
+const PI_HEALTH_ROUTINE_NAME_PATTERN = /Santé du Raspberry Pi|Raspberry Pi Health/i;
 const resultPattern = /Validated|Validé|Not detected|Non détecté|Needs review|À vérifier/i;
 const analyzingPattern = /Checking the photo|Analyse de la photo/i;
 const cameraEnabledContexts = new WeakSet();
@@ -56,24 +57,11 @@ const installSyntheticCamera = (context) => {
             drawing.fillText('Zadiag synthetic operational proof', 34, 458);
             return;
           }
-          drawing.fillStyle = '#c88f70';
+          drawing.fillStyle = '#eef8f5';
           drawing.fillRect(0, 0, canvas.width, canvas.height);
-          drawing.fillStyle = '#6b3029';
-          drawing.beginPath();
-          drawing.ellipse(320, 260, 155, 85, 0, 0, Math.PI * 2);
-          drawing.fill();
-          drawing.fillStyle = '#f6f1dd';
-          drawing.fillRect(205, 220, 230, 42);
-          drawing.fillStyle = '#d8d1ba';
-          for (let x = 220; x < 430; x += 30) drawing.fillRect(x, 220, 3, 42);
-          drawing.strokeStyle = '#6cc7d4';
-          drawing.lineWidth = 8;
-          drawing.beginPath();
-          drawing.moveTo(210, 242);
-          drawing.lineTo(430, 242);
-          drawing.stroke();
-          drawing.fillStyle = '#44201d';
-          drawing.fillRect(255, 292, 130, 18);
+          drawing.fillStyle = '#123b35';
+          drawing.font = 'bold 28px sans-serif';
+          drawing.fillText('No supported routine selected', 70, 245);
         };
         draw();
         const timer = window.setInterval(draw, 250);
@@ -92,6 +80,12 @@ const installSyntheticCamera = (context) => {
     },
   });
   });
+};
+
+export const resolveSyntheticRoutineId = ({ routineId, pageText = '' }) => {
+  if (PI_HEALTH_ROUTINE_IDS.has(routineId)) return routineId;
+  if (routineId) return undefined;
+  return PI_HEALTH_ROUTINE_NAME_PATTERN.test(pageText) ? 'raspberry-pi-health' : undefined;
 };
 
 const percentageStatus = (value, warning, failure) => value >= failure ? 'failure' : value >= warning ? 'warning' : 'ok';
@@ -148,19 +142,20 @@ export const answerPendingCheck = async ({ context, page, appUrl, path, contactE
   }
   await page.goto(destination.href, { waitUntil: 'domcontentloaded', timeout: 30_000 });
   await completeSyntheticOnboarding({ page, contactEmail });
-  if (PI_HEALTH_ROUTINE_IDS.has(routineId)) {
-    const evidence = healthEvidence ?? await collectNemuHealth();
-    await page.evaluate(({ currentRoutineId, currentEvidence }) => {
-      globalThis.__ZADIAG_SYNTHETIC_ROUTINE_ID__ = currentRoutineId;
-      globalThis.__ZADIAG_NEMU_HEALTH__ = currentEvidence;
-    }, { currentRoutineId: routineId, currentEvidence: evidence });
-  }
   const proofButton = page.getByRole('button', { name: /Proof|Preuve/i }).first();
   try {
     await proofButton.waitFor({ state: 'visible', timeout: proofWaitMs });
   } catch {
     return { outcome: 'already_settled' };
   }
+  const pageText = await page.evaluate(() => document.body?.innerText ?? '');
+  const resolvedRoutineId = resolveSyntheticRoutineId({ routineId, pageText });
+  if (!resolvedRoutineId) return { outcome: 'unsupported_routine' };
+  const evidence = healthEvidence ?? await collectNemuHealth();
+  await page.evaluate(({ currentRoutineId, currentEvidence }) => {
+    globalThis.__ZADIAG_SYNTHETIC_ROUTINE_ID__ = currentRoutineId;
+    globalThis.__ZADIAG_NEMU_HEALTH__ = currentEvidence;
+  }, { currentRoutineId: resolvedRoutineId, currentEvidence: evidence });
   await proofButton.click();
   await page.getByRole('button', { name: /Use photo|Utiliser la photo/i }).click({ timeout: 20_000 });
   await page.getByRole('button', { name: /Use photo|Utiliser la photo/i }).click({ timeout: 20_000 });

--- a/ops/pi-synthetic-monitor/synthetic-proof.test.mjs
+++ b/ops/pi-synthetic-monitor/synthetic-proof.test.mjs
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from 'vitest';
-import { answerPendingCheck } from './synthetic-proof.mjs';
+import { answerPendingCheck, resolveSyntheticRoutineId } from './synthetic-proof.mjs';
 
 const locator = (overrides = {}) => ({
   first() { return this; },
@@ -27,8 +27,9 @@ const onboardingPage = () => {
       return locator();
     }),
     evaluate: vi.fn().mockResolvedValue(undefined),
+    waitForFunction: vi.fn().mockResolvedValue({ jsonValue: vi.fn().mockResolvedValue({ result: 'Validé' }) }),
   };
-  return { page, contact, continueButton, declinePilot };
+  return { page, contact, continueButton, declinePilot, proof };
 };
 
 describe('Pi synthetic proof onboarding recovery', () => {
@@ -61,8 +62,10 @@ describe('Pi synthetic proof onboarding recovery', () => {
 
   it('injects Raspberry Pi health evidence for generic and legacy routine ids', async () => {
     const context = { addInitScript: vi.fn().mockResolvedValue(undefined) };
-    const { page } = onboardingPage();
+    const { page, proof } = onboardingPage();
     const healthEvidence = { timestamp: '18/07/2026 20:00:00', rows: [] };
+    proof.waitFor.mockResolvedValue(undefined);
+    page.evaluate.mockResolvedValueOnce('Santé du Raspberry Pi').mockResolvedValueOnce(undefined);
 
     await expect(answerPendingCheck({
       context,
@@ -71,11 +74,23 @@ describe('Pi synthetic proof onboarding recovery', () => {
       contactEmail: 'pi@example.com',
       routineId: 'raspberry-pi-health',
       healthEvidence,
-    })).resolves.toEqual({ outcome: 'already_settled' });
+    })).resolves.toEqual({ outcome: 'Validé' });
 
     expect(page.evaluate).toHaveBeenCalledWith(expect.any(Function), {
       currentRoutineId: 'raspberry-pi-health',
       currentEvidence: healthEvidence,
     });
+  });
+});
+
+describe('Pi synthetic routine resolution', () => {
+  it('recognizes the health routine from a notification or the visible French title', () => {
+    expect(resolveSyntheticRoutineId({ routineId: 'nemu-health' })).toBe('nemu-health');
+    expect(resolveSyntheticRoutineId({ pageText: 'Contrôle · Santé du Raspberry Pi' })).toBe('raspberry-pi-health');
+  });
+
+  it('refuses unrelated and unidentified routines instead of submitting a wrong proof', () => {
+    expect(resolveSyntheticRoutineId({ routineId: 'orthodontic-elastics' })).toBeUndefined();
+    expect(resolveSyntheticRoutineId({ pageText: 'Élastiques orthodontiques' })).toBeUndefined();
   });
 });

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zadiag-pwa",
   "private": true,
-  "version": "0.9.68",
+  "version": "0.9.69",
   "type": "module",
   "packageManager": "pnpm@11.7.0",
   "engines": {


### PR DESCRIPTION
## Résumé
- identifie la routine santé Pi depuis la notification ou son titre visible
- refuse les routines inconnues au lieu d’envoyer l’ancienne preuve orthodontique
- génère exclusivement le tableau de santé Pi pour les contrôles Nemu
- force la session synthétique en français
- publie la version 0.9.69

## Cause
Le chemin de secours pouvait répondre à un contrôle sans identifiant de routine et utilisait alors l’ancienne image synthétique d’élastiques.

## Validation
- `corepack pnpm check`
- 282 tests frontend
- 87 tests backend
- 5 tests ciblés du moniteur Pi
- redémarrage réussi de `zadiag-synthetic-monitor.service`