### PR TITLE
Open verification details from review cards

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zadiag-pwa",
   "private": true,
-  "version": "0.9.75",
+  "version": "0.9.76",
   "type": "module",
   "packageManager": "pnpm@11.7.0",
   "engines": {

--- a/src/screens/ParentDashboard.test.tsx
+++ b/src/screens/ParentDashboard.test.tsx
@@ -704,8 +704,13 @@ describe('ParentDashboard', () => {
     expect(container.textContent).toContain('Confidence 67%');
     expect(container.textContent).toContain('Estimated quality 82%');
     expect(getProofImageUrl).toHaveBeenCalledWith('review');
+    act(() => detailDialog?.querySelector<HTMLButtonElement>('button[aria-label="Close"]')?.click());
+    expect(container.querySelector('.history-detail-dialog')).toBeNull();
+    act(() => container.querySelector<HTMLElement>('.parent-review-copy')?.click());
+    const reopenedDetailDialog = container.querySelector('.history-detail-dialog');
+    expect(reopenedDetailDialog).not.toBeNull();
     vi.useRealTimers();
-    const validate = detailDialog?.querySelector<HTMLButtonElement>('button[aria-label="Validate"]');
+    const validate = reopenedDetailDialog?.querySelector<HTMLButtonElement>('button[aria-label="Validate"]');
 
     await act(async () => {
       validate?.dispatchEvent(new MouseEvent('click', { bubbles: true }));

--- a/src/screens/ParentDashboard.tsx
+++ b/src/screens/ParentDashboard.tsx
@@ -72,6 +72,7 @@ export function ParentDashboard({
   const [weeklyReportOpenSignal, setWeeklyReportOpenSignal] = useState(0);
   const [weeklyInsightOpen, setWeeklyInsightOpen] = useState(false);
   const swipeStartRef = useRef<{ eventId: string; x: number; y: number } | undefined>(undefined);
+  const swipeDecisionRef = useRef(false);
   const handledNotificationEventIdRef = useRef<string | undefined>(undefined);
   const summaryRange = controlledSummaryRange ?? localSummaryRange;
   const setSummaryRange = onSummaryRangeChange ?? setLocalSummaryRange;
@@ -211,6 +212,7 @@ export function ParentDashboard({
   };
   const beginSwipe = (eventId: string, x: number, y: number, target: EventTarget) => {
     if (reviewingId === eventId || (target as HTMLElement).closest('button')) return;
+    swipeDecisionRef.current = false;
     swipeStartRef.current = { eventId, x, y };
   };
   const completeSwipe = (eventId: string, x: number, y: number) => {
@@ -220,6 +222,7 @@ export function ParentDashboard({
     const deltaX = x - swipeStart.x;
     const deltaY = y - swipeStart.y;
     if (Math.abs(deltaX) < 72 || Math.abs(deltaX) < Math.abs(deltaY) * 1.35) return;
+    swipeDecisionRef.current = true;
     void decide(eventId, deltaX > 0 ? 'detected' : 'not_detected');
   };
   const handleTouchStart = (event: TouchEvent<HTMLElement>, eventId: string) => {
@@ -522,6 +525,14 @@ export function ParentDashboard({
                   onMouseDown={(mouseEvent) => handleMouseDown(mouseEvent, event.id)}
                   onMouseLeave={() => { swipeStartRef.current = undefined; }}
                   onMouseUp={(mouseEvent) => handleMouseUp(mouseEvent, event.id)}
+                  onClick={(clickEvent) => {
+                    if ((clickEvent.target as HTMLElement).closest('button')) return;
+                    if (swipeDecisionRef.current) {
+                      swipeDecisionRef.current = false;
+                      return;
+                    }
+                    setDetailEventId(event.id);
+                  }}
                   onTouchCancel={() => { swipeStartRef.current = undefined; }}
                   onTouchEnd={(touchEvent) => handleTouchEnd(touchEvent, event.id)}
                   onTouchStart={(touchEvent) => handleTouchStart(touchEvent, event.id)}
@@ -546,6 +557,7 @@ export function ParentDashboard({
                           <small>{formatDateTime(event.capturedAt ?? event.requestedAt)}</small>
                           {proofExample ? <p className="routine-proof-context"><b>{t('expectedProof')}:</b> {proofExample}</p> : null}
                         </div>
+                        <button type="button" className="parent-review-detail-button" aria-label={`${t('historyDetailTitle')} · ${routineNameFor(event)}`} onClick={() => setDetailEventId(event.id)}><AppIcon name="chevron-forward" /></button>
                       </div>
                       {(source || confidence || quality) ? (
                         <div className="parent-review-analysis">

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -598,7 +598,7 @@ button:disabled { cursor: not-allowed; }
 .parent-empty-history-card p { margin: 3px 0 0; font-size: 12px; line-height: 1.35; }
 .parent-review-section { display: grid; gap: 10px; }
 .parent-review-list { display: grid; gap: 8px; }
-.parent-review-card { display: grid; padding: var(--row-padding-y) var(--row-padding-x); overflow: hidden; border-radius: 20px; touch-action: pan-y; }
+.parent-review-card { display: grid; padding: var(--row-padding-y) var(--row-padding-x); overflow: hidden; border-radius: 20px; cursor: pointer; touch-action: pan-y; }
 .parent-review-main { display: grid; grid-template-columns: 66px minmax(0, 1fr) auto; align-items: center; gap: 12px; min-height: 66px; }
 .parent-review-image {
   align-self: start;
@@ -622,7 +622,9 @@ button:disabled { cursor: not-allowed; }
 .parent-review-image img { width: 100%; height: 100%; display: block; border-radius: inherit; object-fit: cover; object-position: center; }
 .parent-review-image-button img { pointer-events: none; }
 .parent-review-copy { display: grid; align-content: start; gap: 6px; min-width: 0; }
-.parent-review-title-row { min-width: 0; }
+.parent-review-title-row { min-width: 0; display: grid; grid-template-columns: minmax(0, 1fr) auto; align-items: start; gap: 6px; }
+.parent-review-detail-button { width: 28px; height: 28px; display: grid; place-items: center; padding: 0; border: 0; border-radius: 9px; background: transparent; color: var(--color-text-muted); }
+.parent-review-detail-button .svg-icon { font-size: 14px; }
 .parent-review-copy strong { display: block; overflow: hidden; color: var(--color-text); font-size: 15px; text-overflow: ellipsis; white-space: nowrap; }
 .parent-review-copy small { display: block; margin-top: 2px; color: var(--color-text-muted); font-size: 12px; font-weight: 800; }
 .parent-review-copy p { display: -webkit-box; margin: 0; overflow: hidden; color: var(--color-text-muted); font-size: 12px; line-height: 1.32; -webkit-line-clamp: 2; -webkit-box-orient: vertical; }


### PR DESCRIPTION
## Summary
- open the full verification popup by tapping the review card content
- add a visible chevron button for direct and accessible detail access
- preserve proof zoom, approve/reject buttons, and swipe decisions
- bump the application version to 0.9.76

## Root cause
The review block exposed decision controls and proof zoom, but only history rows and notifications were connected to the full verification detail dialog.

## Validation
- `corepack pnpm check`
- 285 frontend tests passed
- 90 backend tests passed