### PR TITLE
Unify routine appearance customization

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zadiag-pwa",
   "private": true,
-  "version": "0.10.14",
+  "version": "0.10.15",
   "type": "module",
   "packageManager": "pnpm@11.7.0",
   "engines": {

--- a/src/components/RoutineAppearanceFields.tsx
+++ b/src/components/RoutineAppearanceFields.tsx
@@ -1,0 +1,56 @@
+import { useState, type CSSProperties } from 'react';
+import type { Locale, RoutineAppearance } from '../domain/models';
+import type { MessageKey } from '../services/i18n';
+import { AppIcon, routineIconName } from './Icon';
+import { RoutineIconPicker } from './RoutineIconPicker';
+
+export function RoutineAppearanceFields({
+  appearance,
+  locale,
+  onChange,
+  t,
+  namePlaceholder,
+}: {
+  appearance: RoutineAppearance;
+  locale: Locale;
+  onChange: (patch: Partial<RoutineAppearance>) => void;
+  t: (key: MessageKey) => string;
+  namePlaceholder?: string;
+}) {
+  const [iconPickerOpen, setIconPickerOpen] = useState(false);
+
+  return (
+    <div className="routine-appearance-fields" style={{ '--routine-accent': appearance.accentColor } as CSSProperties}>
+      <label className="native-input-field">
+        <span>{t('routineDraftName')}</span>
+        <input
+          value={appearance.name}
+          maxLength={120}
+          placeholder={namePlaceholder}
+          onChange={(event) => onChange({ name: event.target.value })}
+        />
+      </label>
+      <fieldset>
+        <legend>{t('routineIcon')}</legend>
+        <button type="button" className="routine-icon-picker-trigger" onClick={() => setIconPickerOpen(true)}>
+          <AppIcon name={routineIconName(appearance.icon)} />
+          <span>{t('routineIconChoose')}</span>
+          <AppIcon name="chevron-forward" />
+        </button>
+      </fieldset>
+      <label className="routine-appearance-color">
+        <span>{t('routineDraftAccentColor')}</span>
+        <input type="color" value={appearance.accentColor} onChange={(event) => onChange({ accentColor: event.target.value.toUpperCase() })} />
+      </label>
+      {iconPickerOpen ? (
+        <RoutineIconPicker
+          selected={routineIconName(appearance.icon)}
+          locale={locale}
+          close={() => setIconPickerOpen(false)}
+          select={(icon) => onChange({ icon })}
+          t={t}
+        />
+      ) : null}
+    </div>
+  );
+}

--- a/src/screens/RoutineDetailScreen.tsx
+++ b/src/screens/RoutineDetailScreen.tsx
@@ -5,7 +5,7 @@ import { presentRoutine } from '../domain/routinePresentation';
 import type { AppState, RoutineAppearance, RoutineAssignment, RoutineValidationMode, VerificationEvent } from '../domain/models';
 import type { MessageKey } from '../services/i18n';
 import { AppIcon, routineIconName } from '../components/Icon';
-import { RoutineIconPicker } from '../components/RoutineIconPicker';
+import { RoutineAppearanceFields } from '../components/RoutineAppearanceFields';
 import { StatusPill } from '../components/StatusPill';
 import { RoutineEditScreen } from './RoutineEditScreen';
 import { SvgIcon } from '../components/SvgIcon';
@@ -188,7 +188,6 @@ export function RoutineDetailScreen({ assignment, state, back, start, getProofIm
   }));
   const [appearanceStatus, setAppearanceStatus] = useState<'saving' | 'saved' | 'error'>();
   const [appearanceEditing, setAppearanceEditing] = useState(false);
-  const [iconPickerOpen, setIconPickerOpen] = useState(false);
   const todayHeatmapRef = useRef<HTMLSpanElement | null>(null);
   const now = Date.now();
   const rawEvents = state.events.filter((event) => event.routineId === assignment.routineId);
