### PR TITLE
Stabilize routine AI capability loading

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zadiag-pwa",
   "private": true,
-  "version": "0.10.1",
+  "version": "0.10.2",
   "type": "module",
   "packageManager": "pnpm@11.7.0",
   "engines": {

--- a/src/screens/RoutinesScreen.test.tsx
+++ b/src/screens/RoutinesScreen.test.tsx
@@ -258,6 +258,51 @@ describe('participant routines navigation', () => {
     expect(container.textContent).toContain('current schedule preserved');
   });
 
+  it('loads AI capabilities once when an unstable repository callback is recreated', async () => {
+    await import('./RoutineDraftEditorScreen');
+    const state: AppState = {
+      role: 'parent', locale: 'en', notificationsEnabled: true,
+      family: { linked: true, childLinked: true, childName: 'Maya', linkingCode: '', parentRecoveryCode: '', consented: true },
+      participantAccess: [{ participant: { id: 'participant-1', displayName: 'Maya' }, membership: { role: 'owner', status: 'active' } }],
+      activeParticipantId: 'participant-1', routineAssignments: [], events: [], routinesLoaded: true, routinesError: false,
+    };
+    const getCapabilities = vi.fn().mockResolvedValue({
+      prescriptionExtraction: { enabled: false, promptVersion: 'prescription-extraction-v1' },
+      routineTranslation: { enabled: false, promptVersion: 'routine-translation-v1' },
+      routineGeneration: { enabled: true, promptVersion: 'routine-generation-v1' },
+      dynamicQuizGeneration: { enabled: false, promptVersion: 'dynamic-quiz-generation-v1' },
+      manualFallback: true as const,
+    });
+    const render = () => root.render(<RoutinesScreen
+      state={state}
+      online
+      onAssignRoutine={vi.fn().mockResolvedValue(undefined)}
+      onGetAiAuthoringCapabilities={() => getCapabilities()}
+      t={(key) => translate('en', key)}
+    />);
+
+    act(render);
+    await act(async () => {
+      document.body.querySelector<HTMLButtonElement>('.routines-add-dock-button')?.click();
+      await Promise.resolve();
+    });
+    expect(getCapabilities).toHaveBeenCalledTimes(1);
+    expect(container.textContent).toContain('Do not include health or identifying information.');
+
+    act(render);
+    await act(async () => { await Promise.resolve(); });
+    expect(getCapabilities).toHaveBeenCalledTimes(1);
+
+    const instruction = container.querySelector<HTMLTextAreaElement>('.routine-draft-main-instruction');
+    act(() => {
+      if (instruction) {
+        Object.getOwnPropertyDescriptor(HTMLTextAreaElement.prototype, 'value')?.set?.call(instruction, 'Track my Java learning.');
+        instruction.dispatchEvent(new Event('input', { bubbles: true }));
+      }
+    });
+    expect(Array.from(container.querySelectorAll<HTMLButtonElement>('button')).find((button) => button.textContent?.includes('Suggest a challenge'))?.disabled).toBe(false);
+  });
+
   it('reviews fork changes before publishing the next routine version', async () => {
     const assignment = createDefaultRoutineAssignment('2026-07-20T08:00:00.000Z');
     const state: AppState = {

--- a/src/screens/RoutinesScreen.tsx
+++ b/src/screens/RoutinesScreen.tsx
@@ -212,6 +212,8 @@ export function RoutinesScreen({
   const [editingDraftId, setEditingDraftId] = useState<string | 'new'>();
   const [forkingRoutineId, setForkingRoutineId] = useState<string>();
   const forkingRoutineIdRef = useRef<string | undefined>(undefined);
+  const getAiAuthoringCapabilitiesRef = useRef(onGetAiAuthoringCapabilities);
+  getAiAuthoringCapabilitiesRef.current = onGetAiAuthoringCapabilities;
   const [assigningDraftId, setAssigningDraftId] = useState<string>();
   const [draftAssignErrorId, setDraftAssignErrorId] = useState<string>();
   const [aiCapabilities, setAiCapabilities] = useState<AiAuthoringCapabilities>();
@@ -317,11 +319,13 @@ export function RoutinesScreen({
   }, [activeParticipantAccess?.participant.id, canAssignRoutine, catalogOpen, catalogSection, draftReloadSequence, onListRoutineDrafts, online]);
 
   useEffect(() => {
-    if (!editingDraftId || !online || !onGetAiAuthoringCapabilities) return;
+    const getCapabilities = getAiAuthoringCapabilitiesRef.current;
+    if (!editingDraftId || !online || !getCapabilities) return;
     let cancelled = false;
-    void onGetAiAuthoringCapabilities().then((capabilities) => { if (!cancelled) setAiCapabilities(capabilities); }).catch(() => { if (!cancelled) setAiCapabilities(undefined); });
+    setAiCapabilities(undefined);
+    void getCapabilities().then((capabilities) => { if (!cancelled) setAiCapabilities(capabilities); }).catch(() => { if (!cancelled) setAiCapabilities(undefined); });
     return () => { cancelled = true; };
-  }, [editingDraftId, onGetAiAuthoringCapabilities, online]);
+  }, [editingDraftId, online, Boolean(onGetAiAuthoringCapabilities)]);
 
   useEffect(() => {
     const participantId = activeParticipantAccess?.participant.id;


### PR DESCRIPTION
## Summary

- stabilize the AI-capability loader when App recreates repository callbacks
- stop the repeated production callable loop that kept the composer capability unresolved
- keep the button disabled while the one authoritative capability request is loading
- cover callback recreation and enabled-button behavior with a regression test
- bump the application version to 0.10.2

## Root cause

`RoutinesScreen` depended on a callback recreated on every App render. Each capability response triggered another render and therefore another request, so the state never settled reliably even though Firebase returned valid authenticated responses and `routineGeneration` was enabled.

## Validation

- `pnpm check`
  - 64 client test files, 312 tests
  - 110 Functions tests
  - production build, architecture, design, routine catalog, and bundle checks
- `git diff --check`

Part of #225.
