### PR TITLE
Use brand color for routine actions

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zadiag-pwa",
   "private": true,
-  "version": "0.10.13",
+  "version": "0.10.14",
   "type": "module",
   "packageManager": "pnpm@11.7.0",
   "engines": {

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -188,7 +188,7 @@ button:disabled { cursor: not-allowed; }
 .routine-appearance-editor legend, .routine-appearance-color > span { margin-bottom: 7px; color: var(--color-text-muted); font-size: 12px; font-weight: 850; }
 .routine-appearance-color { display: grid; }
 .routine-appearance-color input { width: 100%; height: 46px; padding: 4px; border: 1px solid var(--color-border); border-radius: 13px; background: var(--color-surface-solid); }
-.routine-appearance-actions { display: grid; grid-template-columns: .9fr 1.1fr; gap: 10px; }
+.routine-appearance-actions { --color-primary: var(--color-brand-primary); display: grid; grid-template-columns: .9fr 1.1fr; gap: 10px; }
 .routine-appearance-actions .action-button { min-width: 0; box-shadow: none; }
 .routine-appearance-actions .routine-appearance-cancel { border-color: color-mix(in srgb, var(--color-primary) 38%, var(--color-border)); background: var(--color-surface-solid); }
 .routine-appearance-actions .routine-appearance-save { box-shadow: 0 8px 18px color-mix(in srgb, var(--color-primary) 16%, transparent); }

--- a/src/styles/tokens.css
+++ b/src/styles/tokens.css
@@ -2,7 +2,8 @@
   --color-text: #102a43;
   --color-text-strong: #15324b;
   --color-text-muted: #687783;
-  --color-primary: #087f6d;
+  --color-brand-primary: #087f6d;
+  --color-primary: var(--color-brand-primary);
   --color-primary-soft: #e8f6f2;
   --color-danger: #c64d40;
   --color-danger-soft: #fdebe7;


### PR DESCRIPTION
## Summary

- introduce a semantic Zadiag brand-primary token
- keep the existing primary token as its default alias
- scope routine appearance CTAs back to the stable brand color
- preserve the routine accent for identity and presentation only
- bump the application version to 0.10.14

## Design rationale

CTA hierarchy remains consistent across routines regardless of their selected accent color, while routine identity stays visually distinct.

## Validation

- appearance editor regression test passed
- design check passed
- production build and bundle checks passed
- `git diff --check`