### PR TITLE
Stabilize Gemini check analysis output

### DIFF
--- a/functions/src/analysis.test.ts
+++ b/functions/src/analysis.test.ts
@@ -89,9 +89,17 @@ test('calls Gemini with the expected payload and returns a conforming analysis r
   assert.equal(sentUrl, 'https://generativelanguage.googleapis.com/v1beta/models/gemini-test-model:generateContent');
   assert.equal(sentInit?.method, 'POST');
   assert.equal((sentInit?.headers as Record<string, string>)?.Authorization, 'Bearer token-123');
-  const sentBody = JSON.parse(String(sentInit?.body)) as { generationConfig?: { maxOutputTokens?: number; responseMimeType?: string } };
+  const sentBody = JSON.parse(String(sentInit?.body)) as { generationConfig?: {
+    maxOutputTokens?: number;
+    responseMimeType?: string;
+    responseSchema?: { required?: string[]; properties?: Record<string, { enum?: string[] }> };
+    thinkingConfig?: { thinkingBudget?: number };
+  } };
   assert.equal(sentBody.generationConfig?.responseMimeType, 'application/json');
   assert.equal(sentBody.generationConfig?.maxOutputTokens, 768);
+  assert.equal(sentBody.generationConfig?.thinkingConfig?.thinkingBudget, 0);
+  assert.deepEqual(sentBody.generationConfig?.responseSchema?.required, ['status', 'confidence', 'imageQuality', 'reason']);
+  assert.deepEqual(sentBody.generationConfig?.responseSchema?.properties?.status.enum, ['detected', 'not_detected', 'uncertain']);
   assert.deepEqual(result, {
     status: 'detected',
     confidence: 0.93,

--- a/functions/src/analysis.ts
+++ b/functions/src/analysis.ts
@@ -117,6 +117,16 @@ type GeminiGenerateContentResponse = {
 type AnalysisLocale = 'en' | 'fr';
 
 const GEMINI_ANALYSIS_MAX_OUTPUT_TOKENS = 768;
+const GEMINI_ANALYSIS_RESPONSE_SCHEMA = {
+  type: 'OBJECT',
+  required: ['status', 'confidence', 'imageQuality', 'reason'],
+  properties: {
+    status: { type: 'STRING', enum: ['detected', 'not_detected', 'uncertain'] },
+    confidence: { type: 'NUMBER', minimum: 0, maximum: 1 },
+    imageQuality: { type: 'NUMBER', minimum: 0, maximum: 1 },
+    reason: { type: 'STRING', maxLength: 220 },
+  },
+} as const;
 
 const defaultRoutineAnalysis: RoutineAnalysisContext = {
   routineName: 'Treatment adherence',
@@ -190,6 +200,8 @@ const requestGeminiAnalysis = async (
         temperature: 0,
         maxOutputTokens: GEMINI_ANALYSIS_MAX_OUTPUT_TOKENS,
         responseMimeType: 'application/json',
+        responseSchema: GEMINI_ANALYSIS_RESPONSE_SCHEMA,
+        thinkingConfig: { thinkingBudget: 0 },
       },
     }),
   });

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zadiag-pwa",
   "private": true,
-  "version": "0.9.81",
+  "version": "0.9.82",
   "type": "module",
   "packageManager": "pnpm@11.7.0",
   "engines": {


### PR DESCRIPTION
## Summary
- disable unnecessary dynamic thinking for the bounded Gemini 2.5 Flash image classification
- require the exact structured JSON contract consumed by check analysis
- test the thinking budget and response schema sent to Gemini
- bump the app patch version to 0.9.82

## Why
Production logs showed repeated `MAX_TOKENS` completions without JSON for the Raspberry Pi health routine. Gemini exhausted the output budget in its internal reasoning before returning the required payload.

## Validation
- `pnpm check`
- Functions TypeScript build
- analysis tests
- `git diff --check`