### PR TITLE
Harmonize routine appearance actions

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zadiag-pwa",
   "private": true,
-  "version": "0.10.12",
+  "version": "0.10.13",
   "type": "module",
   "packageManager": "pnpm@11.7.0",
   "engines": {

--- a/src/screens/RoutineDetailScreen.appearance.test.tsx
+++ b/src/screens/RoutineDetailScreen.appearance.test.tsx
@@ -44,6 +44,8 @@ describe('routine appearance editor', () => {
 
     expect(trigger?.getAttribute('aria-expanded')).toBe('true');
     expect(container.querySelector('.routine-appearance-top-editor')).not.toBeNull();
+    expect(container.querySelector('.routine-appearance-cancel')?.classList.contains('fill-outline')).toBe(true);
+    expect(container.querySelector('.routine-appearance-save')?.classList.contains('action-button')).toBe(true);
     const pickerTrigger = container.querySelector<HTMLButtonElement>('.routine-icon-picker-trigger');
     expect(pickerTrigger).not.toBeNull();
     await act(async () => {
@@ -63,7 +65,7 @@ describe('routine appearance editor', () => {
     act(() => document.body.querySelector<HTMLButtonElement>('.routine-icon-catalog button')?.click());
 
     await act(async () => {
-      container.querySelector<HTMLButtonElement>('.routine-appearance-actions .primary-action-button')?.click();
+      container.querySelector<HTMLButtonElement>('.routine-appearance-save')?.click();
       await Promise.resolve();
     });
 

--- a/src/screens/RoutineDetailScreen.tsx
+++ b/src/screens/RoutineDetailScreen.tsx
@@ -343,7 +343,10 @@ export function RoutineDetailScreen({ assignment, state, back, start, getProofIm
         <label className="native-input-field"><span>{t('routineDraftName')}</span><input value={appearance.name} maxLength={120} onChange={(event) => { setAppearance((current) => ({ ...current, name: event.target.value })); setAppearanceStatus(undefined); }} /></label>
         <fieldset><legend>{t('routineIcon')}</legend><button type="button" className="routine-icon-picker-trigger" onClick={() => setIconPickerOpen(true)}><AppIcon name={routineIconName(appearance.icon)} /><span>{t('routineIconChoose')}</span><AppIcon name="chevron-forward" /></button></fieldset>
         <label className="routine-appearance-color"><span>{t('routineDraftAccentColor')}</span><input type="color" value={appearance.accentColor} onChange={(event) => { setAppearance((current) => ({ ...current, accentColor: event.target.value.toUpperCase() })); setAppearanceStatus(undefined); }} /></label>
-        <div className="routine-appearance-actions"><button type="button" onClick={() => setAppearanceEditing(false)}>{t('cancel')}</button><button type="button" className="primary-action-button" disabled={!appearance.name.trim() || appearanceStatus === 'saving'} onClick={() => { void saveAppearance(); }}>{t(appearanceStatus === 'saving' ? 'saving' : 'save')}</button></div>
+        <div className="routine-appearance-actions">
+          <ActionButton className="routine-appearance-cancel" fill="outline" onClick={() => setAppearanceEditing(false)}>{t('cancel')}</ActionButton>
+          <ActionButton className="routine-appearance-save" disabled={!appearance.name.trim() || appearanceStatus === 'saving'} aria-busy={appearanceStatus === 'saving'} onClick={() => { void saveAppearance(); }}>{t(appearanceStatus === 'saving' ? 'saving' : 'save')}</ActionButton>
+        </div>
         {appearanceStatus === 'saved' ? <p role="status">{t('routineAppearanceSaved')}</p> : appearanceStatus === 'error' ? <p role="alert" className="form-error">{t('routineAppearanceError')}</p> : null}
       </section> : null}
       {iconPickerOpen ? <RoutineIconPicker selected={routineIconName(appearance.icon)} locale={state.locale} close={() => setIconPickerOpen(false)} select={(icon) => { setAppearance((current) => ({ ...current, icon })); setAppearanceStatus(undefined); }} t={t} /> : null}

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -188,9 +188,10 @@ button:disabled { cursor: not-allowed; }
 .routine-appearance-editor legend, .routine-appearance-color > span { margin-bottom: 7px; color: var(--color-text-muted); font-size: 12px; font-weight: 850; }
 .routine-appearance-color { display: grid; }
 .routine-appearance-color input { width: 100%; height: 46px; padding: 4px; border: 1px solid var(--color-border); border-radius: 13px; background: var(--color-surface-solid); }
-.routine-appearance-editor .primary-action-button { width: 100%; }
-.routine-appearance-actions { display: grid; grid-template-columns: 1fr 1fr; gap: 10px; }
-.routine-appearance-actions button { min-height: var(--height-action); border: 0; border-radius: var(--radius-control); font-weight: 850; }
+.routine-appearance-actions { display: grid; grid-template-columns: .9fr 1.1fr; gap: 10px; }
+.routine-appearance-actions .action-button { min-width: 0; box-shadow: none; }
+.routine-appearance-actions .routine-appearance-cancel { border-color: color-mix(in srgb, var(--color-primary) 38%, var(--color-border)); background: var(--color-surface-solid); }
+.routine-appearance-actions .routine-appearance-save { box-shadow: 0 8px 18px color-mix(in srgb, var(--color-primary) 16%, transparent); }
 .routine-appearance-editor > p { margin: 0; font-size: 12px; text-align: center; }
 .routine-icon-picker-trigger { width: 100%; min-height: 48px; display: grid; grid-template-columns: 30px minmax(0, 1fr) 20px; align-items: center; gap: 9px; padding: 7px 11px; border: 1px solid color-mix(in srgb, var(--color-text) 7%, transparent); border-radius: var(--radius-control); background: color-mix(in srgb, var(--color-primary-soft) 28%, var(--color-surface-solid)); color: var(--color-text); text-align: left; box-shadow: inset 0 1px color-mix(in srgb, var(--color-surface-solid) 86%, transparent); }
 .routine-icon-picker-trigger .app-icon:first-child { color: var(--routine-accent, var(--color-primary)); font-size: 20px; }


### PR DESCRIPTION
## Summary

- replace locally styled appearance actions with the shared `ActionButton` primitive
- present Cancel as a quiet outlined secondary action
- present Save as the single solid primary action using the routine accent
- expose the save busy state accessibly
- remove the competing native/browser button treatment
- bump the application version to 0.10.13

## Design rationale

This follows `DESIGN.md`: reuse shared primitives, preserve one obvious primary action, use semantic tokens, and avoid a parallel button model for a single screen.

## Validation

- 27 relevant frontend tests passed
- design and architecture checks passed
- production build and bundle checks passed
- `git diff --check`