### PR TITLE
Reuse active routine edit drafts

### DIFF
--- a/functions/src/audit.ts
+++ b/functions/src/audit.ts
@@ -36,6 +36,7 @@ type AuditAction =
   | 'delete_routine'
   | 'create_routine_draft'
   | 'fork_routine_assignment_draft'
+  | 'resume_routine_assignment_draft'
   | 'update_routine_draft'
   | 'delete_routine_draft'
   | 'register_contact_email'

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -18,7 +18,7 @@ import { expiredPendingCheckCleanupUpdate, shouldDeleteProofAfterReview, staleCl
 import { reportOperationalAlert, reportOperationalEvent, reportOperationalRecovery } from './observability.js';
 import { shouldRecoverSyntheticPush } from './syntheticMonitor.js';
 import { canLeaveMembership, canRemoveMembership, createMembership, hasParticipantPermission, isCompatibleLegacyContentTarget, isCompatibleMembershipMigration, isCompatibleParticipantMigration, isCompatibleParticipantRefMigration, isProfileColorKey, membershipRoles, migrateLegacyFamilyRelationships, pushRolesForMembership, scheduledAggregatePaths, type MembershipPushRole, type MembershipRole } from './relationships.js';
-import { assertRoutineDraftRevision, createAssignmentForkPackage, createRoutineDraftDocument, RoutineDraftConflictError, RoutineDraftInputError, updateRoutineDraftDocument, type PublishedRoutineVersionDocument, type RoutineDraftDocument } from './routineDrafts.js';
+import { assertRoutineDraftRevision, createAssignmentForkPackage, createRoutineDraftDocument, routineDraftSessionId, RoutineDraftConflictError, RoutineDraftInputError, selectReusableAssignmentDraft, updateRoutineDraftDocument, type IdentifiedRoutineDraft, type PublishedRoutineVersionDocument, type RoutineDraftDocument } from './routineDrafts.js';
 import { ROUTINE_PACKAGE_MIME, parseRoutinePackageEnvelope, serializeRoutinePackage } from './routinePackages.js';
 import { assertExternalPackageResponse, verifyExternalRegistryIndex } from './externalRoutineRegistry.js';
 import { marketplaceEntryAuthorizedForInstall, marketplaceEntryInstallable, marketplaceRole, moderateMarketplaceStatus, type ModerationAction, type ModerationStatus } from './routineMarketplaceGovernance.js';
@@ -2240,35 +2240,60 @@ export const forkRoutineAssignmentDraft = onCall({ region, cors, enforceAppCheck
   const preferredLocale = request.data?.locale === 'fr' ? 'fr' : 'en';
   const participantRef = await requireParticipantRoutineDraftAccess(uid, participantId);
   const assignmentRef = participantRef.collection('routineAssignments').doc(routineId);
-  const draftRef = participantRef.collection('routineDrafts').doc();
-  let document: RoutineDraftDocument | undefined;
+  const ownedDraftsQuery = participantRef.collection('routineDrafts').where('ownerId', '==', uid);
+  const sessionRef = participantRef.collection('routineDraftSessions').doc(routineDraftSessionId(uid, routineId));
+  let result: IdentifiedRoutineDraft | undefined;
+  let reused = false;
   await db.runTransaction(async (transaction) => {
-    const [, assignment] = await Promise.all([
+    const [, assignment, ownedDrafts] = await Promise.all([
       requireParticipantRoutineDraftTransactionAccess(transaction, participantRef, uid),
       transaction.get(assignmentRef),
+      transaction.get(ownedDraftsQuery),
+      transaction.get(sessionRef),
     ]);
     if (!assignment.exists) throw new HttpsError('not-found', 'The routine assignment could not be found.');
     const assignmentData = assignment.data() as RoutineAssignmentDocument;
     if (!assignmentData.routine) throw new HttpsError('failed-precondition', 'The assigned routine content is unavailable.');
-    try {
-      const routinePackage = createAssignmentForkPackage(assignmentData.routine, assignmentData.sourceVersion, preferredLocale);
-      document = {
-        ...createRoutineDraftDocument(uid, routinePackage),
-        forkedFrom: { routineId, ...(assignmentData.sourceVersion ? { sourceVersion: assignmentData.sourceVersion } : {}), origin: assignmentData.sourceCatalogEntryId ? 'community' : assignmentData.sourceDraftId ? 'private' : 'builtin' },
-      };
-    } catch (error) {
-      return routineDraftInputError(error);
+    const existing = selectReusableAssignmentDraft(
+      ownedDrafts.docs.map((draft) => ({ id: draft.id, ...draft.data() } as IdentifiedRoutineDraft)),
+      uid,
+      routineId,
+      assignmentData.sourceVersion,
+    );
+    if (existing) {
+      result = existing;
+      reused = true;
+    } else {
+      const draftRef = participantRef.collection('routineDrafts').doc();
+      try {
+        const routinePackage = createAssignmentForkPackage(assignmentData.routine, assignmentData.sourceVersion, preferredLocale);
+        const document: RoutineDraftDocument = {
+          ...createRoutineDraftDocument(uid, routinePackage),
+          forkedFrom: { routineId, ...(assignmentData.sourceVersion ? { sourceVersion: assignmentData.sourceVersion } : {}), origin: assignmentData.sourceCatalogEntryId ? 'community' : assignmentData.sourceDraftId ? 'private' : 'builtin' },
+        };
+        result = { id: draftRef.id, ...document };
+        transaction.create(draftRef, document);
+      } catch (error) {
+        return routineDraftInputError(error);
+      }
     }
-    if (!document) throw new HttpsError('internal', 'The routine draft could not be prepared.');
-    transaction.create(draftRef, document);
+    if (!result) throw new HttpsError('internal', 'The routine draft could not be prepared.');
+    transaction.set(sessionRef, {
+      ownerId: uid,
+      routineId,
+      sourceVersion: assignmentData.sourceVersion ?? 0,
+      draftId: result.id,
+      updatedAt: new Date().toISOString(),
+    });
   });
+  if (!result) throw new HttpsError('internal', 'The routine draft could not be prepared.');
   await recordAuditEvent(db, {
-    action: 'fork_routine_assignment_draft',
+    action: reused ? 'resume_routine_assignment_draft' : 'fork_routine_assignment_draft',
     actorUid: uid,
     participantId,
-    metadata: { draftId: draftRef.id, routineId, sourceVersion: document?.forkedFrom?.sourceVersion },
+    metadata: { draftId: result.id, routineId, sourceVersion: result.forkedFrom?.sourceVersion },
   });
-  return { id: draftRef.id, ...document };
+  return result;
 });
 
 export const exportRoutinePackage = onCall({ region, cors, enforceAppCheck: true }, async (request) => {

--- a/functions/src/routineDrafts.test.ts
+++ b/functions/src/routineDrafts.test.ts
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
-import { assertRoutineDraftRevision, createAssignmentForkPackage, createRoutineDraftDocument, parseRoutineDraftPackage, RoutineDraftConflictError, RoutineDraftInputError, updateRoutineDraftDocument } from './routineDrafts.js';
+import { assertRoutineDraftRevision, createAssignmentForkPackage, createRoutineDraftDocument, parseRoutineDraftPackage, routineDraftSessionId, RoutineDraftConflictError, RoutineDraftInputError, selectReusableAssignmentDraft, updateRoutineDraftDocument } from './routineDrafts.js';
 
 const routinePackage = () => ({
   schemaVersion: 1,
@@ -81,6 +81,32 @@ test('forks an assignment snapshot into an independent next-version package', ()
   assert.equal(fork.routine.name, source.routine.name);
   assert.notEqual(fork.routine, source.routine);
   assert.equal(source.routine.id, 'private-routine');
+});
+
+test('reuses the latest compatible active assignment draft', () => {
+  const first = {
+    id: 'first',
+    ...createRoutineDraftDocument('owner-1', routinePackage(), '2026-07-20T10:00:00.000Z'),
+    forkedFrom: { routineId: 'private-routine', sourceVersion: undefined, origin: 'builtin' as const },
+  };
+  const latest = {
+    ...first,
+    id: 'latest',
+    revision: 2,
+    updatedAt: '2026-07-20T10:05:00.000Z',
+  };
+  const archived = { ...latest, id: 'archived', state: 'archived' as const, updatedAt: '2026-07-20T10:10:00.000Z' };
+  const otherOwner = { ...latest, id: 'other-owner', ownerId: 'owner-2', updatedAt: '2026-07-20T10:20:00.000Z' };
+
+  assert.equal(selectReusableAssignmentDraft([first, archived, otherOwner, latest], 'owner-1', 'private-routine')?.id, 'latest');
+  assert.equal(selectReusableAssignmentDraft([latest], 'owner-1', 'other-routine'), undefined);
+  assert.equal(selectReusableAssignmentDraft([latest], 'owner-1', 'private-routine', 1), undefined);
+});
+
+test('uses one stable edit session per owner and assigned routine', () => {
+  assert.equal(routineDraftSessionId('owner-1', 'routine-1'), routineDraftSessionId('owner-1', 'routine-1'));
+  assert.notEqual(routineDraftSessionId('owner-1', 'routine-1'), routineDraftSessionId('owner-1', 'routine-2'));
+  assert.notEqual(routineDraftSessionId('owner-1', 'routine-1'), routineDraftSessionId('owner-2', 'routine-1'));
 });
 
 test('rejects stale optimistic revisions actionably', () => {

--- a/functions/src/routineDrafts.ts
+++ b/functions/src/routineDrafts.ts
@@ -1,3 +1,4 @@
+import { createHash } from 'node:crypto';
 import { z } from 'zod';
 
 const packageBytesLimit = 64 * 1024;
@@ -82,6 +83,31 @@ export interface PublishedRoutineVersionDocument {
 
 export class RoutineDraftInputError extends Error {}
 export class RoutineDraftConflictError extends Error {}
+
+export type IdentifiedRoutineDraft = RoutineDraftDocument & { id: string };
+
+export const routineDraftSessionId = (ownerId: string, routineId: string) => createHash('sha256')
+  .update(`${ownerId}:${routineId}`)
+  .digest('hex');
+
+export const selectReusableAssignmentDraft = (
+  drafts: IdentifiedRoutineDraft[],
+  ownerId: string,
+  routineId: string,
+  sourceVersion?: number,
+) => drafts
+  .filter((draft) => (
+    draft.ownerId === ownerId
+    && draft.state === 'active'
+    && draft.forkedFrom?.routineId === routineId
+    && (draft.forkedFrom?.sourceVersion ?? 0) === (sourceVersion ?? 0)
+    && draft.package.version === (sourceVersion ?? 0) + 1
+  ))
+  .sort((left, right) => (
+    right.updatedAt.localeCompare(left.updatedAt)
+    || right.revision - left.revision
+    || right.id.localeCompare(left.id)
+  ))[0];
 
 export const assertRoutineDraftRevision = (currentRevision: number, expectedRevision: number) => {
   if (currentRevision !== expectedRevision) throw new RoutineDraftConflictError('stale_revision');

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zadiag-pwa",
   "private": true,
-  "version": "0.9.95",
+  "version": "0.9.96",
   "type": "module",
   "packageManager": "pnpm@11.7.0",
   "engines": {


### PR DESCRIPTION
## What changed

- Resume the latest compatible active draft when a responsible user reopens an assigned routine.
- Serialize concurrent edit openings through one deterministic backend session per user and routine.
- Record resumed edit sessions separately in the audit trail.
- Cover draft selection and stable session identity with backend tests.

## Why

Opening the edit view always generated a new random draft, even when the user left without changing anything. Repeated openings therefore filled the catalogue with identical pristine drafts.

## Impact

Reopening a routine now returns the existing active draft. Double taps and concurrent requests also converge on the same draft instead of creating duplicates.

## Validation

- `corepack pnpm check`
- 302 frontend tests passed
- 98 backend tests passed
- architecture, design, build, routine catalogue, and bundle checks passed
