### PR TITLE
Add Raspberry Pi connectivity checks

### DIFF
--- a/ops/pi-synthetic-monitor/README.md
+++ b/ops/pi-synthetic-monitor/README.md
@@ -4,6 +4,19 @@ This monitor keeps a persistent Chromium profile connected to the production PWA
 
 Every five minutes, it answers newly received check notifications through the real participant UI with a deterministic virtual-camera image. It also reloads the participant screen and looks for a pending check directly, so a missed Web Push delivery cannot leave a synthetic control unanswered. Processed notification check IDs and retry counts are persisted in `.pi-monitor/handled-checks.json`, so restarts cannot submit the same notification twice. A notified check is attempted at most three times.
 
+The virtual camera supports two isolated operational routines:
+
+- `Santé du Raspberry Pi` / `Raspberry Pi Health`: memory, CPU load, disk, temperature, Docker and agent status;
+- `Connectivité du Raspberry Pi` / `Raspberry Pi Connectivity`: active interface, gateway reachability, DNS resolution, Zadiag HTTPS latency, NTP synchronization and agent status.
+
+For a private AI-authored connectivity routine, keep the French or English title above exactly. The participant dashboard exposes the persisted routine ID as a non-visual data attribute, so notification-driven checks select the exact routine card while the title identifies which bounded collector and proof template to use.
+
+Suggested French authoring instruction:
+
+```text
+Crée une routine nommée « Connectivité du Raspberry Pi ». À chaque contrôle, le Raspberry Pi vérifie automatiquement son interface réseau, sa passerelle, la résolution DNS, l’accès HTTPS à Zadiag, la synchronisation NTP et l’état de l’agent, puis envoie son tableau de connectivité horodaté comme preuve photo.
+```
+
 Chromium runs inside Xvfb instead of native headless mode because persistent Web Push and service workers are more reliable with a real browser display context.
 
 The runtime configuration and Chromium profile live in `.pi-monitor/`, which is intentionally ignored by Git. The monitor is isolated from real participant data and uses a dedicated Firebase anonymous UID.

--- a/ops/pi-synthetic-monitor/synthetic-proof.mjs
+++ b/ops/pi-synthetic-monitor/synthetic-proof.mjs
@@ -5,7 +5,10 @@ import { promisify } from 'node:util';
 
 const execFileAsync = promisify(execFile);
 const PI_HEALTH_ROUTINE_IDS = new Set(['nemu-health', 'raspberry-pi-health']);
+const PI_CONNECTIVITY_ROUTINE_IDS = new Set(['raspberry-pi-connectivity']);
 const PI_HEALTH_ROUTINE_NAME_PATTERN = /Santé du Raspberry Pi|Raspberry Pi Health/i;
+const PI_CONNECTIVITY_ROUTINE_NAME_PATTERN = /Connectivité du Raspberry Pi|Raspberry Pi Connectivity/i;
+const SUPPORTED_ROUTINE_NAME_PATTERN = /Santé du Raspberry Pi|Raspberry Pi Health|Connectivité du Raspberry Pi|Raspberry Pi Connectivity/i;
 const resultPattern = /Validated|Validé|Not detected|Non détecté|Needs review|À vérifier/i;
 const analyzingPattern = /Checking the photo|Analyse de la photo|Vérification de la photo/i;
 const cameraEnabledContexts = new WeakSet();
