### PR TITLE
Align completed responses with validated success

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zadiag-pwa",
   "private": true,
-  "version": "0.10.10",
+  "version": "0.10.11",
   "type": "module",
   "packageManager": "pnpm@11.7.0",
   "engines": {

--- a/src/components/AdherenceSummaryCard.tsx
+++ b/src/components/AdherenceSummaryCard.tsx
@@ -23,7 +23,7 @@ const ranges: Array<{
 
 const ringSegments: Array<{ status: VerificationStatus; color: string }> = [
   { status: 'detected', color: 'var(--color-primary)' },
-  { status: 'answered', color: 'var(--color-info-soft)' },
+  { status: 'answered', color: 'var(--color-primary)' },
   { status: 'not_detected', color: 'var(--color-summary-not-detected)' },
   { status: 'uncertain', color: 'var(--color-summary-uncertain)' },
   { status: 'missed', color: 'var(--color-summary-missed)' },

--- a/src/components/RoutineHistoryPanel.test.ts
+++ b/src/components/RoutineHistoryPanel.test.ts
@@ -1,0 +1,11 @@
+import { describe, expect, it } from 'vitest';
+import { groupedVerificationStatuses } from './RoutineHistoryPanel';
+
+describe('groupedVerificationStatuses', () => {
+  it('offers one validated filter for photo and structured-response successes', () => {
+    expect(groupedVerificationStatuses(['detected', 'answered', 'missed'])).toEqual([
+      { status: 'detected', eventStatuses: ['detected', 'answered'] },
+      { status: 'missed', eventStatuses: ['missed'] },
+    ]);
+  });
+});

--- a/src/components/RoutineHistoryPanel.tsx
+++ b/src/components/RoutineHistoryPanel.tsx
@@ -4,7 +4,7 @@ import type { MessageKey } from '../services/i18n';
 import { presentRoutine } from '../domain/routinePresentation';
 import { AppIcon, routineIconName } from './Icon';
 import { StatusPill, statusMessageKey } from './StatusPill';
-import { canRetakeCapture, stalePendingCheckReason, withResolvedEventStatuses } from '../domain/adherence';
+import { canRetakeCapture, isSuccessfulVerification, stalePendingCheckReason, withResolvedEventStatuses } from '../domain/adherence';
 import { coalesceActivePendingEventsByRoutine } from '../domain/dashboardChecks';
 import { EmptyState, ListRow } from './ui';
 import { readUiStorageJson, writeUiStorageString } from '../services/uiStorage';
@@ -35,6 +35,15 @@ const analysisTag = (event: VerificationEvent, locale: Locale) => {
   if (event.analysisSource === 'ai') return locale === 'fr' ? 'IA' : 'AI';
   if (event.analysisSource === 'self' || event.reason === 'self_validated') return 'Auto';
   return undefined;
+};
+
+export const groupedVerificationStatuses = (statuses: VerificationStatus[]) => {
+  const groups = new Map<VerificationStatus, VerificationStatus[]>();
+  statuses.forEach((eventStatus) => {
+    const status = isSuccessfulVerification({ status: eventStatus }) ? 'detected' : eventStatus;
+    groups.set(status, [...(groups.get(status) ?? []), eventStatus]);
+  });
+  return Array.from(groups, ([status, eventStatuses]) => ({ status, eventStatuses }));
 };
 
 export function RoutineHistoryPanel({
@@ -90,8 +99,8 @@ export function RoutineHistoryPanel({
     });
     return ids;
   }, [sortedEvents]);
-  const statuses = useMemo<VerificationStatus[]>(
-    () => Array.from(new Set(sortedEvents.map((event) => event.status))),
+  const statusFilters = useMemo(
+    () => groupedVerificationStatuses(Array.from(new Set(sortedEvents.map((event) => event.status)))),
     [sortedEvents],
   );
   const excludedStatusSet = useMemo(() => new Set(excludedStatuses), [excludedStatuses]);
@@ -108,11 +117,13 @@ export function RoutineHistoryPanel({
         ? current.filter((item) => item !== routineId)
         : [...current, routineId]);
   };
-  const toggleStatusFilter = (status: VerificationStatus) => {
-    setExcludedStatuses((current) =>
-      current.includes(status)
-        ? current.filter((item) => item !== status)
-        : [...current, status]);
+  const toggleStatusFilter = (eventStatuses: VerificationStatus[]) => {
+    setExcludedStatuses((current) => {
+      const allActive = eventStatuses.every((status) => !current.includes(status));
+      return allActive
+        ? Array.from(new Set([...current, ...eventStatuses]))
+        : current.filter((status) => !eventStatuses.includes(status));
+    });
   };
   const filtered = useMemo(() => sortedEvents.filter((event) =>
     !excludedStatusSet.has(event.status)
@@ -157,9 +168,9 @@ export function RoutineHistoryPanel({
             <div className="filter-group">
               <span>{t('filterByStatus')}</span>
               <div className="filter-chips">
-                {statuses.map((status) => {
-                  const active = !excludedStatuses.includes(status);
-                  return <button type="button" key={status} aria-pressed={active} className={`filter-status-${status} ${active ? 'active' : ''}`} onClick={() => toggleStatusFilter(status)}>{t(statusMessageKey(status))}</button>;
+                {statusFilters.map(({ status, eventStatuses }) => {
+                  const active = eventStatuses.every((eventStatus) => !excludedStatuses.includes(eventStatus));
+                  return <button type="button" key={status} aria-pressed={active} className={`filter-status-${status} ${active ? 'active' : ''}`} onClick={() => toggleStatusFilter(eventStatuses)}>{t(statusMessageKey(status))}</button>;
                 })}
               </div>
             </div>

--- a/src/domain/adherence.test.ts
+++ b/src/domain/adherence.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { adherenceSummary, canRetakeCapture, isFreshCapture, isReviewableVerification, resolvedEventStatus, stalePendingCheckReason } from './adherence';
+import { adherenceSummary, canRetakeCapture, isFreshCapture, isReviewableVerification, isSuccessfulVerification, resolvedEventStatus, stalePendingCheckReason } from './adherence';
 import type { VerificationEvent } from './models';
 
 const event = (status: VerificationEvent['status']): VerificationEvent => ({
@@ -14,10 +14,18 @@ const event = (status: VerificationEvent['status']): VerificationEvent => ({
 describe('adherenceSummary', () => {
   it('excludes pending checks and calculates a supportive completion rate', () => {
     const result = adherenceSummary([
-      event('detected'), event('detected'), event('uncertain'), event('pending'),
+      event('detected'), event('answered'), event('uncertain'), event('pending'),
     ]);
     expect(result).toMatchObject({ completed: 3, successful: 2, attention: 1 });
     expect(result.rate).toBeCloseTo(2 / 3);
+  });
+});
+
+describe('isSuccessfulVerification', () => {
+  it('treats photo validations and completed structured responses as successes', () => {
+    expect(isSuccessfulVerification(event('detected'))).toBe(true);
+    expect(isSuccessfulVerification(event('answered'))).toBe(true);
+    expect(isSuccessfulVerification(event('uncertain'))).toBe(false);
   });
 });
 

--- a/src/domain/adherence.ts
+++ b/src/domain/adherence.ts
@@ -12,12 +12,15 @@ const retakeWindowMs = 15 * 60_000;
 
 export const isCompletedVerification = (event: VerificationEvent) => finalStatuses.has(event.status);
 
+export const isSuccessfulVerification = (event: Pick<VerificationEvent, 'status'>) =>
+  event.status === 'detected' || event.status === 'answered';
+
 export const isReviewableVerification = (event: VerificationEvent) =>
   event.status === 'uncertain' && !['approved', 'rejected'].includes(event.reviewStatus ?? '');
 
 export function adherenceSummary(events: VerificationEvent[]) {
   const completed = events.filter(isCompletedVerification);
-  const successful = completed.filter((event) => event.status === 'detected');
+  const successful = completed.filter(isSuccessfulVerification);
   const attention = completed.filter((event) => ['not_detected', 'uncertain', 'missed', 'expired'].includes(event.status));
   const statusCounts = completed.reduce<Record<string, number>>((counts, event) => ({
     ...counts,

--- a/src/domain/reporting.test.ts
+++ b/src/domain/reporting.test.ts
@@ -76,7 +76,7 @@ describe('weeklyInsight', () => {
     assignment.plan.timeZone = 'UTC';
     const events: VerificationEvent[] = [
       { id: 'one', routineId: assignment.routineId, sessionId: 'one', requestedAt: '2026-07-17T12:15:00.000Z', expiresAt: '2026-07-17T14:00:00.000Z', status: 'detected', responsibleActions: [{ type: 'approved', at: '2026-07-17T13:00:00.000Z', actorUid: 'owner', actorName: 'Idriss' }] },
-      { id: 'two', routineId: assignment.routineId, sessionId: 'two', requestedAt: '2026-07-16T12:15:00.000Z', expiresAt: '2026-07-16T14:00:00.000Z', status: 'detected' },
+      { id: 'two', routineId: assignment.routineId, sessionId: 'two', requestedAt: '2026-07-16T12:15:00.000Z', expiresAt: '2026-07-16T14:00:00.000Z', status: 'answered' },
       { id: 'three', routineId: assignment.routineId, sessionId: 'three', requestedAt: '2026-07-15T07:45:00.000Z', expiresAt: '2026-07-15T09:30:00.000Z', status: 'missed' },
       { id: 'previous', routineId: assignment.routineId, sessionId: 'previous', requestedAt: '2026-07-08T12:15:00.000Z', expiresAt: '2026-07-08T14:00:00.000Z', status: 'detected' },
     ];

--- a/src/domain/reporting.ts
+++ b/src/domain/reporting.ts
@@ -1,4 +1,4 @@
-import { adherenceSummary, isCompletedVerification } from './adherence';
+import { adherenceSummary, isCompletedVerification, isSuccessfulVerification } from './adherence';
 import type { MonitoringPlan, RoutineAssignment, VerificationEvent } from './models';
 import { buildMonitoringPlanFromGroups, groupsFromLegacyPlan } from './monitoringPlan';
 
@@ -156,7 +156,7 @@ export const planningRecommendation = (
 
   events.filter((event) => event.routineId === assignment.routineId
     && eventTimestamp(event) >= cutoff && eventTimestamp(event) <= now
-    && ['detected', 'missed', 'expired'].includes(event.status)).forEach((event) => {
+    && (isSuccessfulVerification(event) || ['missed', 'expired'].includes(event.status))).forEach((event) => {
     const schedule = eventScheduleParts(event.requestedAt, assignment.plan.timeZone);
     groups.forEach((group) => {
       if (!group.weekdays.includes(schedule.weekday)) return;
@@ -164,7 +164,7 @@ export const planningRecommendation = (
         if (schedule.minute < timeMinutes(window.start) || schedule.minute > timeMinutes(window.end)) return;
         const key = `${group.id}:${window.id}`;
         const current = performance.get(key) ?? { failures: 0, successes: 0 };
-        if (event.status === 'detected') current.successes += 1;
+        if (isSuccessfulVerification(event)) current.successes += 1;
         else current.failures += 1;
         performance.set(key, current);
       });
@@ -210,7 +210,7 @@ export const weeklyInsight = (
   const windowScores = new Map<string, { start: string; end: string; successes: number }>();
   const currentEvents = eventsForReportingPeriods(events, 'week', now).current;
 
-  currentEvents.filter((event) => event.status === 'detected').forEach((event) => {
+  currentEvents.filter(isSuccessfulVerification).forEach((event) => {
     const assignment = assignments.find((item) => item.routineId === event.routineId);
     if (!assignment) return;
     const schedule = eventScheduleParts(event.requestedAt, assignment.plan.timeZone);

--- a/src/screens/RoutineDetailScreen.test.ts
+++ b/src/screens/RoutineDetailScreen.test.ts
@@ -36,7 +36,7 @@ describe('routine progress heatmap', () => {
   it('maps routine events to daily heatmap states and intensity levels', () => {
     const days = calendarDays([
       { id: 'done-1', routineId: 'routine', sessionId: 'one', requestedAt: '2026-07-02T08:00:00.000Z', expiresAt: '2026-07-02T09:00:00.000Z', status: 'detected' },
-      { id: 'done-2', routineId: 'routine', sessionId: 'two', requestedAt: '2026-07-02T10:00:00.000Z', expiresAt: '2026-07-02T11:00:00.000Z', status: 'detected' },
+      { id: 'done-2', routineId: 'routine', sessionId: 'two', requestedAt: '2026-07-02T10:00:00.000Z', expiresAt: '2026-07-02T11:00:00.000Z', status: 'answered' },
       { id: 'review', routineId: 'routine', sessionId: 'three', requestedAt: '2026-07-03T08:00:00.000Z', expiresAt: '2026-07-03T09:00:00.000Z', status: 'uncertain' },
       { id: 'missed', routineId: 'routine', sessionId: 'four', requestedAt: '2026-07-04T08:00:00.000Z', expiresAt: '2026-07-04T09:00:00.000Z', status: 'missed' },
     ], 'en-US', new Date(2026, 6, 5));

--- a/src/screens/RoutineDetailScreen.tsx
+++ b/src/screens/RoutineDetailScreen.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef, useState } from 'react';
 import { cameraOutline, chevronBackOutline, chevronForwardOutline, ellipsisHorizontal, peopleOutline } from 'ionicons/icons';
-import { adherenceSummary, withResolvedEventStatuses } from '../domain/adherence';
+import { adherenceSummary, isSuccessfulVerification, withResolvedEventStatuses } from '../domain/adherence';
 import { presentRoutine } from '../domain/routinePresentation';
 import type { AppState, RoutineAppearance, RoutineAssignment, RoutineValidationMode, VerificationEvent } from '../domain/models';
 import type { MessageKey } from '../services/i18n';
@@ -68,7 +68,7 @@ export const calendarDays = (events: VerificationEvent[], locale: string, refere
     const dayStart = new Date(day);
     dayStart.setHours(0, 0, 0, 0);
     const dayEvents = events.filter((event) => sameLocalDay(event.requestedAt, day));
-    const successful = dayEvents.filter((event) => event.status === 'detected').length;
+    const successful = dayEvents.filter(isSuccessfulVerification).length;
     const attention = dayEvents.filter((event) => ['not_detected', 'uncertain'].includes(event.status)).length;
     const missed = dayEvents.filter((event) => ['missed', 'expired'].includes(event.status)).length;
     const total = successful + attention + missed;
@@ -140,7 +140,7 @@ const streakFor = (events: VerificationEvent[]) => {
   let streak = 0;
   const day = new Date();
   day.setHours(0, 0, 0, 0);
-  while (events.some((event) => event.status === 'detected' && sameLocalDay(event.requestedAt, day))) {
+  while (events.some((event) => isSuccessfulVerification(event) && sameLocalDay(event.requestedAt, day))) {
     streak += 1;
     day.setDate(day.getDate() - 1);
   }

--- a/src/screens/RoutinesScreen.test.tsx
+++ b/src/screens/RoutinesScreen.test.tsx
@@ -447,7 +447,7 @@ describe('participant routines navigation', () => {
       family: { linked: true, childLinked: true, childName: 'Maya', linkingCode: '', parentRecoveryCode: '', consented: false },
       routineAssignments: [assignment],
       events: [
-        { id: 'done', routineId: assignment.routineId, sessionId: 'one', requestedAt: '2026-07-02T08:00:00.000Z', expiresAt: '2026-07-02T09:00:00.000Z', status: 'detected' },
+        { id: 'done', routineId: assignment.routineId, sessionId: 'one', requestedAt: '2026-07-02T08:00:00.000Z', expiresAt: '2026-07-02T09:00:00.000Z', status: 'answered' },
         { id: 'missed', routineId: assignment.routineId, sessionId: 'two', requestedAt: '2026-07-02T10:00:00.000Z', capturedAt: '2026-07-02T10:20:00.000Z', expiresAt: '2026-07-02T11:00:00.000Z', status: 'not_detected', proofImagePath: 'families/family/checks/missed/proof.jpg', analysisSource: 'ai', confidence: 0.82, imageQuality: 0.74, reason: 'Elastics not visible', reviewStatus: 'approved', reviewedAt: '2026-07-02T10:30:00.000Z', reviewReason: 'Checked manually' },
         { id: 'next', routineId: assignment.routineId, sessionId: 'three', requestedAt: '2026-07-02T18:00:00.000Z', expiresAt: '2026-07-02T20:00:00.000Z', status: 'pending' },
         { id: 'other', routineId: 'another-routine', sessionId: 'four', requestedAt: '2026-07-02T12:00:00.000Z', expiresAt: '2026-07-02T13:00:00.000Z', status: 'detected', reason: 'Other routine event' },

--- a/src/screens/RoutinesScreen.tsx
+++ b/src/screens/RoutinesScreen.tsx
@@ -9,7 +9,7 @@ import { DisclosureToggle } from '../components/DisclosureToggle';
 import { ParticipantSelector } from '../components/ParticipantSelector';
 import { presentRoutine } from '../domain/routinePresentation';
 import { assignableRoutineTemplates, marketplaceFromTemplates, presentRoutineTemplate } from '../domain/routineMarketplace';
-import { withResolvedEventStatuses } from '../domain/adherence';
+import { isCompletedVerification, isSuccessfulVerification, withResolvedEventStatuses } from '../domain/adherence';
 import { routineContentChanges, selectRoutineVersionTarget, type PublishedRoutineVersion, type RoutineCatalogEntry, type RoutineContentChange, type RoutineDraft } from '../domain/routineDraft';
 import { readUiStorageJson, readUiStorageString, removeUiStorageItem, writeUiStorageString } from '../services/uiStorage';
 import type { AiAuthoringCapabilities, AiRoutineProposal, AiRoutineResponseKind } from '../services/contracts';
@@ -47,10 +47,10 @@ const readStoredStringSet = (key: string) => {
 const routineCompletionRatesById = (events: VerificationEvent[]) => {
   const stats = new Map<string, { completed: number; successful: number }>();
   events.forEach((event) => {
-    if (event.status === 'pending' || event.status === 'analyzing') return;
+    if (!isCompletedVerification(event)) return;
     const current = stats.get(event.routineId) ?? { completed: 0, successful: 0 };
     current.completed += 1;
-    if (event.status === 'detected') current.successful += 1;
+    if (isSuccessfulVerification(event)) current.successful += 1;
     stats.set(event.routineId, current);
   });
   return new Map([...stats].map(([routineId, item]) => [

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -719,14 +719,16 @@ button:disabled { cursor: not-allowed; }
 .filter-chips::-webkit-scrollbar { display: none; }
 .filter-chips button { flex: 0 1 auto; min-height: var(--height-action); max-width: 100%; padding: 6px 12px; border: 1px solid transparent; border-radius: 11px; background: var(--color-control-surface); color: var(--color-text-muted); font-size: 12px; font-weight: 800; line-height: 1.05; white-space: normal; }
 .filter-chips button.active { background: var(--color-text); color: var(--color-surface-solid); box-shadow: 0 4px 12px rgba(16,42,67,.16); }
-.filter-chips .filter-status-detected { background: var(--color-primary-soft); color: var(--color-primary); }
+.filter-chips .filter-status-detected,
+.filter-chips .filter-status-answered { background: var(--color-primary-soft); color: var(--color-primary); }
 .filter-chips .filter-status-uncertain { background: var(--color-warning-soft); color: var(--color-warning-strong); }
 .filter-chips .filter-status-missed,
 .filter-chips .filter-status-expired,
 .filter-chips .filter-status-analyzing { background: var(--color-disabled-surface); color: var(--color-disabled-text); }
 .filter-chips .filter-status-pending { background: var(--color-info-soft); color: var(--color-text); }
 .filter-chips .filter-status-not_detected { background: var(--color-danger-soft); color: var(--color-danger); }
-.filter-chips .filter-status-detected.active { background: var(--color-primary); color: var(--color-surface-solid); }
+.filter-chips .filter-status-detected.active,
+.filter-chips .filter-status-answered.active { background: var(--color-primary); color: var(--color-surface-solid); }
 .filter-chips .filter-status-uncertain.active { background: var(--color-warning-strong); color: var(--color-surface-solid); }
 .filter-chips .filter-status-missed.active,
 .filter-chips .filter-status-expired.active,
@@ -952,12 +954,11 @@ button:disabled { cursor: not-allowed; }
   .planning-recommendation { grid-column: 1 / -1; }
 }
 .status-pill { display: inline-flex; flex: 0 0 auto; align-items: center; justify-content: center; white-space: nowrap; padding: 7px 10px; border-radius: 99px; background: #eef2f4; color: var(--color-text); font-weight: 900; font-size: 11px; text-transform: capitalize; }
-.status-detected { background: var(--color-primary-soft); color: var(--color-primary); }
+.status-detected, .status-answered { background: var(--color-primary-soft); color: var(--color-primary); }
 .status-uncertain { background: var(--color-warning-soft); color: var(--color-warning-strong); }
 .status-pending { background: var(--color-info-soft); color: var(--color-text); }
 .status-missed, .status-expired { background: var(--color-disabled-surface); color: var(--color-disabled-text); }
 .status-not_detected { background: var(--color-danger-soft); color: var(--color-danger); }
-.status-answered { background: var(--color-info-soft); color: var(--color-text); }
 
 .check-card { color: var(--color-surface-solid); padding: 25px; border-radius: 29px; background: linear-gradient(135deg, #187e70, #35a18f); box-shadow: 0 18px 36px rgba(29,138,122,.2); }
 .check-card h2 { color: var(--color-surface-solid); font-size: 28px; margin-top: 16px; }


### PR DESCRIPTION
## Summary
- centralize successful verification semantics so both photo detections and completed structured responses count as validated successes
- use the green success palette for `answered` badges and summary-ring segments
- merge `detected` and `answered` into one “Validated” history filter
- include structured-response successes in routine rates, heatmaps, streaks, best-window insights, and reports
- bump the application version to 0.10.11

## Root cause
The earlier fix changed only the visible label for the technical `answered` status. Color and reporting logic still treated `answered` as a separate informational outcome, producing a blue “Validated” badge, duplicate filters, and an incorrect 2/3 success rate.

## Impact
Existing Photocalia responses will display with the same green validated styling as photo checks and will count in all success metrics without a data migration.

## Validation
- `corepack pnpm exec vitest run src/domain/adherence.test.ts src/domain/reporting.test.ts src/components/StatusPill.test.ts src/components/RoutineHistoryPanel.test.ts src/screens/RoutineDetailScreen.test.ts src/screens/RoutinesScreen.test.tsx` (51 tests)
- `corepack pnpm check` (312 client tests, 110 Functions tests, production build, architecture, design, routine catalog, and bundle checks)