### PR TITLE
Use package version for app builds

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -5,7 +5,7 @@ import react from '@vitejs/plugin-react';
 import { VitePWA } from 'vite-plugin-pwa';
 
 const packageJson = JSON.parse(readFileSync(resolve(process.cwd(), 'package.json'), 'utf8')) as { version: string };
-const appVersion = process.env.VITE_APP_VERSION ?? packageJson.version;
+const appVersion = packageJson.version;
 const appUpdatedAt = process.env.VITE_APP_UPDATED_AT ?? new Date().toISOString();
 
 export default defineConfig({


### PR DESCRIPTION
## Summary

- make `package.json` the single source of truth for the application version
- prevent a stale Vercel `VITE_APP_VERSION` variable from overriding version-only releases

## Root cause

Vercel still defined `VITE_APP_VERSION=0.10.9`. The Vite configuration preferred that environment value over the newly bumped `package.json` version, so the successful `0.10.10` deployment continued to identify itself as `0.10.9`.

## User impact

Future GitHub version bumps are reflected automatically in the splash screen, settings diagnostics, update controller, and `app-version.json` without manually synchronizing a Vercel variable.

## Validation

- `VITE_APP_VERSION=0.10.9 npm run build`
- generated `dist/app-version.json` reports `0.10.10`
- architecture check passed
- `git diff --check`