### PR TITLE
Refine routine library layout

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zadiag-pwa",
   "private": true,
-  "version": "0.9.93",
+  "version": "0.9.94",
   "type": "module",
   "packageManager": "pnpm@11.7.0",
   "engines": {

--- a/src/screens/RoutinesScreen.test.tsx
+++ b/src/screens/RoutinesScreen.test.tsx
@@ -126,10 +126,11 @@ describe('participant routines navigation', () => {
     const listDrafts = vi.fn().mockResolvedValue([draft]);
     const deleteDraft = vi.fn().mockResolvedValue(undefined);
     const assignDraft = vi.fn().mockResolvedValue(undefined);
+    const exportDraft = vi.fn().mockResolvedValue({ content: '{}', mimeType: 'application/vnd.zadiag.routine+json', fileName: 'routine.zadiag-routine' });
     vi.spyOn(window, 'confirm').mockReturnValue(true);
 
     act(() => {
-      root.render(<RoutinesScreen state={state} onAssignRoutine={async () => undefined} onListRoutineDrafts={listDrafts} onDeleteRoutineDraft={deleteDraft} onAssignRoutineDraft={assignDraft} t={(key) => translate('en', key)} />);
+      root.render(<RoutinesScreen state={state} onAssignRoutine={async () => undefined} onListRoutineDrafts={listDrafts} onDeleteRoutineDraft={deleteDraft} onAssignRoutineDraft={assignDraft} onExportRoutinePackage={exportDraft} t={(key) => translate('en', key)} />);
     });
     await act(async () => {
       document.body.querySelector<HTMLButtonElement>('.routines-add-dock-button')?.click();
@@ -146,13 +147,15 @@ describe('participant routines navigation', () => {
     expect(document.body.textContent).toContain('My hydration plan');
     expect(document.body.querySelectorAll('.routine-catalog-item')).toHaveLength(0);
 
-    const view = Array.from(document.body.querySelectorAll<HTMLButtonElement>('button')).find((button) => button.textContent === 'View');
+    expect(document.body.textContent).toContain('Revision 2');
+    const view = document.body.querySelector<HTMLButtonElement>('button[aria-label="View"]');
     act(() => view?.click());
     expect(view?.getAttribute('aria-expanded')).toBe('true');
     expect(document.body.textContent).toContain('A private draft description');
     expect(document.body.textContent).toContain('Revision 2 · 1 issues');
     expect(document.body.textContent).toContain('Responsible view');
     expect(document.body.textContent).toContain('Participant view');
+    expect(Array.from(document.body.querySelectorAll<HTMLButtonElement>('button')).find((button) => button.textContent?.includes('Export'))).toBeDefined();
     expect(Array.from(document.body.querySelectorAll<HTMLButtonElement>('button')).find((button) => button.textContent === 'Assign this draft')?.disabled).toBe(true);
     expect(assignDraft).not.toHaveBeenCalled();
 
@@ -162,6 +165,40 @@ describe('participant routines navigation', () => {
     });
     expect(deleteDraft).toHaveBeenCalledWith('participant-1', 'draft-1', 2);
     expect(document.body.textContent).not.toContain('My hydration plan');
+  });
+
+  it('keeps loaded drafts visible without a blocking message during refresh', async () => {
+    const assignment = createDefaultRoutineAssignment('2026-07-02T08:00:00.000Z');
+    const state: AppState = {
+      role: 'parent', locale: 'en', notificationsEnabled: true,
+      family: { linked: true, childLinked: true, childName: 'Maya', linkingCode: '', parentRecoveryCode: '', consented: true },
+      participantAccess: [{ participant: { id: 'participant-1', displayName: 'Maya' }, membership: { role: 'owner', status: 'active' } }],
+      activeParticipantId: 'participant-1', routineAssignments: [assignment], events: [], routinesLoaded: true, routinesError: false,
+    };
+    const draft: RoutineDraft = {
+      id: 'draft-1', ownerId: 'owner-1', revision: 4, state: 'active',
+      package: { schemaVersion: 1, version: 1, defaultLocale: 'en', availableLocales: ['en'], routine: { ...assignment.routine, id: 'private-hydration', name: 'My hydration plan' } },
+      validation: { status: 'valid', issues: [] }, createdAt: '2026-07-02T08:00:00.000Z', updatedAt: '2026-07-02T09:00:00.000Z',
+    };
+    const initialList = vi.fn().mockResolvedValue([draft]);
+    const render = (listDrafts: (participantId: string) => Promise<RoutineDraft[]>) => root.render(<RoutinesScreen state={state} onAssignRoutine={vi.fn()} onListRoutineDrafts={listDrafts} t={(key) => translate('en', key)} />);
+
+    act(() => render(initialList));
+    await act(async () => {
+      document.body.querySelector<HTMLButtonElement>('.routines-add-dock-button')?.click();
+      await Promise.resolve();
+    });
+    await act(async () => {
+      Array.from(document.body.querySelectorAll<HTMLButtonElement>('.routine-catalog-tabs button')).find((button) => button.textContent === 'Private drafts')?.click();
+      await Promise.resolve();
+    });
+    expect(document.body.textContent).toContain('My hydration plan');
+
+    const refreshingList = vi.fn(() => new Promise<RoutineDraft[]>(() => undefined));
+    act(() => render(refreshingList));
+    expect(document.body.querySelector('#routine-catalog-drafts-panel')?.getAttribute('aria-busy')).toBe('true');
+    expect(document.body.textContent).toContain('My hydration plan');
+    expect(document.body.textContent).not.toContain('Loading private drafts');
   });
 
   it('opens the selected routine element in a focused private draft editor', async () => {
@@ -234,7 +271,7 @@ describe('participant routines navigation', () => {
       Array.from(document.body.querySelectorAll<HTMLButtonElement>('.routine-catalog-tabs button')).find((button) => button.textContent === 'Private drafts')?.click();
       await Promise.resolve();
     });
-    act(() => Array.from(document.body.querySelectorAll<HTMLButtonElement>('button')).find((button) => button.textContent === 'View')?.click());
+    act(() => document.body.querySelector<HTMLButtonElement>('button[aria-label="View"]')?.click());
     act(() => Array.from(document.body.querySelectorAll<HTMLButtonElement>('button')).find((button) => button.textContent === 'Review publication')?.click());
 
     expect(publish).not.toHaveBeenCalled();

--- a/src/screens/RoutinesScreen.tsx
+++ b/src/screens/RoutinesScreen.tsx
@@ -573,10 +573,10 @@ export function RoutinesScreen({
           </div> : null}
           <div className="routine-catalog-list">
             {catalogSection === 'drafts' && onListRoutineDrafts ? (
-              <section id="routine-catalog-drafts-panel" className="routine-library-group" role="tabpanel" aria-labelledby="routine-catalog-drafts-tab">
+              <section id="routine-catalog-drafts-panel" className="routine-library-group" role="tabpanel" aria-labelledby="routine-catalog-drafts-tab" aria-busy={draftsStatus === 'loading'}>
                 <div className="routine-library-group-heading"><h3 id="routine-library-drafts-title">{t('routineLibraryDrafts')}</h3><div>{onImportRoutinePackage ? <label className="routine-import-button">{t('routineImport')}<input type="file" accept="application/vnd.zadiag.routine+json,.zadiag-routine" onChange={(event) => { const file = event.target.files?.[0]; if (file) void importPackage(file); event.target.value = ''; }} /></label> : null}{onCreateRoutineDraft ? <button type="button" onClick={() => openDraftEditor('new')}>{t('routineDraftNew')}</button> : null}</div></div>
                 {!online ? <p className="routine-library-state" role="status">{t('routineLibraryDraftsOffline')}</p> : null}
-                {online && draftsStatus === 'loading' ? <p className="routine-library-state" role="status">{t('routineLibraryLoadingDrafts')}</p> : null}
+                {online && draftsStatus === 'loading' && !routineDrafts.length ? <p className="routine-library-state" role="status">{t('routineLibraryLoadingDrafts')}</p> : null}
                 {online && draftsStatus === 'error' ? (
                   <div className="routine-library-state" role="alert">
                     <p>{t('routineLibraryDraftsError')}</p>
@@ -601,16 +601,13 @@ export function RoutinesScreen({
                     <article className="routine-library-draft" key={draft.id} style={visual.style}>
                       <div className="routine-library-draft-heading">
                         <span className="settings-row-icon routine-icon" aria-hidden="true"><AppIcon name={routineIconName(visual.icon)} /></span>
-                        <div>
-                          <span className="routine-library-badge">{t(statusKey)}</span>
+                        <div className="routine-library-draft-copy">
+                          <div className="routine-library-draft-meta"><span className="routine-library-badge">{t(statusKey)}</span><small>{formatMessage(t('routineLibraryRevision'), { revision: draft.revision })}</small></div>
                           <h4>{visual.name}</h4>
                         </div>
                         <div className="routine-library-draft-actions">
-                          {onUpdateRoutineDraft && draft.state === 'active' ? <button type="button" onClick={() => openDraftEditor(draft.id)}>{t('routineDraftResume')}</button> : <button type="button" aria-expanded={expanded} onClick={() => setOpenDraftId(expanded ? undefined : draft.id)}>{expanded ? t('routineLibraryCloseDraft') : t('routineLibraryOpenDraft')}</button>}
-                          <button type="button" disabled={deletingDraftId === draft.id} onClick={() => { void deleteDraft(draft, visual.name); }} aria-label={formatMessage(t('routineLibraryDeleteDraft'), { routine: visual.name })}>
-                            <AppIcon name="close" />
-                          </button>
-                          {onExportRoutinePackage ? <button type="button" onClick={() => { void exportDraft(draft.id); }}>{t('routineExport')}</button> : null}
+                          {onUpdateRoutineDraft && draft.state === 'active' ? <button type="button" className="routine-library-draft-edit" onClick={() => openDraftEditor(draft.id)}>{t('routineDraftResume')}</button> : null}
+                          <DisclosureToggle expanded={expanded} showLabel={t('routineLibraryOpenDraft')} hideLabel={t('routineLibraryCloseDraft')} onToggle={() => setOpenDraftId(expanded ? undefined : draft.id)} />
                         </div>
                       </div>
                       {expanded ? (
@@ -623,6 +620,10 @@ export function RoutinesScreen({
                           {onAssignRoutineDraft ? <button type="button" className="routine-draft-assign" disabled={draft.validation.status !== 'valid' || draft.state !== 'active' || assigningDraftId === draft.id} onClick={() => { void assignDraft(draft); }}>{assigningDraftId === draft.id ? t('routineDraftAssigning') : t('routineDraftAssign')}</button> : null}
                           {reviewingPublication ? <section className="routine-publish-review" aria-label={t('routinePublishReviewTitle')}><h5>{formatMessage(t('routinePublishReviewVersion'), { version: draft.package.version })}</h5>{changes.length ? <ul>{changes.map((change) => <li key={change}>{t(routineChangeLabelKeys[change])}</li>)}</ul> : <p>{t(sourceAssignment ? 'routinePublishNoChanges' : 'routinePublishNewRoutine')}</p>}<p>{t('routinePublishImmutableNotice')}</p><div><button type="button" onClick={() => setReviewingPublishDraftId(undefined)}>{t('cancel')}</button><button type="button" className="routine-draft-publish" disabled={!changes.length && Boolean(sourceAssignment) || publishingDraftId === draft.id} onClick={() => { void publishDraft(draft); }}>{publishingDraftId === draft.id ? t('routineDraftPublishing') : t('routinePublishConfirm')}</button></div></section> : null}
                           {onPublishRoutineDraft && !reviewingPublication ? <button type="button" className="routine-draft-publish" disabled={draft.validation.status !== 'valid' || draft.state !== 'active' || publishingDraftId === draft.id} onClick={() => setReviewingPublishDraftId(draft.id)}>{t('routineDraftPublish')}</button> : null}
+                          {onExportRoutinePackage || onDeleteRoutineDraft ? <div className="routine-library-draft-secondary-actions">
+                            {onExportRoutinePackage ? <button type="button" onClick={() => { void exportDraft(draft.id); }}><AppIcon name="download" />{t('routineExport')}</button> : null}
+                            {onDeleteRoutineDraft ? <button type="button" className="danger" disabled={deletingDraftId === draft.id} onClick={() => { void deleteDraft(draft, visual.name); }} aria-label={formatMessage(t('routineLibraryDeleteDraft'), { routine: visual.name })}><AppIcon name="close" />{deletingDraftId === draft.id ? t('deleting') : t('delete')}</button> : null}
+                          </div> : null}
                         </div>
                       ) : null}
                       {draftAssignErrorId === draft.id ? <p className="request-feedback error" role="alert">{t('routineDraftAssignError')}</p> : null}

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -1256,7 +1256,7 @@ button:disabled { cursor: not-allowed; }
 }
 .routine-catalog-card.has-tabs { grid-template-rows: auto auto minmax(0, 1fr) auto; }
 .routine-catalog-tabs { display: grid; grid-template-columns: repeat(3, minmax(0, 1fr)); gap: 4px; padding: 4px; border-radius: 12px; background: var(--color-control-surface); }
-.routine-catalog-tabs button { min-width: 0; min-height: var(--height-action); padding: 7px 5px; overflow: hidden; border: 0; border-radius: 9px; background: transparent; color: var(--color-text-muted); font-size: 10px; font-weight: 800; text-overflow: ellipsis; white-space: nowrap; }
+.routine-catalog-tabs button { min-width: 0; min-height: var(--height-action); padding: 7px 5px; border: 0; border-radius: 9px; background: transparent; color: var(--color-text-muted); font-size: 10px; font-weight: 800; line-height: 1.2; overflow-wrap: anywhere; }
 .routine-catalog-tabs button[aria-selected='true'] { background: var(--color-surface-solid); color: var(--color-text); box-shadow: var(--shadow-sm); }
 .routine-catalog-tabs button:focus-visible { outline: 2px solid var(--color-primary); outline-offset: 2px; }
 .routine-catalog-heading { display: flex; align-items: flex-start; justify-content: space-between; gap: 12px; }
@@ -1291,11 +1291,15 @@ button:disabled { cursor: not-allowed; }
 .routine-library-state button { min-height: var(--height-action); padding: 8px 12px; border: 0; border-radius: 10px; background: var(--color-text); color: var(--color-surface-solid); font-weight: 850; }
 .routine-library-draft { display: grid; gap: 8px; padding: 10px 0; border-top: 1px solid color-mix(in srgb, var(--color-text) 7%, transparent); }
 .routine-library-draft-heading { display: grid; grid-template-columns: 42px minmax(0, 1fr) auto; align-items: start; gap: 10px; }
+.routine-library-draft-copy { min-width: 0; }
+.routine-library-draft-meta { display: flex; align-items: center; flex-wrap: wrap; gap: 5px 8px; }
+.routine-library-draft-meta small { color: var(--color-text-muted); font-size: 10px; font-weight: 750; }
 .routine-library-draft-heading h4 { margin: 3px 0 0; color: var(--color-text); font-size: 14px; }
 .routine-library-badge { display: inline-flex; padding: 4px 7px; border-radius: 8px; background: color-mix(in srgb, var(--routine-accent, var(--color-primary)) 13%, var(--color-surface-solid)); color: var(--routine-accent, var(--color-primary)); font-size: 10px; font-weight: 900; }
-.routine-library-draft-actions { display: flex; gap: 4px; }
+.routine-library-draft-actions { display: flex; align-items: center; gap: 6px; }
 .routine-library-draft-actions button { min-height: var(--height-action); padding: 8px 10px; border: 0; border-radius: 10px; background: var(--color-control-surface); color: var(--color-text); font-size: 12px; font-weight: 850; }
-.routine-library-draft-actions button:last-child { width: var(--height-action); padding: 0; color: var(--color-text-muted); }
+.routine-library-draft-actions .routine-library-draft-edit { background: var(--color-text); color: var(--color-surface-solid); }
+.routine-library-draft-actions .card-disclosure-toggle { width: var(--height-action); padding: 0; background: color-mix(in srgb, var(--routine-accent, var(--color-primary)) 11%, var(--color-surface-solid)); color: var(--routine-accent, var(--color-primary)); }
 .routine-library-draft-detail { display: grid; gap: 4px; padding-left: 52px; }
 .routine-library-draft-detail p { margin: 0; color: var(--color-text-muted); font-size: 12px; }
 .routine-library-draft-detail small { color: var(--color-text-muted); font-size: 10px; font-weight: 750; }
@@ -1305,6 +1309,10 @@ button:disabled { cursor: not-allowed; }
 .routine-draft-preview-grid b { color: var(--routine-accent, var(--color-primary)); }
 .routine-draft-assign { justify-self: start; min-height: var(--height-action); padding: 8px 12px; border: 0; border-radius: 10px; background: var(--routine-accent, var(--color-primary)); color: var(--color-surface-solid); font-weight: 900; }
 .routine-draft-publish { justify-self: start; min-height: var(--height-action); padding: 8px 12px; border: 1px solid var(--routine-accent, var(--color-primary)); border-radius: 10px; background: var(--color-surface-solid); color: var(--routine-accent, var(--color-primary)); font-weight: 900; }
+.routine-library-draft-secondary-actions { display: flex; flex-wrap: wrap; gap: 6px; margin-top: 6px; padding-top: 10px; border-top: 1px solid var(--color-border); }
+.routine-library-draft-secondary-actions button { display: inline-flex; align-items: center; gap: 5px; min-height: var(--height-action); padding: 8px 10px; border: 0; border-radius: 10px; background: var(--color-control-surface); color: var(--color-text); font-size: 11px; font-weight: 850; }
+.routine-library-draft-secondary-actions button.danger { color: var(--color-danger); }
+.routine-library-draft-secondary-actions .app-icon { font-size: 16px; }
 .routine-upgrade-card { display: grid; gap: 6px; margin: 8px 0; padding: 12px; border: 1px solid var(--color-border); border-radius: 14px; background: var(--color-control-surface); }
 .routine-upgrade-card small { color: var(--color-primary); font-weight: 900; text-transform: uppercase; }
 .routine-upgrade-card h3, .routine-upgrade-card p { margin: 0; }
@@ -1382,7 +1390,8 @@ button:disabled { cursor: not-allowed; }
   .routine-catalog-item .routine-catalog-proof { display: block; overflow: visible; -webkit-line-clamp: unset; }
   .routine-catalog-add { grid-column: 1 / -1; width: 100%; justify-self: stretch; align-self: start; padding-inline: 11px; }
   .routine-library-draft-heading { grid-template-columns: 36px minmax(0, 1fr); }
-  .routine-library-draft-actions { grid-column: 2; }
+  .routine-library-draft-actions { grid-column: 2; justify-content: space-between; }
+  .routine-library-draft-actions .routine-library-draft-edit { flex: 1; }
   .routine-library-draft-detail { padding-left: 46px; }
 }
 .routines-empty-card { display: grid; gap: 6px; padding: var(--block-padding-lg); text-align: center; }


### PR DESCRIPTION
## What changed

- Let the three library tabs wrap cleanly instead of truncating long French labels.
- Show each private draft revision directly in its collapsed row so similarly named drafts remain distinguishable.
- Keep **Edit** as the only prominent draft action and move export and deletion behind the existing disclosure chevron.
- Give export and delete explicit icon-and-label treatments in the expanded details.
- Keep already loaded drafts visible during background refreshes without showing a blocking loading panel.

## Why

On narrow mobile screens, the community tab and export label were clipped, draft rows were crowded with competing controls, identical names were hard to distinguish, and a refresh message remained visible above already loaded content. The export clipping came from a `:last-child` rule that incorrectly forced the last action into an icon-sized square.

## Impact

The routine library is calmer and easier to scan on mobile, secondary and destructive actions are progressively disclosed, and refreshes no longer shift the content unnecessarily.

## Validation

- `corepack pnpm exec vitest run src/screens/RoutinesScreen.test.tsx` — 25 tests
- `corepack pnpm check` — 302 frontend tests, 96 backend tests, build, architecture, design, routine catalog, and bundle checks
- `git diff --check`