@@ -340,16 +339,18 @@ export function RoutineDetailScreen({ assignment, state, back, start, getProofIm
         <button type="button" className="more-button" aria-label={t('moreOptions')}><SvgIcon icon={ellipsisHorizontal} /></button>
       </div>
       {appearanceEditing && edit && onSaveAppearance ? <section className="card routine-appearance-editor routine-appearance-top-editor">
-        <label className="native-input-field"><span>{t('routineDraftName')}</span><input value={appearance.name} maxLength={120} onChange={(event) => { setAppearance((current) => ({ ...current, name: event.target.value })); setAppearanceStatus(undefined); }} /></label>
-        <fieldset><legend>{t('routineIcon')}</legend><button type="button" className="routine-icon-picker-trigger" onClick={() => setIconPickerOpen(true)}><AppIcon name={routineIconName(appearance.icon)} /><span>{t('routineIconChoose')}</span><AppIcon name="chevron-forward" /></button></fieldset>
-        <label className="routine-appearance-color"><span>{t('routineDraftAccentColor')}</span><input type="color" value={appearance.accentColor} onChange={(event) => { setAppearance((current) => ({ ...current, accentColor: event.target.value.toUpperCase() })); setAppearanceStatus(undefined); }} /></label>
+        <RoutineAppearanceFields
+          appearance={appearance}
+          locale={state.locale}
+          onChange={(patch) => { setAppearance((current) => ({ ...current, ...patch })); setAppearanceStatus(undefined); }}
+          t={t}
+        />
         <div className="routine-appearance-actions">
           <ActionButton className="routine-appearance-cancel" fill="outline" onClick={() => setAppearanceEditing(false)}>{t('cancel')}</ActionButton>
           <ActionButton className="routine-appearance-save" disabled={!appearance.name.trim() || appearanceStatus === 'saving'} aria-busy={appearanceStatus === 'saving'} onClick={() => { void saveAppearance(); }}>{t(appearanceStatus === 'saving' ? 'saving' : 'save')}</ActionButton>
         </div>
         {appearanceStatus === 'saved' ? <p role="status">{t('routineAppearanceSaved')}</p> : appearanceStatus === 'error' ? <p role="alert" className="form-error">{t('routineAppearanceError')}</p> : null}
       </section> : null}
-      {iconPickerOpen ? <RoutineIconPicker selected={routineIconName(appearance.icon)} locale={state.locale} close={() => setIconPickerOpen(false)} select={(icon) => { setAppearance((current) => ({ ...current, icon })); setAppearanceStatus(undefined); }} t={t} /> : null}
       <nav className="routine-tabs" aria-label={t('routineSections')}>
         {tabs.map((item) => <button type="button" className={tab === item ? 'active' : ''} aria-current={tab === item ? 'page' : undefined} onClick={() => setTab(item)} key={item}>{t(item === 'details' ? 'infoTab' : item === 'plan' ? 'monitoringPlan' : 'trackingTab')}</button>)}
       </nav>

--- a/src/screens/RoutineDraftEditorScreen.test.tsx
+++ b/src/screens/RoutineDraftEditorScreen.test.tsx
@@ -1,6 +1,7 @@
 import { act } from 'react';
 import { createRoot, type Root } from 'react-dom/client';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { routineIconCatalog } from '../components/routineIconCatalog';
 import type { RoutineDraft } from '../domain/routineDraft';
 import { translate } from '../services/i18n';
 import { RoutineDraftEditorScreen } from './RoutineDraftEditorScreen';
@@ -42,7 +43,7 @@ describe('private routine draft editor', () => {
     expect(container.textContent).toContain('Brouillon enregistré · révision 1 · prêt');
   });
 
-  it('reveals only useful customization and derives the icon from the category', async () => {
+  it('reveals the shared appearance editor, suggests an icon from the category, and allows overriding it', async () => {
     const save = vi.fn().mockImplementation(async (routinePackage) => ({ ...savedDraft(routinePackage.routine.name), package: routinePackage, validation: { status: 'valid', issues: [] } }));
     act(() => root.render(<RoutineDraftEditorScreen locale="en" online save={save} cancel={() => undefined} reload={() => undefined} t={(key) => translate('en', key)} />));
     const customize = Array.from(container.querySelectorAll('button')).find((button) => button.textContent?.includes('Customize'));
@@ -56,8 +57,12 @@ describe('private routine draft editor', () => {
     expect(container.textContent).not.toContain('Expected proof');
     const category = container.querySelector<HTMLSelectElement>('select');
     act(() => { if (category) { category.value = 'medication'; category.dispatchEvent(new Event('change', { bubbles: true })); } });
+    act(() => container.querySelector<HTMLButtonElement>('.routine-icon-picker-trigger')?.click());
+    expect(document.body.querySelectorAll('.routine-icon-catalog button')).toHaveLength(routineIconCatalog.length);
+    const star = document.body.querySelector<HTMLButtonElement>('.routine-icon-catalog button[aria-label="Star"]');
+    act(() => star?.click());
     await act(async () => { container.querySelector<HTMLFormElement>('form')?.requestSubmit(); await Promise.resolve(); });
-    expect(save.mock.calls[0][0].routine).toMatchObject({ category: 'medication', icon: 'medical' });
+    expect(save.mock.calls[0][0].routine).toMatchObject({ category: 'medication', icon: 'star' });
   });
 
   it('asks only for the intent and response mode, then previews the participant interaction', async () => {

--- a/src/screens/RoutineDraftEditorScreen.tsx
+++ b/src/screens/RoutineDraftEditorScreen.tsx
@@ -1,7 +1,8 @@
-import { useState, type CSSProperties, type FormEvent } from 'react';
+import { useState, type FormEvent } from 'react';
 import type { Locale, Routine, RoutineCategory, RoutineResponseDefinition } from '../domain/models';
 import { createBlankRoutinePackage, DEFAULT_PRIVATE_ROUTINE_ACCENT, prepareMinimalRoutinePackage, routinePackageInLocale, type RoutineDraft, type RoutinePackageV1 } from '../domain/routineDraft';
-import { AppIcon, routineIconName } from '../components/Icon';
+import { AppIcon } from '../components/Icon';
+import { RoutineAppearanceFields } from '../components/RoutineAppearanceFields';
 import { formatMessage, type MessageKey } from '../services/i18n';
 import type { AiRoutineProposal, AiRoutineResponseKind } from '../services/contracts';
 
@@ -173,15 +174,15 @@ export function RoutineDraftEditorScreen({
   const accentColor = /^#[0-9a-f]{6}$/i.test(routine.accentColor ?? '') ? routine.accentColor! : DEFAULT_PRIVATE_ROUTINE_ACCENT;
   const responseKind = routine.response?.kind ?? 'photo';
   const participantPreviewName = routine.name.trim() || routine.instructions?.split(/[.!?\n]/)[0]?.trim() || t('routineDraftEditorTitle');
-  const identityFields = <div className="routine-draft-customization routine-draft-customization-direct" style={{ '--routine-accent': accentColor } as CSSProperties}>
-    <div className="routine-draft-name-row">
-      <span className="settings-row-icon routine-icon" aria-hidden="true"><AppIcon name={routineIconName(routine.icon)} /></span>
-      <label className="routine-draft-field"><span>{t('routineDraftName')}</span><input value={routine.name} maxLength={120} placeholder={t('routineDraftNamePlaceholder')} onChange={(event) => updateRoutine({ name: event.target.value })} /></label>
-    </div>
-    <div className="routine-draft-appearance-fields">
-      <label className="routine-draft-field"><span>{t('routineDraftCategory')}</span><select value={routine.category ?? 'custom'} onChange={(event) => updateCategory(event.target.value as RoutineCategory)}>{routineCategories.map((category) => <option value={category} key={category}>{t(categoryLabels[category])}</option>)}</select></label>
-      <label className="routine-draft-field routine-draft-color-field"><span>{t('routineDraftAccentColor')}</span><input type="color" value={accentColor} onChange={(event) => updateRoutine({ accentColor: event.target.value.toUpperCase() })} /></label>
-    </div>
+  const identityFields = <div className="routine-draft-customization routine-draft-customization-direct">
+    <label className="routine-draft-field"><span>{t('routineDraftCategory')}</span><select value={routine.category ?? 'custom'} onChange={(event) => updateCategory(event.target.value as RoutineCategory)}>{routineCategories.map((category) => <option value={category} key={category}>{t(categoryLabels[category])}</option>)}</select></label>
+    <RoutineAppearanceFields
+      appearance={{ name: routine.name, icon: routine.icon ?? categoryIcons[routine.category ?? 'custom'], accentColor }}
+      locale={locale}
+      onChange={updateRoutine}
+      namePlaceholder={t('routineDraftNamePlaceholder')}
+      t={t}
+    />
   </div>;
   return (
     <div className="content-screen routine-draft-editor-screen">

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -180,12 +180,12 @@ button:disabled { cursor: not-allowed; }
 .app-splash-card strong { font-size: 24px; font-weight: 900; color: var(--color-text); }
 .app-splash-version { margin-top: -10px; color: var(--color-text-muted); font-size: 11px; font-weight: 800; }
 .app-splash-card span { color: var(--color-text-muted); font-size: 13px; font-weight: 700; }
-.routine-appearance-editor { display: grid; gap: 14px; }
+.routine-appearance-editor, .routine-appearance-fields { display: grid; gap: 14px; }
 .routine-appearance-editor h2 { margin: 0; }
 .routine-appearance-trigger { width: 100%; border: 0; color: inherit; font: inherit; text-align: left; cursor: pointer; }
 .routine-appearance-top-editor { margin: 0; }
-.routine-appearance-editor fieldset { margin: 0; padding: 0; border: 0; }
-.routine-appearance-editor legend, .routine-appearance-color > span { margin-bottom: 7px; color: var(--color-text-muted); font-size: 12px; font-weight: 850; }
+.routine-appearance-fields fieldset { margin: 0; padding: 0; border: 0; }
+.routine-appearance-fields legend, .routine-appearance-color > span { margin-bottom: 7px; color: var(--color-text-muted); font-size: 12px; font-weight: 850; }
 .routine-appearance-color { display: grid; }
 .routine-appearance-color input { width: 100%; height: 46px; padding: 4px; border: 1px solid var(--color-border); border-radius: 13px; background: var(--color-surface-solid); }
 .routine-appearance-actions { --color-primary: var(--color-brand-primary); display: grid; grid-template-columns: .9fr 1.1fr; gap: 10px; }
@@ -1491,13 +1491,12 @@ button:disabled { cursor: not-allowed; }
 .routine-draft-customize .app-icon.expanded { transform: rotate(180deg); }
 .routine-draft-customization { display: grid; gap: 12px; padding-top: 12px; border-top: 1px solid var(--color-border); }
 .routine-draft-customization-direct { padding-top: 0; border-top: 0; }
-.routine-draft-name-row { display: grid; grid-template-columns: 36px minmax(0, 1fr); align-items: end; gap: 10px; }
-.routine-draft-name-row .routine-icon { color: var(--routine-accent, var(--color-primary)); }
-.routine-draft-appearance-fields { display: grid; grid-template-columns: minmax(0, 1fr) auto; align-items: end; gap: 10px; }
 .routine-draft-field { display: grid; gap: 6px; color: var(--color-text); font-size: 12px; font-weight: 850; }
 .routine-draft-field input:not([type='color']), .routine-draft-field select, .routine-draft-field textarea { width: 100%; min-height: var(--height-action); padding: 10px 12px; border: 1px solid var(--color-border); border-radius: 12px; background: var(--color-surface-solid); color: var(--color-text); font: inherit; font-weight: 650; }
+.routine-draft-customization > .routine-draft-field { gap: 7px; color: var(--color-text-muted); }
+.routine-draft-customization > .routine-draft-field select { min-height: 50px; padding: 12px 14px; border-color: rgba(16,42,67,.14); border-radius: 16px; background: rgba(255,255,255,.72); color: var(--color-text); font-size: 16px; font-weight: 800; }
+.routine-draft-customization > .routine-draft-field select:focus { border-color: var(--color-primary); box-shadow: 0 0 0 3px rgba(8,127,109,.12); outline: 0; }
 .routine-draft-field textarea { min-height: 128px; line-height: 1.5; resize: vertical; }
-.routine-draft-color-field input[type='color'] { width: var(--height-action); height: var(--height-action); padding: 4px; border: 1px solid var(--color-border); border-radius: 12px; background: var(--color-surface-solid); }
 .routine-draft-save-state { display: grid; gap: 8px; margin: 0; padding: 12px; border-radius: 12px; background: var(--color-control-surface); color: var(--color-text-muted); font-size: 12px; }
 .routine-draft-save-state p { margin: 0; }
 .routine-draft-save-state button { justify-self: start; min-height: var(--height-action); padding: 8px 12px; border: 0; border-radius: 10px; background: var(--color-text); color: var(--color-surface-solid); font-weight: 850; }


### PR DESCRIPTION
## Summary
- share one routine appearance editor between creation and routine details
- expose the full icon catalog during routine creation while preserving category-based icon suggestions
- harmonize category, name, icon, and color controls with the existing premium UI
- remove duplicated picker state and obsolete styles
- bump the application version to 0.10.15

## Impact
Routine creation now offers the same name, color, and icon customization as routine details, with a consistent interface and one implementation to maintain.

## Validation
- `npm run check`
- 313 client tests
- 21 functions tests
- production build, bundle, design, and architecture checks