@@ -26,17 +29,17 @@ const installSyntheticCamera = (context) => {
         const draw = () => {
           const drawing = canvas.getContext('2d');
           if (!drawing) return;
-          const health = globalThis.__ZADIAG_NEMU_HEALTH__;
-          if (['nemu-health', 'raspberry-pi-health'].includes(globalThis.__ZADIAG_SYNTHETIC_ROUTINE_ID__) && health) {
+          const evidence = globalThis.__ZADIAG_SYNTHETIC_EVIDENCE__ ?? globalThis.__ZADIAG_NEMU_HEALTH__;
+          if (['nemu-health', 'raspberry-pi-health', 'raspberry-pi-connectivity'].includes(globalThis.__ZADIAG_SYNTHETIC_ROUTINE_ID__) && evidence) {
             drawing.fillStyle = '#9fbeb6';
             drawing.fillRect(0, 0, canvas.width, canvas.height);
             drawing.fillStyle = '#123b35';
-            drawing.font = 'bold 26px sans-serif';
-            drawing.fillText('Raspberry Pi Health', 18, 48);
+            drawing.font = `bold ${evidence.title?.length > 24 ? 21 : 26}px sans-serif`;
+            drawing.fillText(evidence.title ?? 'Raspberry Pi Health', 18, 48);
             drawing.font = '15px sans-serif';
             drawing.fillStyle = '#48645f';
-            drawing.fillText(health.timestamp, 18, 76);
-            health.rows.forEach((row, index) => {
+            drawing.fillText(evidence.timestamp, 18, 76);
+            evidence.rows.forEach((row, index) => {
               const y = 102 + index * 54;
               drawing.fillStyle = '#bfd3ce';
               drawing.fillRect(14, y, 332, 44);
@@ -84,8 +87,10 @@ const installSyntheticCamera = (context) => {
 
 export const resolveSyntheticRoutineId = ({ routineId, pageText = '' }) => {
   if (PI_HEALTH_ROUTINE_IDS.has(routineId)) return routineId;
-  if (routineId) return undefined;
-  return PI_HEALTH_ROUTINE_NAME_PATTERN.test(pageText) ? 'raspberry-pi-health' : undefined;
+  if (PI_CONNECTIVITY_ROUTINE_IDS.has(routineId)) return routineId;
+  if (PI_HEALTH_ROUTINE_NAME_PATTERN.test(pageText)) return 'raspberry-pi-health';
+  if (PI_CONNECTIVITY_ROUTINE_NAME_PATTERN.test(pageText)) return 'raspberry-pi-connectivity';
+  return undefined;
 };
 
 const percentageStatus = (value, warning, failure) => value >= failure ? 'failure' : value >= warning ? 'warning' : 'ok';
@@ -105,6 +110,7 @@ export const collectNemuHealth = async () => {
     .catch(() => []);
   const unhealthyContainers = docker.filter((status) => !/^Up\b/.test(status) || /unhealthy/i.test(status)).length;
   return {
+    title: 'Raspberry Pi Health',
     timestamp: new Intl.DateTimeFormat('fr-FR', { dateStyle: 'short', timeStyle: 'medium', timeZone: 'Europe/Paris' }).format(new Date()),
     rows: [
       { label: 'Mémoire', value: `${memoryPercent}%`, status: percentageStatus(memoryPercent, 80, 92) },
@@ -116,6 +122,65 @@ export const collectNemuHealth = async () => {
     ]
   };
 };
+
+const latencyStatus = (latencyMs, warningMs, failureMs) => latencyMs >= failureMs ? 'failure' : latencyMs >= warningMs ? 'warning' : 'ok';
+const boundedLatency = (startedAt, clock) => Math.max(0, Math.min(99_999, Math.round(clock() - startedAt)));
+
+export const collectPiConnectivity = async ({
+  execFileImpl = execFileAsync,
+  fetchImpl = fetch,
+  readFileImpl = readFile,
+  clock = () => Date.now(),
+  now = new Date(),
+} = {}) => {
+  const route = await execFileImpl('ip', ['route', 'show', 'default'])
+    .then(({ stdout }) => stdout.trim())
+    .catch(() => '');
+  const interfaceName = route.match(/\bdev\s+([a-zA-Z0-9_.:-]+)/)?.[1];
+  const gateway = route.match(/\bvia\s+([0-9a-fA-F:.]+)/)?.[1];
+  const interfaceState = interfaceName
+    ? await readFileImpl(`/sys/class/net/${interfaceName}/operstate`, 'utf8').then((value) => value.trim()).catch(() => 'indisponible')
+    : 'indisponible';
+
+  const gatewayStartedAt = clock();
+  const gatewayOk = gateway
+    ? await execFileImpl('ping', ['-c', '1', '-W', '2', gateway]).then(() => true).catch(() => false)
+    : false;
+  const gatewayLatency = boundedLatency(gatewayStartedAt, clock);
+
+  const dnsStartedAt = clock();
+  const dnsOk = await execFileImpl('getent', ['ahosts', 'www.zadiag.com'])
+    .then(({ stdout }) => Boolean(stdout.trim()))
+    .catch(() => false);
+  const dnsLatency = boundedLatency(dnsStartedAt, clock);
+
+  const httpsStartedAt = clock();
+  const httpsStatus = await fetchImpl('https://www.zadiag.com/app-version.json', { signal: AbortSignal.timeout(8_000), cache: 'no-store' })
+    .then((response) => response.ok ? response.status : response.status || 0)
+    .catch(() => 0);
+  const httpsLatency = boundedLatency(httpsStartedAt, clock);
+
+  const ntpSynchronized = await execFileImpl('timedatectl', ['show', '--property=NTPSynchronized', '--value'])
+    .then(({ stdout }) => stdout.trim().toLowerCase() === 'yes')
+    .catch(() => false);
+
+  return {
+    title: 'Raspberry Pi Connectivity',
+    timestamp: new Intl.DateTimeFormat('fr-FR', { dateStyle: 'short', timeStyle: 'medium', timeZone: 'Europe/Paris' }).format(now),
+    rows: [
+      { label: 'Interface', value: interfaceName ? `${interfaceName} · ${interfaceState}` : 'indisponible', status: interfaceState === 'up' ? 'ok' : interfaceState === 'unknown' ? 'warning' : 'failure' },
+      { label: 'Passerelle', value: gatewayOk ? `${gatewayLatency} ms` : 'injoignable', status: gatewayOk ? latencyStatus(gatewayLatency, 250, 1_000) : 'failure' },
+      { label: 'DNS', value: dnsOk ? `résolu · ${dnsLatency} ms` : 'échec', status: dnsOk ? latencyStatus(dnsLatency, 500, 2_000) : 'failure' },
+      { label: 'Zadiag HTTPS', value: httpsStatus ? `HTTP ${httpsStatus} · ${httpsLatency} ms` : 'injoignable', status: httpsStatus === 200 ? latencyStatus(httpsLatency, 1_500, 4_000) : 'failure' },
+      { label: 'Horloge NTP', value: ntpSynchronized ? 'synchronisée' : 'non synchronisée', status: ntpSynchronized ? 'ok' : 'warning' },
+      { label: 'Agent', value: 'service actif', status: 'ok' },
+    ],
+  };
+};
+
+const collectEvidenceForRoutine = (routineId) => routineId === 'raspberry-pi-connectivity'
+  ? collectPiConnectivity()
+  : collectNemuHealth();
 
 const completeSyntheticOnboarding = async ({ page, contactEmail }) => {
   const contactInput = page.getByRole('textbox', { name: /Contact email|E-mail de contact/i }).first();
@@ -131,7 +196,7 @@ const completeSyntheticOnboarding = async ({ page, contactEmail }) => {
   }
 };
 
-export const answerPendingCheck = async ({ context, page, appUrl, path, contactEmail, routineId, healthEvidence, proofWaitMs = 20_000 }) => {
+export const answerPendingCheck = async ({ context, page, appUrl, path, contactEmail, routineId, evidence, healthEvidence, proofWaitMs = 20_000 }) => {
   await installSyntheticCamera(context);
   let destination = new URL('/', appUrl);
   try {
@@ -142,21 +207,24 @@ export const answerPendingCheck = async ({ context, page, appUrl, path, contactE
   }
   await page.goto(destination.href, { waitUntil: 'domcontentloaded', timeout: 30_000 });
   await completeSyntheticOnboarding({ page, contactEmail });
-  const healthCard = page.locator('.today-routine-card').filter({ hasText: PI_HEALTH_ROUTINE_NAME_PATTERN });
-  const proofButton = healthCard.getByRole('button', { name: /Proof|Preuve/i }).first();
+  const routineCard = routineId
+    ? page.locator(`.today-routine-card[data-routine-id=${JSON.stringify(routineId)}]`).first()
+    : page.locator('.today-routine-card').filter({ hasText: SUPPORTED_ROUTINE_NAME_PATTERN }).first();
+  const proofButton = routineCard.getByRole('button', { name: /Proof|Preuve/i }).first();
   try {
     await proofButton.waitFor({ state: 'visible', timeout: proofWaitMs });
   } catch {
     return { outcome: 'already_settled' };
   }
-  const pageText = await healthCard.innerText();
+  const pageText = await routineCard.innerText();
   const resolvedRoutineId = resolveSyntheticRoutineId({ routineId, pageText });
   if (!resolvedRoutineId) return { outcome: 'unsupported_routine' };
-  const evidence = healthEvidence ?? await collectNemuHealth();
+  const currentEvidence = evidence ?? healthEvidence ?? await collectEvidenceForRoutine(resolvedRoutineId);
   await page.evaluate(({ currentRoutineId, currentEvidence }) => {
     globalThis.__ZADIAG_SYNTHETIC_ROUTINE_ID__ = currentRoutineId;
+    globalThis.__ZADIAG_SYNTHETIC_EVIDENCE__ = currentEvidence;
     globalThis.__ZADIAG_NEMU_HEALTH__ = currentEvidence;
-  }, { currentRoutineId: resolvedRoutineId, currentEvidence: evidence });
+  }, { currentRoutineId: resolvedRoutineId, currentEvidence });
   await proofButton.click();
   await page.waitForFunction(() => {
     const video = document.querySelector('video');

--- a/ops/pi-synthetic-monitor/synthetic-proof.test.mjs
+++ b/ops/pi-synthetic-monitor/synthetic-proof.test.mjs
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from 'vitest';
-import { answerPendingCheck, resolveSyntheticRoutineId } from './synthetic-proof.mjs';
+import { answerPendingCheck, collectPiConnectivity, resolveSyntheticRoutineId } from './synthetic-proof.mjs';
 
 const locator = (overrides = {}) => ({
   first() { return this; },
@@ -29,7 +29,7 @@ const onboardingPage = () => {
       if (name?.test?.('Proof')) return proof;
       return locator();
     }),
-    locator: vi.fn((selector) => selector === '.today-routine-card'
+    locator: vi.fn((selector) => selector.startsWith('.today-routine-card')
       ? proof
       : locator({ waitFor: vi.fn().mockResolvedValue(undefined) })),
     evaluate: vi.fn().mockResolvedValue(undefined),
@@ -87,6 +87,29 @@ describe('Pi synthetic proof onboarding recovery', () => {
       currentEvidence: healthEvidence,
     });
   });
+
+  it('injects connectivity evidence for a private routine recognized by its visible title', async () => {
+    const context = { addInitScript: vi.fn().mockResolvedValue(undefined) };
+    const { page, proof } = onboardingPage();
+    const connectivityEvidence = { title: 'Raspberry Pi Connectivity', timestamp: '21/07/2026 17:30:00', rows: [] };
+    proof.waitFor.mockResolvedValue(undefined);
+    proof.innerText.mockResolvedValue('Connectivité du Raspberry Pi');
+
+    await expect(answerPendingCheck({
+      context,
+      page,
+      appUrl: 'https://www.zadiag.com',
+      contactEmail: 'pi@example.com',
+      routineId: 'private-connectivity-routine',
+      evidence: connectivityEvidence,
+    })).resolves.toEqual({ outcome: 'Validé' });
+
+    expect(page.locator).toHaveBeenCalledWith('.today-routine-card[data-routine-id="private-connectivity-routine"]');
+    expect(page.evaluate).toHaveBeenCalledWith(expect.any(Function), {
+      currentRoutineId: 'raspberry-pi-connectivity',
+      currentEvidence: connectivityEvidence,
+    });
+  });
 });
 
 describe('Pi synthetic routine resolution', () => {
@@ -95,8 +118,52 @@ describe('Pi synthetic routine resolution', () => {
     expect(resolveSyntheticRoutineId({ pageText: 'Contrôle · Santé du Raspberry Pi' })).toBe('raspberry-pi-health');
   });
 
+  it('recognizes a private connectivity routine from its exact visible title', () => {
+    expect(resolveSyntheticRoutineId({ routineId: 'raspberry-pi-connectivity' })).toBe('raspberry-pi-connectivity');
+    expect(resolveSyntheticRoutineId({ routineId: 'private-routine', pageText: 'Connectivité du Raspberry Pi' })).toBe('raspberry-pi-connectivity');
+  });
+
   it('refuses unrelated and unidentified routines instead of submitting a wrong proof', () => {
     expect(resolveSyntheticRoutineId({ routineId: 'orthodontic-elastics' })).toBeUndefined();
     expect(resolveSyntheticRoutineId({ pageText: 'Élastiques orthodontiques' })).toBeUndefined();
+  });
+});
+
+describe('Pi connectivity evidence', () => {
+  it('collects a bounded green dashboard when every network probe succeeds', async () => {
+    const execFileImpl = vi.fn(async (command, args) => {
+      if (command === 'ip') return { stdout: 'default via 192.168.1.1 dev eth0 proto dhcp\n' };
+      if (command === 'ping') return { stdout: '1 packets transmitted, 1 received' };
+      if (command === 'getent') return { stdout: '203.0.113.10 STREAM www.zadiag.com\n' };
+      if (command === 'timedatectl' && args.some((argument) => argument.includes('NTPSynchronized'))) return { stdout: 'yes\n' };
+      throw new Error(`Unexpected command ${command}`);
+    });
+    const clockValues = [0, 42, 100, 130, 200, 340];
+    const evidence = await collectPiConnectivity({
+      execFileImpl,
+      readFileImpl: vi.fn().mockResolvedValue('up\n'),
+      fetchImpl: vi.fn().mockResolvedValue({ ok: true, status: 200 }),
+      clock: () => clockValues.shift(),
+      now: new Date('2026-07-21T15:30:00.000Z'),
+    });
+
+    expect(evidence.title).toBe('Raspberry Pi Connectivity');
+    expect(evidence.rows.map((row) => row.label)).toEqual(['Interface', 'Passerelle', 'DNS', 'Zadiag HTTPS', 'Horloge NTP', 'Agent']);
+    expect(evidence.rows.every((row) => row.status === 'ok')).toBe(true);
+    expect(evidence.rows[1].value).toBe('42 ms');
+    expect(evidence.rows[3].value).toBe('HTTP 200 · 140 ms');
+  });
+
+  it('reports failures without throwing when network probes are unavailable', async () => {
+    const evidence = await collectPiConnectivity({
+      execFileImpl: vi.fn().mockRejectedValue(new Error('offline')),
+      readFileImpl: vi.fn().mockRejectedValue(new Error('missing')),
+      fetchImpl: vi.fn().mockRejectedValue(new Error('offline')),
+      clock: () => 0,
+    });
+
+    expect(evidence.rows.slice(0, 4).map((row) => row.status)).toEqual(['failure', 'failure', 'failure', 'failure']);
+    expect(evidence.rows[4]).toMatchObject({ label: 'Horloge NTP', status: 'warning' });
+    expect(evidence.rows[5]).toMatchObject({ label: 'Agent', status: 'ok' });
   });
 });

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zadiag-pwa",
   "private": true,
-  "version": "0.10.2",
+  "version": "0.10.3",
   "type": "module",
   "packageManager": "pnpm@11.7.0",
   "engines": {

--- a/src/screens/ChildDashboard.test.tsx
+++ b/src/screens/ChildDashboard.test.tsx
@@ -81,6 +81,7 @@ describe('participant Today screen', () => {
     expect(container.textContent).not.toContain('Completed today');
     expect(container.textContent).not.toContain('This week');
     expect(container.querySelectorAll('.today-task')).toHaveLength(1);
+    expect(container.querySelector('.today-routine-card')?.getAttribute('data-routine-id')).toBe(pending.routineId);
 
     const complete = Array.from(container.querySelectorAll('button')).find((button) => button.textContent?.includes('Proof'));
     act(() => complete?.dispatchEvent(new MouseEvent('click', { bubbles: true })));

--- a/src/screens/ChildDashboard.tsx
+++ b/src/screens/ChildDashboard.tsx
@@ -164,7 +164,7 @@ export function ChildDashboard({
           const actionable = main.status === 'pending' && Date.parse(main.expiresAt) > now;
           const structuredResponse = ['confirmation', 'checklist'].includes(main.challenge?.response.kind ?? 'photo');
           return (
-            <article className={`today-task today-routine-card ${actionable ? 'actionable' : 'expired-only'}`} style={presentation.style} key={group.routineId}>
+            <article className={`today-task today-routine-card ${actionable ? 'actionable' : 'expired-only'}`} data-routine-id={group.routineId} style={presentation.style} key={group.routineId}>
               <div className="today-routine-main">
                 <div className="today-routine-primary">
                   <div className="today-task-copy">


### PR DESCRIPTION
## Summary

- add an automated Raspberry Pi connectivity evidence profile alongside the existing system-health profile
- probe the active interface, gateway, DNS, Zadiag HTTPS, NTP synchronization, and monitor-agent state
- render the timestamped result through the existing deterministic virtual camera
- recognize private routines titled “Connectivité du Raspberry Pi” or “Raspberry Pi Connectivity”
- target notification-driven checks by their persisted routine ID to prevent submitting evidence to the wrong pending card
- document the exact AI-authoring instruction and bump the application version to 0.10.3

## Runtime impact

The installed Pi monitor keeps its existing service and Chromium profile. After deployment, a service restart loads the second collector; no new secret or daemon is required.

## Validation

- real Pi probe: wlan0, gateway, DNS, Zadiag HTTPS, NTP, and agent all green
- `pnpm check`
  - 64 client/ops test files, 316 tests
  - 110 Functions tests
  - production build, architecture, design, routine catalog, and bundle checks
- `git diff --check`

Part of #225.
