### PR TITLE
Compact the verification detail popup

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zadiag-pwa",
   "private": true,
-  "version": "0.9.71",
+  "version": "0.9.72",
   "type": "module",
   "packageManager": "pnpm@11.7.0",
   "engines": {

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -1520,22 +1520,23 @@ button:disabled { cursor: not-allowed; }
 .routine-history-open:focus-visible { outline: 3px solid color-mix(in srgb, var(--routine-accent) 34%, transparent); outline-offset: -3px; border-radius: 12px; }
 .routine-history-row .submission-thumb-button { position: relative; z-index: 2; }
 .history-detail-backdrop { position: fixed; z-index: 70; inset: 0; display: grid; align-items: end; padding: 12px; background: rgba(8,26,40,.48); backdrop-filter: blur(5px); }
-.history-detail-dialog { width: min(100%, 520px); height: min(90dvh, 760px); display: grid; grid-template-rows: auto minmax(150px, 34%) minmax(0, 1fr); gap: 10px; margin: 0 auto; padding: 15px; overflow: hidden; border-radius: 24px; background: var(--color-surface-solid); box-shadow: 0 24px 70px rgba(8,26,40,.28); }
+.history-detail-dialog { width: min(100%, 520px); height: min(88dvh, 720px); display: grid; grid-template-rows: auto minmax(150px, 38%) minmax(0, 1fr); gap: 8px; margin: 0 auto; padding: 12px; overflow: hidden; border-radius: 22px; background: var(--color-surface-solid); box-shadow: 0 24px 70px rgba(8,26,40,.28); }
 .history-detail-dialog.no-proof { grid-template-rows: auto minmax(0, 1fr); }
-.history-detail-dialog.has-actions { grid-template-rows: auto minmax(150px, 34%) auto minmax(0, 1fr); }
+.history-detail-dialog.has-actions { grid-template-rows: auto minmax(150px, 38%) auto minmax(0, 1fr); }
 .history-detail-dialog.no-proof.has-actions { grid-template-rows: auto auto minmax(0, 1fr); }
 .history-detail-dialog > header { display: flex; align-items: flex-start; justify-content: space-between; gap: 12px; }
 .history-detail-dialog > header small { color: var(--color-text-muted); font-size: 10px; font-weight: 900; letter-spacing: .08em; text-transform: uppercase; }
-.history-detail-dialog > header h2 { margin-top: 3px; font-size: 18px; }
-.history-detail-heading { display: grid; justify-items: start; gap: 3px; }
-.history-detail-heading .status-pill { margin-top: 3px; }
+.history-detail-dialog > header h2 { margin: 0; font-size: 17px; }
+.history-detail-heading { display: grid; grid-template-columns: auto auto; align-items: center; justify-items: start; gap: 2px 8px; }
+.history-detail-heading > small { grid-column: 1 / -1; }
+.history-detail-heading .status-pill { margin: 0; }
 .history-detail-dialog > header button { width: 36px; height: 36px; display: grid; place-items: center; flex: 0 0 auto; border: 0; border-radius: 12px; background: #f0f4f3; color: var(--color-text); }
 .history-detail-proof { width: 100%; min-height: 150px; overflow: hidden; border-radius: 16px; background: #eef4f2; }
 .history-detail-proof img { width: 100%; height: 100%; display: block; object-fit: contain; }
-.history-detail-dialog dl { min-height: 0; display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); align-content: start; gap: 8px; margin: 0; padding-right: 2px; overflow-y: auto; }
-.history-detail-dialog dl > div { display: grid; align-content: start; gap: 4px; min-height: 62px; padding: 9px 10px; border: 1px solid var(--color-border); border-radius: 12px; background: var(--color-canvas-elevated); }
+.history-detail-dialog dl { min-height: 0; display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); align-content: start; gap: 6px; margin: 0; padding-right: 2px; overflow-y: auto; }
+.history-detail-dialog dl > div { display: grid; align-content: start; gap: 2px; min-height: 50px; padding: 7px 9px; border: 1px solid var(--color-border); border-radius: 10px; background: var(--color-canvas-elevated); }
 .history-detail-dialog dl > div.wide { grid-column: 1 / -1; min-height: auto; }
-.history-detail-dialog dt { color: var(--color-text-muted); font-size: 11px; font-weight: 850; }
+.history-detail-dialog dt { color: var(--color-text-muted); font-size: 10px; font-weight: 850; }
 .history-detail-dialog dd { margin: 0; overflow-wrap: anywhere; color: var(--color-text); font-size: 12px; font-weight: 800; }
 .history-responsible-actions dd { display: grid; gap: 5px; }
 .history-responsible-actions dd span { color: var(--color-text); font-weight: 750; }


### PR DESCRIPTION
## Résumé
- réduit la hauteur et les espacements de la popup de vérification
- place le statut sur la même ligne que la date
- compacte les cartes de métadonnées et leur grille
- réserve davantage de place à la preuve
- conserve les boutons de décision à leur taille tactile
- publie la version 0.9.72

## Impact
Les informations utiles tiennent mieux sur un écran iPhone avec moins de défilement, sans réduire la lisibilité de la preuve ni les actions de validation.

## Validation
- `corepack pnpm check`
- 285 tests frontend
- 90 tests backend
- `corepack pnpm check:design`
- 43 tests ciblés des écrans concernés