### PR TITLE
Keep deleted default routines removed

### DIFF
--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -10,7 +10,7 @@ import webpush, { type PushSubscription } from 'web-push';
 import { assertChildName, createLinkCode, createRecoveryCode, createRelationshipInvitationCode, hashLinkCode, isFirestoreDocumentId, isFreshCheckSubmission, isLegacyRecoveryCode, isRecoveryCode, isRelationshipInvitationCode, normalizeLinkCode, sensitiveCodeAttemptState } from './helpers.js';
 import { analyzeWithGemini, parseImageDataUrl, routeAnalysisStatusForReview, type AnalysisResult, type RoutineAnalysisContext } from './analysis.js';
 import { checkExpiresAt, getLocalDateKey, getWindowForDate, monitoringPlanSchema, plannedCheckDispatchSchedule, shouldAutoDispatchCheck } from './planning.js';
-import { createDefaultRoutineAssignment, createDraftRoutineAssignment, createRoutineAssignment, DEFAULT_ROUTINE_ID, isRoutineValidationMode, routineFromCatalog, type RoutineAssignmentDocument, type RoutineDocument } from './routines.js';
+import { createDefaultRoutineAssignment, createDraftRoutineAssignment, createRoutineAssignment, DEFAULT_ROUTINE_ID, isRoutineValidationMode, routineFromCatalog, shouldCreateDefaultRoutineAssignment, type RoutineAssignmentDocument, type RoutineDocument } from './routines.js';
 import { buildCheckNotificationPayload, buildReviewNotificationPayload, buildTestNotificationPayload, normalizePushPreferences, normalizePushSubscription, type SyntheticReceiptPayload } from './notifications.js';
 import { isCheckRequestRateLimited } from './reminders.js';
 import { recordAuditEvent, recordJourneyEvent, type JourneyStage } from './audit.js';
@@ -461,7 +461,7 @@ const ensureFamilyRoutineMigration = async (familyRef: FirebaseFirestore.Documen
     assignmentRef.get(),
   ]);
   if (!currentFamily.exists) throw new HttpsError('not-found', 'The family could not be found.');
-  if (Number(currentFamily.data()?.routineMigrationVersion ?? 0) >= 1 && currentAssignment.exists) return currentAssignment;
+  if (!shouldCreateDefaultRoutineAssignment(currentFamily.data()?.routineMigrationVersion, currentAssignment.exists)) return currentAssignment;
 
   await db.runTransaction(async (transaction) => {
     const [family, assignment] = await Promise.all([
@@ -469,7 +469,7 @@ const ensureFamilyRoutineMigration = async (familyRef: FirebaseFirestore.Documen
       transaction.get(assignmentRef),
     ]);
     if (!family.exists) throw new HttpsError('not-found', 'The family could not be found.');
-    if (assignment.exists) return;
+    if (!shouldCreateDefaultRoutineAssignment(family.data()?.routineMigrationVersion, assignment.exists)) return;
     const legacyPlan = monitoringPlanSchema.safeParse(family.data()?.plan);
     const assignedAt = String(family.data()?.createdAt ?? new Date().toISOString());
     transaction.create(assignmentRef, createDefaultRoutineAssignment(

--- a/functions/src/routines.test.ts
+++ b/functions/src/routines.test.ts
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
-import { createDefaultRoutineAssignment, createDraftRoutineAssignment, DEFAULT_ROUTINE_ID, isRoutineValidationMode, migrateCheckRoutineId } from './routines.js';
+import { createDefaultRoutineAssignment, createDraftRoutineAssignment, DEFAULT_ROUTINE_ID, isRoutineValidationMode, migrateCheckRoutineId, shouldCreateDefaultRoutineAssignment } from './routines.js';
 
 const plan = {
   checksPerDay: 1,
@@ -33,6 +33,12 @@ test('migrates legacy checks idempotently', () => {
   const migrated = migrateCheckRoutineId(legacy);
   assert.equal(migrated.routineId, DEFAULT_ROUTINE_ID);
   assert.deepEqual(migrateCheckRoutineId(migrated), migrated);
+});
+
+test('does not recreate a deliberately deleted default routine after migration', () => {
+  assert.equal(shouldCreateDefaultRoutineAssignment(0, false), true);
+  assert.equal(shouldCreateDefaultRoutineAssignment(1, false), false);
+  assert.equal(shouldCreateDefaultRoutineAssignment(1, true), false);
 });
 
 test('accepts only supported routine validation modes', () => {

--- a/functions/src/routines.ts
+++ b/functions/src/routines.ts
@@ -62,6 +62,11 @@ export interface RoutineAssignmentDocument {
 export const routineFromCatalog = (routineId: string) =>
   availableRoutines.find((routine) => routine.id === routineId);
 
+export const shouldCreateDefaultRoutineAssignment = (
+  routineMigrationVersion: unknown,
+  defaultAssignmentExists: boolean,
+) => Number(routineMigrationVersion ?? 0) < 1 && !defaultAssignmentExists;
+
 export const createDefaultRoutineAssignment = (
   plan: MonitoringPlan,
   assignedAt = new Date().toISOString(),

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zadiag-pwa",
   "private": true,
-  "version": "0.9.70",
+  "version": "0.9.71",
   "type": "module",
   "packageManager": "pnpm@11.7.0",
   "engines": {


### PR DESCRIPTION
## Résumé
- empêche la migration historique de recréer la routine orthodontique après sa suppression
- conserve la création automatique uniquement pour les profils réellement non migrés
- ajoute une non-régression pour les suppressions volontaires
- publie la version 0.9.71

## Cause
La migration exigeait à tort que l’affectation par défaut existe encore. Dès qu’elle était supprimée, le prochain appel backend la recréait malgré `routineMigrationVersion: 1`.

## Validation
- `corepack pnpm check`
- 285 tests frontend
- 90 tests backend