### PR TITLE
Show completed responses as validated

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zadiag-pwa",
   "private": true,
-  "version": "0.10.7",
+  "version": "0.10.8",
   "type": "module",
   "packageManager": "pnpm@11.7.0",
   "engines": {

--- a/src/components/StatusPill.test.ts
+++ b/src/components/StatusPill.test.ts
@@ -1,0 +1,8 @@
+import { describe, expect, it } from 'vitest';
+import { statusMessageKey } from './StatusPill';
+
+describe('statusMessageKey', () => {
+  it('presents a completed structured response as validated', () => {
+    expect(statusMessageKey('answered')).toBe('validated');
+  });
+});

--- a/src/components/StatusPill.tsx
+++ b/src/components/StatusPill.tsx
@@ -3,7 +3,7 @@ import type { MessageKey } from '../services/i18n';
 
 export const statusMessageKey = (status: VerificationStatus): MessageKey => {
   if (status === 'detected') return 'validated';
-  if (status === 'answered') return 'answered';
+  if (status === 'answered') return 'validated';
   if (status === 'not_detected') return 'notDetected';
   if (status === 'uncertain') return 'uncertain';
   if (status === 'missed') return 'missed';


### PR DESCRIPTION
## Summary
- display completed structured routine responses as “Validated” / “Validé” consistently with successful photo checks
- keep the internal `answered` status unchanged
- add a regression test for the shared status mapping
- bump the application version to 0.10.8

## Root cause
Structured routine responses use the technical `answered` state, and the shared status component exposed that implementation detail as “Répondu”.

## Impact
Existing and future structured responses will display “Validé” after the client updates; no data migration or repeated check is required.

## Validation
- `corepack pnpm check`
- 308 client tests passed
- 110 functions tests passed
- production build and bundle checks passed