### PR TITLE
Fix contact email registration forwarding

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zadiag-pwa",
   "private": true,
-  "version": "0.9.76",
+  "version": "0.9.77",
   "type": "module",
   "packageManager": "pnpm@11.7.0",
   "engines": {

--- a/src/services/repositoryFactory.test.ts
+++ b/src/services/repositoryFactory.test.ts
@@ -38,6 +38,7 @@ class FakeFirebaseRepository implements AppRepository {
     this.listeners.forEach((listener) => listener());
   }
 
+  async registerContactEmail(email: string) { return email.trim().toLowerCase(); }
   async selectRole(role: Role) { this.state = { ...this.state, role }; }
   async selectActiveParticipant(participantId: string) { this.state.activeParticipantId = participantId; }
   async createParticipant() { return 'participant-1'; }
@@ -95,6 +96,7 @@ describe('repository factory', () => {
     expect(firebaseRepositoryLoaded).toBe(true);
     expect(repository.snapshot()).toMatchObject({ role: 'parent', family: { linked: true, childName: 'Maya' } });
     expect(listener).toHaveBeenCalled();
+    await expect(repository.registerContactEmail?.(' USER@EXAMPLE.COM ')).resolves.toBe('user@example.com');
     await expect(repository.inviteParticipantMember?.('participant-1', 'caregiver')).resolves.toMatchObject({ code: 'ZI-123456' });
     await expect(repository.createRelationshipRecovery?.('participant-1')).resolves.toMatchObject({ recoveryCode: 'PR-2345-6789-ABCD' });
     expect(repository.listRoutineDrafts).toBeTypeOf('function');

--- a/src/services/repositoryFactory.ts
+++ b/src/services/repositoryFactory.ts
@@ -28,6 +28,12 @@ class LazyFirebaseRepository implements AppRepository {
     this.emit();
   }
 
+  async registerContactEmail(email: string) {
+    const repository = await this.load();
+    if (!repository.registerContactEmail) throw new Error('contact_email_registration_unavailable');
+    return repository.registerContactEmail(email);
+  }
+
   async selectRole(role: Role) {
     return (await this.load()).selectRole(role);
   }


### PR DESCRIPTION
## What changed

- forward `registerContactEmail` through `LazyFirebaseRepository`
- add a regression assertion covering the lazy repository boundary
- bump the app version to `0.9.70`

## Root cause

The contact screen called an optional method on the lazy repository. The concrete Firebase repository implemented it, but the lazy wrapper did not. The guard in `App.tsx` therefore returned silently, so clicking Continue produced no network request or visible error.

## Impact

New users can submit their contact email and continue onboarding again.

## Validation

- `pnpm check`
- 283 frontend tests
- 89 Functions tests
- architecture and design checks
- production build and bundle-size check
