### PR TITLE
Fix reviewed check detail presentation

### DIFF
--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -3218,7 +3218,6 @@ export const reviewCheck = onCall({ region, cors, enforceAppCheck: true }, async
       reviewStatus: decision === 'detected' ? 'approved' : 'rejected',
       reviewedAt,
       reviewedBy: uid,
-      reviewReason: 'responsible_review',
       responsibleActions: [
         ...(Array.isArray(checkData.responsibleActions) ? checkData.responsibleActions : []),
         { type: decision === 'detected' ? 'approved' : 'rejected', at: reviewedAt, actorUid: uid, actorName },

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zadiag-pwa",
   "private": true,
-  "version": "0.9.83",
+  "version": "0.9.84",
   "type": "module",
   "packageManager": "pnpm@11.7.0",
   "engines": {

--- a/src/components/VerificationEventDetailDialog.test.tsx
+++ b/src/components/VerificationEventDetailDialog.test.tsx
@@ -1,0 +1,52 @@
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import type { VerificationEvent } from '../domain/models';
+import { translate } from '../services/i18n';
+import { VerificationEventDetailDialog } from './VerificationEventDetailDialog';
+
+const reviewedEvent: VerificationEvent = {
+  id: 'reviewed',
+  routineId: 'routine',
+  sessionId: 'session',
+  requestedAt: '2026-07-20T12:03:00.000Z',
+  capturedAt: '2026-07-20T12:17:00.000Z',
+  expiresAt: '2026-07-20T14:00:00.000Z',
+  status: 'detected',
+  reviewStatus: 'approved',
+  reviewedAt: '2026-07-20T12:18:00.000Z',
+  reviewReason: 'responsible_review',
+};
+
+describe('VerificationEventDetailDialog', () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+  });
+
+  it('opens reviewed information by default without exposing its legacy system marker', () => {
+    act(() => root.render(<VerificationEventDetailDialog event={reviewedEvent} locale="en" onClose={() => undefined} t={(key) => translate('en', key)} />));
+
+    expect(container.querySelector('dl')).not.toBeNull();
+    expect(container.querySelector('button[aria-label="Hide information"]')?.getAttribute('aria-expanded')).toBe('true');
+    expect(container.textContent).not.toContain('responsible_review');
+    expect(container.textContent).not.toContain('Review comment');
+  });
+
+  it('keeps information collapsed while a check is still waiting for review', () => {
+    act(() => root.render(<VerificationEventDetailDialog event={{ ...reviewedEvent, status: 'uncertain', reviewStatus: 'pending', reviewedAt: undefined, reviewReason: undefined }} locale="en" onClose={() => undefined} t={(key) => translate('en', key)} />));
+
+    expect(container.querySelector('dl')).toBeNull();
+    expect(container.querySelector('button[aria-label="Show all information"]')?.getAttribute('aria-expanded')).toBe('false');
+  });
+});

