### PR TITLE
Auto-size the verification detail popup

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zadiag-pwa",
   "private": true,
-  "version": "0.9.72",
+  "version": "0.9.73",
   "type": "module",
   "packageManager": "pnpm@11.7.0",
   "engines": {

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -1520,10 +1520,10 @@ button:disabled { cursor: not-allowed; }
 .routine-history-open:focus-visible { outline: 3px solid color-mix(in srgb, var(--routine-accent) 34%, transparent); outline-offset: -3px; border-radius: 12px; }
 .routine-history-row .submission-thumb-button { position: relative; z-index: 2; }
 .history-detail-backdrop { position: fixed; z-index: 70; inset: 0; display: grid; align-items: end; padding: 12px; background: rgba(8,26,40,.48); backdrop-filter: blur(5px); }
-.history-detail-dialog { width: min(100%, 520px); height: min(88dvh, 720px); display: grid; grid-template-rows: auto minmax(150px, 38%) minmax(0, 1fr); gap: 8px; margin: 0 auto; padding: 12px; overflow: hidden; border-radius: 22px; background: var(--color-surface-solid); box-shadow: 0 24px 70px rgba(8,26,40,.28); }
-.history-detail-dialog.no-proof { grid-template-rows: auto minmax(0, 1fr); }
-.history-detail-dialog.has-actions { grid-template-rows: auto minmax(150px, 38%) auto minmax(0, 1fr); }
-.history-detail-dialog.no-proof.has-actions { grid-template-rows: auto auto minmax(0, 1fr); }
+.history-detail-dialog { width: min(100%, 520px); max-height: 88dvh; display: grid; grid-template-rows: auto auto minmax(0, auto); gap: 8px; margin: 0 auto; padding: 12px; overflow: hidden; border-radius: 22px; background: var(--color-surface-solid); box-shadow: 0 24px 70px rgba(8,26,40,.28); }
+.history-detail-dialog.no-proof { grid-template-rows: auto minmax(0, auto); }
+.history-detail-dialog.has-actions { grid-template-rows: auto auto auto minmax(0, auto); }
+.history-detail-dialog.no-proof.has-actions { grid-template-rows: auto auto minmax(0, auto); }
 .history-detail-dialog > header { display: flex; align-items: flex-start; justify-content: space-between; gap: 12px; }
 .history-detail-dialog > header small { color: var(--color-text-muted); font-size: 10px; font-weight: 900; letter-spacing: .08em; text-transform: uppercase; }
 .history-detail-dialog > header h2 { margin: 0; font-size: 17px; }
@@ -1531,11 +1531,11 @@ button:disabled { cursor: not-allowed; }
 .history-detail-heading > small { grid-column: 1 / -1; }
 .history-detail-heading .status-pill { margin: 0; }
 .history-detail-dialog > header button { width: 36px; height: 36px; display: grid; place-items: center; flex: 0 0 auto; border: 0; border-radius: 12px; background: #f0f4f3; color: var(--color-text); }
-.history-detail-proof { width: 100%; min-height: 150px; overflow: hidden; border-radius: 16px; background: #eef4f2; }
+.history-detail-proof { width: 100%; height: min(34dvh, 280px); min-height: 180px; overflow: hidden; border-radius: 16px; background: #eef4f2; }
 .history-detail-proof img { width: 100%; height: 100%; display: block; object-fit: contain; }
-.history-detail-dialog dl { min-height: 0; display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); align-content: start; gap: 6px; margin: 0; padding-right: 2px; overflow-y: auto; }
-.history-detail-dialog dl > div { display: grid; align-content: start; gap: 2px; min-height: 50px; padding: 7px 9px; border: 1px solid var(--color-border); border-radius: 10px; background: var(--color-canvas-elevated); }
-.history-detail-dialog dl > div.wide { grid-column: 1 / -1; min-height: auto; }
+.history-detail-dialog dl { min-height: 0; max-height: min(31dvh, 230px); display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); align-content: start; gap: 5px; margin: 0; padding-right: 2px; overflow-y: auto; }
+.history-detail-dialog dl > div { min-width: 0; min-height: 0; display: flex; align-items: baseline; justify-content: space-between; gap: 6px; padding: 6px 8px; border: 1px solid var(--color-border); border-radius: 9px; background: var(--color-canvas-elevated); }
+.history-detail-dialog dl > div.wide { grid-column: 1 / -1; min-height: auto; display: grid; justify-content: stretch; gap: 2px; }
 .history-detail-dialog dt { color: var(--color-text-muted); font-size: 10px; font-weight: 850; }
 .history-detail-dialog dd { margin: 0; overflow-wrap: anywhere; color: var(--color-text); font-size: 12px; font-weight: 800; }
 .history-responsible-actions dd { display: grid; gap: 5px; }


### PR DESCRIPTION
## Résumé
- retire la hauteur fixe de 88dvh qui maintenait artificiellement la popup presque plein écran
- adapte désormais la hauteur au contenu avec une limite maximale
- plafonne la preuve à 280 px sans la rogner
- transforme les métadonnées principales en lignes label/valeur compactes
- conserve un défilement interne uniquement lorsque les détails supplémentaires l’exigent
- publie la version 0.9.73

## Cause
La première réduction diminuait les espacements, mais la hauteur fixe du conteneur annulait visuellement le gain sur iPhone.

## Validation
- `corepack pnpm check`
- 285 tests frontend
- 90 tests backend
- `corepack pnpm check:design`
- 43 tests ciblés des écrans concernés