### PR TITLE
Revert pull-to-update resistance

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zadiag-pwa",
   "private": true,
-  "version": "0.9.99",
+  "version": "0.9.100",
   "type": "module",
   "packageManager": "pnpm@11.7.0",
   "engines": {

--- a/src/components/PullToUpdate.test.tsx
+++ b/src/components/PullToUpdate.test.tsx
@@ -25,7 +25,6 @@ describe('PullToUpdate', () => {
   afterEach(() => {
     if (root) act(() => root?.unmount());
     container?.remove();
-    vi.unstubAllGlobals();
   });
 
   const renderPullToUpdate = (
@@ -56,29 +55,6 @@ describe('PullToUpdate', () => {
     dispatchTouch(page, 'touchend', 20, 100);
 
     await act(async () => Promise.resolve());
-    expect(onUpdate).toHaveBeenCalledOnce();
-  });
-
-  it('adds resistance, latches at the threshold, and confirms it once', async () => {
-    const onUpdate = vi.fn().mockResolvedValue(false);
-    const vibrate = vi.fn();
-    vi.stubGlobal('navigator', { ...navigator, vibrate });
-    const page = renderPullToUpdate(onUpdate);
-    const shell = page.closest('.app-shell') as HTMLElement;
-
-    dispatchTouch(page, 'touchstart', 20, 20);
-    dispatchTouch(page, 'touchmove', 20, 100);
-    const thresholdOffset = Number.parseFloat(shell.style.getPropertyValue('--pull-distance'));
-    dispatchTouch(page, 'touchmove', 20, 220);
-    const maximumOffset = Number.parseFloat(shell.style.getPropertyValue('--pull-distance'));
-    dispatchTouch(page, 'touchmove', 20, 70);
-    dispatchTouch(page, 'touchend', 20, 70);
-
-    await act(async () => Promise.resolve());
-    expect(thresholdOffset).toBeLessThan(80);
-    expect(maximumOffset).toBeLessThan(60);
-    expect(vibrate).toHaveBeenCalledOnce();
-    expect(vibrate).toHaveBeenCalledWith(10);
     expect(onUpdate).toHaveBeenCalledOnce();
   });
 

--- a/src/components/PullToUpdate.tsx
+++ b/src/components/PullToUpdate.tsx
@@ -1,11 +1,9 @@
-import { useRef, useState, type CSSProperties, type ReactNode, type TouchEvent } from 'react';
+import { useRef, useState, type ReactNode, type TouchEvent } from 'react';
 import { createPortal } from 'react-dom';
 import type { MessageKey } from '../services/i18n';
 
 const PULL_THRESHOLD = 72;
-const MAX_PULL_DISTANCE = 160;
-const PULL_RESISTANCE = 0.65;
-const PULL_OVERSHOOT_RESISTANCE = 0.08;
+const MAX_PULL_DISTANCE = 110;
 const HORIZONTAL_SWIPE_THRESHOLD = 64;
 const HORIZONTAL_SWIPE_DOMINANCE = 1.35;
 const SWIPE_NAVIGATION_EXCLUSION_SELECTOR = 'button, a, input, select, textarea, summary, [role="button"], dialog, .parent-review-card, [data-swipe-navigation="ignore"]';
@@ -21,13 +19,6 @@ type SwipeGesture = {
   startY: number;
 };
 
-const resistedPullDistance = (distance: number) => {
-  const boundedDistance = Math.max(0, Math.min(MAX_PULL_DISTANCE, distance));
-  if (boundedDistance <= PULL_THRESHOLD) return boundedDistance * PULL_RESISTANCE;
-  return PULL_THRESHOLD * PULL_RESISTANCE
-    + (boundedDistance - PULL_THRESHOLD) * PULL_OVERSHOOT_RESISTANCE;
-};
-
 export function PullToUpdate({
   children,
   onHorizontalSwipe,
@@ -41,13 +32,13 @@ export function PullToUpdate({
 }) {
   const gestureRef = useRef<PullGesture | undefined>(undefined);
   const swipeGestureRef = useRef<SwipeGesture | undefined>(undefined);
-  const thresholdReachedRef = useRef(false);
+  const distanceRef = useRef(0);
   const [pullDistance, setPullDistance] = useState(0);
   const [updating, setUpdating] = useState(false);
 
   const resetPull = () => {
     gestureRef.current = undefined;
-    thresholdReachedRef.current = false;
+    distanceRef.current = 0;
     setPullDistance(0);
   };
 
@@ -66,7 +57,7 @@ export function PullToUpdate({
       startY: touch.clientY,
       scrollContainer,
     };
-    thresholdReachedRef.current = false;
+    distanceRef.current = 0;
     setPullDistance(0);
   };
 
@@ -84,17 +75,13 @@ export function PullToUpdate({
       resetPull();
       return;
     }
-    if (verticalDistance > 0) event.preventDefault();
     const distance = Math.max(0, Math.min(MAX_PULL_DISTANCE, verticalDistance));
-    if (distance >= PULL_THRESHOLD && !thresholdReachedRef.current) {
-      thresholdReachedRef.current = true;
-      navigator.vibrate?.(10);
-    }
-    setPullDistance(resistedPullDistance(distance));
+    distanceRef.current = distance;
+    setPullDistance(distance);
   };
 
   const endPull = (event: TouchEvent<HTMLDivElement>) => {
-    const shouldUpdate = Boolean(gestureRef.current && !updating && thresholdReachedRef.current);
+    const shouldUpdate = Boolean(gestureRef.current && !updating && distanceRef.current >= PULL_THRESHOLD);
     const swipeGesture = swipeGestureRef.current;
     const touch = event.changedTouches[0];
     swipeGestureRef.current = undefined;
@@ -120,7 +107,7 @@ export function PullToUpdate({
 
   const label = updating
     ? t('settingsPullUpdateChecking')
-    : thresholdReachedRef.current
+    : pullDistance >= PULL_THRESHOLD
       ? t('settingsPullUpdateRelease')
       : t('settingsPullUpdatePull');
   const visible = updating || pullDistance > 0;
@@ -144,8 +131,7 @@ export function PullToUpdate({
 
   return (
     <div
-      className={`app-shell ${pullDistance > 0 ? 'pull-active' : ''}`}
-      style={{ '--pull-distance': `${pullDistance}px` } as CSSProperties}
+      className="app-shell"
       onTouchStart={startPull}
       onTouchMove={movePull}
       onTouchEnd={endPull}

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -459,15 +459,7 @@ button:disabled { cursor: not-allowed; }
 .routine-card-heading p { margin: 5px 0 0; font-size: 13px; }
 .empty-state { padding: 30px 18px; text-align: center; }
 
-.app-shell {
-  position: relative;
-  height: 100dvh;
-  overflow: hidden;
-  background: var(--color-canvas);
-  transform: translateY(var(--pull-distance, 0));
-  transition: transform .24s cubic-bezier(.22, 1, .36, 1);
-}
-.app-shell.pull-active { transition: none; }
+.app-shell { position: relative; height: 100dvh; overflow: hidden; background: var(--color-canvas); }
 .app-shell > .content-screen { height: 100%; min-height: 0; overflow-y: auto; overscroll-behavior-y: contain; touch-action: pan-y; -webkit-overflow-scrolling: touch; }
 .pull-update-indicator {
   position: fixed;


### PR DESCRIPTION
## What changed

- revert the progressive pull resistance, threshold latch, shell displacement, and haptic confirmation introduced by #222
- restore the previous pull-to-update interaction and its original tests
- keep the startup stage labels and animated striped progress bar unchanged
- advance the application version to `0.9.100`

## Why

The revised pull gesture did not feel right in use, so this returns to the established interaction without undoing unrelated startup improvements.

## Validation

- `pnpm check`
- `git diff --cached --check`