### PR TITLE
Add review actions to proof lightbox

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zadiag-pwa",
   "private": true,
-  "version": "0.9.80",
+  "version": "0.9.81",
   "type": "module",
   "packageManager": "pnpm@11.7.0",
   "engines": {

--- a/src/components/ProofLightbox.tsx
+++ b/src/components/ProofLightbox.tsx
@@ -1,10 +1,12 @@
 import { AppIcon } from './Icon';
 import { useModalFocus } from '../hooks/useModalFocus';
+import type { ReactNode } from 'react';
 
-export function ProofLightbox({ src, alt, closeLabel, onClose }: {
+export function ProofLightbox({ src, alt, closeLabel, actions, onClose }: {
   src: string;
   alt: string;
   closeLabel: string;
+  actions?: ReactNode;
   onClose: () => void;
 }) {
   const dialogRef = useModalFocus<HTMLDivElement>(true, onClose);
@@ -12,7 +14,10 @@ export function ProofLightbox({ src, alt, closeLabel, onClose }: {
   return (
     <div ref={dialogRef} className="proof-lightbox" role="dialog" aria-modal="true" aria-label={alt} tabIndex={-1} onClick={onClose}>
       <button type="button" className="proof-lightbox-close" data-autofocus aria-label={closeLabel} onClick={onClose}><AppIcon name="close" /></button>
-      <img src={src} alt={alt} onClick={(event) => event.stopPropagation()} />
+      <div className={`proof-lightbox-content${actions ? ' has-actions' : ''}`} onClick={(event) => event.stopPropagation()}>
+        <img src={src} alt={alt} />
+        {actions ? <div className="proof-lightbox-actions">{actions}</div> : null}
+      </div>
     </div>
   );
 }

--- a/src/screens/ParentDashboard.test.tsx
+++ b/src/screens/ParentDashboard.test.tsx
@@ -709,8 +709,11 @@ describe('ParentDashboard', () => {
     act(() => container.querySelector<HTMLElement>('.parent-review-copy')?.click());
     const reopenedDetailDialog = container.querySelector('.history-detail-dialog');
     expect(reopenedDetailDialog).not.toBeNull();
+    act(() => reopenedDetailDialog?.querySelector<HTMLButtonElement>('button[aria-label="Close"]')?.click());
+    act(() => container.querySelector<HTMLButtonElement>('.parent-review-image-button')?.click());
+    expect(container.querySelector('.proof-lightbox')).not.toBeNull();
     vi.useRealTimers();
-    const validate = reopenedDetailDialog?.querySelector<HTMLButtonElement>('button[aria-label="Validate"]');
+    const validate = container.querySelector<HTMLButtonElement>('.proof-lightbox button[aria-label="Validate"]');
 
     await act(async () => {
       validate?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
@@ -718,6 +721,7 @@ describe('ParentDashboard', () => {
     });
 
     expect(reviewCheck).toHaveBeenCalledWith('review', 'detected');
+    expect(container.querySelector('.proof-lightbox')).toBeNull();
   });
 
   it('tries to recover proof images for legacy uncertain checks without proof metadata', async () => {

--- a/src/screens/ParentDashboard.tsx
+++ b/src/screens/ParentDashboard.tsx
@@ -64,7 +64,7 @@ export function ParentDashboard({
   const [reviewErrorId, setReviewErrorId] = useState<string>();
   const [requestingActiveReminder, setRequestingActiveReminder] = useState(false);
   const [activeReminderStatus, setActiveReminderStatus] = useState<'sent' | 'error'>();
-  const [enlargedProofUrl, setEnlargedProofUrl] = useState<string>();
+  const [enlargedProof, setEnlargedProof] = useState<{ eventId: string; url: string }>();
   const [detailEventId, setDetailEventId] = useState<string>();
   const [dismissedAnomaly, setDismissedAnomaly] = useState<string>();
   const [planningRecommendationOpen, setPlanningRecommendationOpen] = useState(false);
@@ -183,14 +183,16 @@ export function ParentDashboard({
     }
   };
   const decide = async (eventId: string, decision: 'detected' | 'not_detected') => {
-    if (!reviewCheck) return;
+    if (!reviewCheck) return false;
     setReviewingId(eventId);
     setReviewErrorId(undefined);
     try {
       await reviewCheck(eventId, decision);
+      return true;
     } catch (error) {
       console.error(error);
       setReviewErrorId(eventId);
+      return false;
     } finally {
       setReviewingId(undefined);
     }
@@ -543,7 +545,7 @@ export function ParentDashboard({
                         type="button"
                         className="parent-review-image parent-review-image-button"
                         aria-label={t('responsibleReviewImageAlt')}
-                        onClick={() => setEnlargedProofUrl(proofUrl)}
+                        onClick={() => setEnlargedProof({ eventId: event.id, url: proofUrl })}
                       >
                         {renderImage()}
                       </button>
@@ -602,8 +604,19 @@ export function ParentDashboard({
         <UpcomingChecksSection checks={upcomingChecks} now={nowDate} locale={locale} titleId="responsible-upcoming-checks-title" t={t} />
       ) : null}
 
-      {enlargedProofUrl ? (
-        <ProofLightbox src={enlargedProofUrl} alt={t('responsibleReviewImageAlt')} closeLabel={t('close')} onClose={() => setEnlargedProofUrl(undefined)} />
+      {enlargedProof ? (
+        <ProofLightbox
+          src={enlargedProof.url}
+          alt={t('responsibleReviewImageAlt')}
+          closeLabel={t('close')}
+          onClose={() => setEnlargedProof(undefined)}
+          actions={(
+            <>
+              <button type="button" className="parent-review-button reject" aria-label={t('responsibleReviewReject')} disabled={reviewingId === enlargedProof.eventId} onClick={() => { void decide(enlargedProof.eventId, 'not_detected').then((completed) => { if (completed) setEnlargedProof(undefined); }); }}><AppIcon name="close" /></button>
+              <button type="button" className="parent-review-button approve" aria-label={t('responsibleReviewApprove')} disabled={reviewingId === enlargedProof.eventId} onClick={() => { void decide(enlargedProof.eventId, 'detected').then((completed) => { if (completed) setEnlargedProof(undefined); }); }}><AppIcon name="check" /></button>
+            </>
+          )}
+        />
       ) : null}
 
       <section className="today-section participant-history-section parent-history-section dashboard-summary-section" aria-labelledby="responsible-summary-title">

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -731,7 +731,9 @@ button:disabled { cursor: not-allowed; }
   padding: max(18px, env(safe-area-inset-top)) 18px max(18px, env(safe-area-inset-bottom));
   background: rgba(10, 24, 38, .82);
 }
+.proof-lightbox-content { max-width: min(100%, 860px); max-height: 86dvh; display: grid; gap: 10px; }
 .proof-lightbox img {
+  width: 100%;
   max-width: min(100%, 860px);
   max-height: 86vh;
   display: block;
@@ -739,6 +741,9 @@ button:disabled { cursor: not-allowed; }
   object-fit: contain;
   box-shadow: 0 22px 70px rgba(0,0,0,.35);
 }
+.proof-lightbox-content.has-actions img { max-height: calc(86dvh - 64px); }
+.proof-lightbox-actions { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 10px; }
+.proof-lightbox-actions .parent-review-button { width: 100%; min-height: 48px; box-shadow: var(--shadow-sm); }
 .proof-lightbox-close {
   position: fixed;
   top: max(14px, env(safe-area-inset-top));


### PR DESCRIPTION
## Summary
- add reject and approve actions below enlarged review proofs
- keep the shared lightbox unchanged when opened from ordinary routine history
- close the lightbox after a successful decision and keep it open when the review fails
- bump the application version to 0.9.81

## Why
Responsible users can now decide directly while inspecting the full-size proof instead of closing the image first.

## Validation
- `corepack pnpm check`
- 285 frontend tests passed
- 90 backend tests passed