### PR TITLE
Animate startup progress stripes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zadiag-pwa",
   "private": true,
-  "version": "0.9.97",
+  "version": "0.9.98",
   "type": "module",
   "packageManager": "pnpm@11.7.0",
   "engines": {

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -189,6 +189,8 @@ button:disabled { cursor: not-allowed; }
     var(--color-primary) 0 6px,
     color-mix(in srgb, var(--color-primary) 68%, var(--color-primary-soft)) 6px 12px
   );
+  background-size: 17px 17px;
+  animation: splash-progress-stripes .7s linear infinite;
   transition: width .2s ease;
 }
 .startup-recovery-page {
@@ -2299,6 +2301,9 @@ button:disabled { cursor: not-allowed; }
 @keyframes brand-breathe {
   0%, 100% { transform: scale(1); }
   50% { transform: scale(1.035); }
+}
+@keyframes splash-progress-stripes {
+  to { background-position: 17px 0; }
 }
 @keyframes brand-dot {
   0%, 55%, 100% { transform: translateY(0); }


### PR DESCRIPTION
## What changed

- animate the diagonal startup progress stripes horizontally
- preserve the real width-based startup progress
- use one seamless pattern period to avoid a visible loop jump
- rely on the existing reduced-motion guardrail to neutralize the animation when requested
- bump the application version to `0.9.98`

## Why

A moving stripe pattern shows that the interface is still active during a slow or stalled startup while the stage label identifies the current operation.

## Validation

- `pnpm check`
- `git diff --check`