### PR TITLE
Fix routine draft serialization

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zadiag-pwa",
   "private": true,
-  "version": "0.10.3",
+  "version": "0.10.4",
   "type": "module",
   "packageManager": "pnpm@11.7.0",
   "engines": {

--- a/src/domain/routineDraft.test.ts
+++ b/src/domain/routineDraft.test.ts
@@ -91,6 +91,7 @@ describe('private routine draft domain', () => {
     expect(prepared.routine.instructionSteps).toHaveLength(2);
     expect(prepared.routine.proofType).toBe('photo');
     expect(prepared.routine.analysis?.detectedCriteria).toContain('élastiques orthodontiques');
+    expect(Object.hasOwn(prepared.routine, 'translations')).toBe(false);
   });
 
   it('uses the current user locale when translated content is available', () => {
@@ -105,6 +106,7 @@ describe('private routine draft domain', () => {
     expect(localized.routine.name).toBe('Routine du soir');
     expect(localized.routine.instructions).toBe('Mettre les élastiques après le dîner.');
     expect(localized.routine.translations).toBeUndefined();
+    expect(Object.hasOwn(localized.routine, 'translations')).toBe(false);
   });
 
   it('creates an owned active draft at revision one without retaining mutable input', () => {

--- a/src/domain/routineDraft.ts
+++ b/src/domain/routineDraft.ts
@@ -81,7 +81,7 @@ export const routinePackageInLocale = (routinePackage: RoutinePackageV1, locale:
   if (localized || next.defaultLocale === locale) {
     next.defaultLocale = locale;
     next.availableLocales = [locale];
-    next.routine.translations = undefined;
+    delete next.routine.translations;
   }
   return next;
 };
@@ -120,7 +120,7 @@ export const prepareMinimalRoutinePackage = (routinePackage: RoutinePackageV1, r
   const fit = (value: string, maximum: number) => value.slice(0, maximum).trim();
   const shouldFill = (value: string | undefined) => regenerateDerived || !value?.trim();
   next.availableLocales = [next.defaultLocale];
-  routine.translations = undefined;
+  delete routine.translations;
   if (!routine.name.trim()) routine.name = generatedName;
   if (shouldFill(routine.description)) routine.description = fit(instruction, 500);
   if (shouldFill(routine.responsibleName)) routine.responsibleName = copy.responsibleName;

--- a/src/screens/RoutineDraftEditorScreen.test.tsx
+++ b/src/screens/RoutineDraftEditorScreen.test.tsx
@@ -38,6 +38,7 @@ describe('private routine draft editor', () => {
     expect(save.mock.calls[0][0].routine.instructionSteps).toHaveLength(2);
     expect(save.mock.calls[0][0].routine.analysis.detectedCriteria).toContain('élastiques orthodontiques');
     expect(save.mock.calls[0][0].routine.translations).toBeUndefined();
+    expect(Object.hasOwn(save.mock.calls[0][0].routine, 'translations')).toBe(false);
     expect(container.textContent).toContain('Brouillon enregistré · révision 1 · prêt');
   });
 


### PR DESCRIPTION
## Summary

- Remove optional routine translations instead of retaining them as `undefined`.
- Prevent Firebase callable serialization from converting the absent field to `null`.
- Cover both locale normalization and final routine creation payloads with regression tests.
- Bump the web application to 0.10.4.

## Root cause

The routine composer set `routine.translations` to `undefined`. Firebase callable encoding preserves object keys and encodes `undefined` as `null`. The strict routine package schema rejects `translations: null`, so `createRoutineDraft` returned HTTP 400 even though the generated routine was valid in the UI.

## User impact

AI-generated and manually authored single-language routines can be created and assigned normally.

## Validation

- `corepack pnpm exec vitest run src/domain/routineDraft.test.ts src/screens/RoutineDraftEditorScreen.test.tsx`
- `corepack pnpm check`