--- a/src/components/VerificationEventDetailDialog.tsx
+++ b/src/components/VerificationEventDetailDialog.tsx
@@ -21,7 +21,7 @@ export function VerificationEventDetailDialog({ event, locale, proofUrl: provide
   const dialogRef = useModalFocus<HTMLDivElement>(true, onClose);
   const [loadedProofUrl, setLoadedProofUrl] = useState<string>();
   const [proofError, setProofError] = useState(false);
-  const [detailsExpanded, setDetailsExpanded] = useState(false);
+  const [detailsExpanded, setDetailsExpanded] = useState(() => ['approved', 'rejected'].includes(event.reviewStatus ?? ''));
   const [reviewing, setReviewing] = useState(false);
   const [reviewError, setReviewError] = useState(false);
   const [requestStatus, setRequestStatus] = useState<'sending' | 'sent' | 'error'>();
@@ -33,6 +33,7 @@ export function VerificationEventDetailDialog({ event, locale, proofUrl: provide
   const formatDateTime = (value: string) => new Intl.DateTimeFormat(formatterLocale, { dateStyle: 'short', timeStyle: 'short' }).format(new Date(value));
   const analysisSourceLabel = event.analysisSource ? t(event.analysisSource === 'ai' ? 'analysisSourceAi' : event.analysisSource === 'fallback' ? 'analysisSourceFallback' : 'analysisSourceSelf') : undefined;
   const reviewStatusLabel = event.reviewStatus ? t(event.reviewStatus === 'approved' ? 'historyReviewApproved' : event.reviewStatus === 'rejected' ? 'historyReviewRejected' : 'historyReviewPending') : undefined;
+  const reviewReason = event.reviewReason === 'responsible_review' ? undefined : event.reviewReason;
   const actionKeys: Record<NonNullable<VerificationEvent['responsibleActions']>[number]['type'], MessageKey> = {
     requested: 'historyActionRequested',
     reminded: 'historyActionReminded',
@@ -51,6 +52,10 @@ export function VerificationEventDetailDialog({ event, locale, proofUrl: provide
       .catch((error) => { console.error(error); if (active) setProofError(true); });
     return () => { active = false; };
   }, [event.id, event.proofImagePath, getProofImageUrl, providedProofUrl]);
+
+  useEffect(() => {
+    if (['approved', 'rejected'].includes(event.reviewStatus ?? '')) setDetailsExpanded(true);
+  }, [event.reviewStatus]);
 
   const decide = async (decision: 'detected' | 'not_detected') => {
     if (!reviewCheck) return;
@@ -122,7 +127,7 @@ export function VerificationEventDetailDialog({ event, locale, proofUrl: provide
           {event.reason ? <div className="wide"><dt>{t('analysisReason')}</dt><dd>{event.reason}</dd></div> : null}
           {reviewStatusLabel ? <div><dt>{t('historyReviewDecision')}</dt><dd>{reviewStatusLabel}</dd></div> : null}
           {event.reviewedAt ? <div><dt>{t('historyReviewedAt')}</dt><dd>{formatDateTime(event.reviewedAt)}</dd></div> : null}
-          {event.reviewReason ? <div className="wide"><dt>{t('historyReviewComment')}</dt><dd>{event.reviewReason}</dd></div> : null}
+          {reviewReason ? <div className="wide"><dt>{t('historyReviewComment')}</dt><dd>{reviewReason}</dd></div> : null}
           {event.responsibleActions?.length ? (
             <div className="wide history-responsible-actions">
               <dt>{t('historyResponsibleActions')}</dt>

--- a/src/screens/RoutinesScreen.test.tsx
+++ b/src/screens/RoutinesScreen.test.tsx
@@ -277,8 +277,8 @@ describe('participant routines navigation', () => {
     expect(historyOpen?.getAttribute('aria-label')).toContain('Check details');
     act(() => historyOpen?.click());
     expect(container.querySelector('.history-detail-dialog')).not.toBeNull();
-    expect(container.querySelector('.history-detail-dialog dl')).toBeNull();
-    act(() => container.querySelector<HTMLButtonElement>('button[aria-label="Show all information"]')?.click());
+    expect(container.querySelector('.history-detail-dialog dl')).not.toBeNull();
+    expect(container.querySelector<HTMLButtonElement>('button[aria-label="Hide information"]')?.getAttribute('aria-expanded')).toBe('true');
     expect(container.querySelector('.history-detail-dialog')?.textContent).toContain('Proof sent');
     expect(container.querySelector('.history-detail-dialog')?.textContent).toContain('AI');
     expect(container.querySelector('.history-detail-dialog')?.textContent).toContain('82%');

--- a/src/services/demoRepository.ts
+++ b/src/services/demoRepository.ts
@@ -590,7 +590,6 @@ export class DemoRepository implements AppRepository {
       reviewStatus: decision === 'detected' ? 'approved' : 'rejected',
       reviewedAt,
       reviewedBy: 'demo-parent',
-      reviewReason: 'responsible_review',
       responsibleActions: [...(event.responsibleActions ?? []), {
         type: decision === 'detected' ? 'approved' : 'rejected',
         at: reviewedAt, actorUid: 'demo-parent', actorName: this.state.accountDisplayName ?? 'Responsable démo',

--- a/src/services/firebaseRepository.ts
+++ b/src/services/firebaseRepository.ts
@@ -157,7 +157,7 @@ const asEvent = (id: string, data: DocumentData): VerificationEvent => ({
   reviewStatus: asReviewStatus(data.reviewStatus),
   reviewedAt: data.reviewedAt ? String(data.reviewedAt) : undefined,
   reviewedBy: data.reviewedBy ? String(data.reviewedBy) : undefined,
-  reviewReason: data.reviewReason ? String(data.reviewReason) : undefined,
+  reviewReason: data.reviewReason && data.reviewReason !== 'responsible_review' ? String(data.reviewReason) : undefined,
   responsibleActions: asResponsibleActions(data.responsibleActions),
 });
 

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -1593,8 +1593,8 @@ button:disabled { cursor: not-allowed; }
 .history-detail-proof > span { width: 100%; height: 100%; display: flex; align-items: center; justify-content: center; gap: 9px; padding: 16px; color: var(--color-text-muted); font-size: 12px; font-weight: 800; text-align: center; }
 .history-detail-proof-loading .button-spinner { flex: 0 0 auto; }
 .history-detail-disclosure { min-height: var(--height-action); display: flex; align-items: center; justify-content: space-between; gap: 10px; padding-left: 4px; color: var(--color-text-muted); font-size: 12px; font-weight: 850; }
-.history-detail-dialog dl { min-height: 0; max-height: min(31dvh, 230px); display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); align-content: start; gap: 5px; margin: 0; padding-right: 2px; overflow-y: auto; }
-.history-detail-dialog dl > div { min-width: 0; min-height: 0; display: flex; align-items: baseline; justify-content: space-between; gap: 6px; padding: 6px 8px; border: 1px solid var(--color-border); border-radius: 9px; background: var(--color-canvas-elevated); }
+.history-detail-dialog dl { min-height: 0; max-height: min(46dvh, 360px); display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); grid-auto-rows: max-content; align-content: start; gap: 7px; margin: 0; padding-right: 2px; overflow-y: auto; overscroll-behavior: contain; }
+.history-detail-dialog dl > div { min-width: 0; min-height: 34px; display: flex; align-items: baseline; justify-content: space-between; gap: 6px; padding: 7px 10px; border: 1px solid var(--color-border); border-radius: 9px; background: var(--color-canvas-elevated); }
 .history-detail-dialog dl > div.wide { grid-column: 1 / -1; min-height: auto; display: grid; justify-content: stretch; gap: 2px; }
 .history-detail-dialog dt { color: var(--color-text-muted); font-size: 10px; font-weight: 850; }
 .history-detail-dialog dd { margin: 0; overflow-wrap: anywhere; color: var(--color-text); font-size: 12px; font-weight: 800; }


### PR DESCRIPTION
## Summary
- open check information by default after a responsible decision while keeping pending reviews compact
- prevent detail rows from collapsing and overlapping on mobile
- make the expanded information area scroll cleanly when content is long
- stop persisting the internal `responsible_review` marker and hide it for existing records
- add focused coverage for reviewed and pending popup states
- bump the app patch version to 0.9.84

## Evidence
Reviewed against the three Mayuri iPhone captures received on 2026-07-20.

## Validation
- `pnpm check`
- 45 targeted popup/dashboard/routine tests
- `git diff --check`