### PR TITLE
Claim single-use rewards atomically

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -68,6 +68,18 @@ service cloud.firestore {
         allow create, update, delete: if false;
       }
 
+      match /rewardPolicies/{policyId} {
+        allow read, write: if false;
+
+        match /rewardCodes/{codeId} {
+          allow read, write: if false;
+        }
+      }
+
+      match /rewardClaims/{checkId} {
+        allow read, write: if false;
+      }
+
       // Quiz corrections are server-only until the callable grades a submission.
       match /quizAnswerKeys/{checkId} {
         allow read, write: if false;
@@ -102,6 +114,18 @@ service cloud.firestore {
       match /routineAssignments/{assignmentId} {
         allow read: if canViewParticipant(participantId);
         allow write: if false;
+      }
+
+      match /rewardPolicies/{policyId} {
+        allow read, write: if false;
+
+        match /rewardCodes/{codeId} {
+          allow read, write: if false;
+        }
+      }
+
+      match /rewardClaims/{checkId} {
+        allow read, write: if false;
       }
 
       match /quizAnswerKeys/{checkId} {

--- a/functions/package.json
+++ b/functions/package.json
@@ -8,7 +8,8 @@
   },
   "scripts": {
     "build": "tsc",
-    "test": "npm run build && node --test lib/*.test.js"
+    "test": "npm run build && node --test lib/*.test.js",
+    "test:reward-integration": "npm run build && node --test lib/rewards.integration.js"
   },
   "dependencies": {
     "firebase-admin": "^14.2.0",

--- a/functions/src/cleanup.test.ts
+++ b/functions/src/cleanup.test.ts
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
-import { expiredPendingCheckCleanupUpdate, shouldDeleteProofAfterReview, staleCleanupCutoffs } from './cleanup.js';
+import { expiredPendingCheckCleanupUpdate, expiredRewardSecretCutoff, shouldDeleteProofAfterReview, staleCleanupCutoffs } from './cleanup.js';
 
 test('computes conservative stale cleanup cutoffs', () => {
   const cutoffs = staleCleanupCutoffs(new Date('2026-07-10T12:00:00.000Z'));
@@ -23,4 +23,9 @@ test('deletes proof images after every completed responsible review', () => {
   assert.equal(shouldDeleteProofAfterReview('detected'), true);
   assert.equal(shouldDeleteProofAfterReview('not_detected'), true);
   assert.equal(shouldDeleteProofAfterReview('uncertain'), false);
+});
+
+test('uses the current instant to remove expired reward secrets', () => {
+  const now = new Date('2026-07-24T08:00:00.000Z');
+  assert.equal(expiredRewardSecretCutoff(now), now.toISOString());
 });

--- a/functions/src/cleanup.ts
+++ b/functions/src/cleanup.ts
@@ -23,3 +23,5 @@ export const expiredPendingCheckCleanupUpdate = (now = new Date()) => ({
 
 export const shouldDeleteProofAfterReview = (decision: string) =>
   decision === 'detected' || decision === 'not_detected';
+
+export const expiredRewardSecretCutoff = (now = new Date()) => now.toISOString();

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -16,6 +16,7 @@ import { isCheckRequestRateLimited } from './reminders.js';
 import { recordAuditEvent, recordJourneyEvent, type JourneyStage } from './audit.js';
 import { expiredPendingCheckCleanupUpdate, shouldDeleteProofAfterReview, staleCleanupCutoffs } from './cleanup.js';
 import { reportOperationalAlert, reportOperationalEvent, reportOperationalRecovery } from './observability.js';
+import { claimRewardForSuccessfulTransition, cleanupExpiredRewardSecrets, deleteRoutineRewardSecrets } from './rewards.js';
 import { shouldRecoverSyntheticPush } from './syntheticMonitor.js';
 import { canLeaveMembership, canRemoveMembership, canRenameParticipant, createMembership, hasParticipantPermission, isCompatibleLegacyContentTarget, isCompatibleMembershipMigration, isCompatibleParticipantMigration, isCompatibleParticipantRefMigration, isProfileColorKey, membershipRoles, migrateLegacyFamilyRelationships, participantRenameUpdates, pushRolesForMembership, scheduledAggregatePaths, type MembershipPushRole, type MembershipRole } from './relationships.js';
 import { assertRoutineDraftRevision, createAssignmentForkPackage, createRoutineDraftDocument, routineDraftSessionId, RoutineDraftConflictError, RoutineDraftInputError, selectReusableAssignmentDraft, updateRoutineDraftDocument, type IdentifiedRoutineDraft, type PublishedRoutineVersionDocument, type RoutineDraftDocument } from './routineDrafts.js';
@@ -302,6 +303,23 @@ type ReviewedCheckPayload = Record<string, unknown> & {
   id: string;
   proofImagePath?: unknown;
   proofImageExpiresAt?: unknown;
+};
+
+const reportRewardOutcome = (
+  check: Record<string, unknown>,
+  familyId: string,
+  checkId: string,
+  routineId: string,
+) => {
+  const status = (check.reward as { status?: unknown } | undefined)?.status;
+  if (typeof status !== 'string') return;
+  reportOperationalEvent({
+    kind: 'reward_claim_outcome',
+    familyId,
+    checkId,
+    routineId,
+    details: { status },
+  });
 };
 
 const requireAggregatePermission = async (
@@ -2825,6 +2843,7 @@ export const deleteRoutine = onCall({
   });
 
   const deletedAfterTransaction = await deleteQueryDocumentsInBatches(routineChecksQuery);
+  await deleteRoutineRewardSecrets(db, familyRef.path, routineId);
   await recordAuditEvent(db, {
     action: 'delete_routine',
     actorUid: uid,
@@ -3262,10 +3281,14 @@ export const submitRoutineResponse = onCall({ region, cors, enforceAppCheck: tru
     responseKind = submission.kind;
     itemCount = submission.kind === 'checklist' ? submission.items.length : 1;
     routineId = typeof checkData.routineId === 'string' && checkData.routineId ? checkData.routineId : DEFAULT_ROUTINE_ID;
-    const update = { status: 'answered', submittedAt, submission };
+    const reward = await claimRewardForSuccessfulTransition({
+      transaction, aggregateRef, checkRef, checkData, nextStatus: 'answered',
+    });
+    const update = { status: 'answered', submittedAt, submission, ...(reward ? { reward } : {}) };
     transaction.update(checkRef, update);
     return { id: check.id, ...checkData, ...update };
   });
+  reportRewardOutcome(response, familyId, checkId, routineId);
   await recordAuditEvent(db, {
     action: 'submit_proof',
     actorUid: uid,
@@ -3306,11 +3329,15 @@ export const submitQuizResponse = onCall({ region, cors, enforceAppCheck: true }
       model: String(secretData.model),
       promptVersion: String(secretData.promptVersion),
     };
-    const update = { status: 'answered', submittedAt, submission: graded.submission, quizResult };
+    const reward = await claimRewardForSuccessfulTransition({
+      transaction, aggregateRef, checkRef, checkData, nextStatus: 'answered',
+    });
+    const update = { status: 'answered', submittedAt, submission: graded.submission, quizResult, ...(reward ? { reward } : {}) };
     transaction.update(checkRef, update);
     transaction.delete(answerKeyRef);
     return { id: check.id, ...checkData, ...update };
   });
+  reportRewardOutcome(response, familyId, checkId, routineId);
   await recordAuditEvent(db, { action: 'submit_proof', actorUid: uid, familyId, role: 'child', metadata: { checkId, routineId, responseKind: 'quiz', questionCount } });
   return response;
 });
@@ -3403,9 +3430,14 @@ export const analyzeCheck = onCall({
       if (!check.exists || !isCurrentAnalysisAttempt(checkData, capturedAt)) {
         throw new HttpsError('failed-precondition', 'This check is no longer awaiting this analysis.');
       }
-      transaction.update(checkRef, autoUpdate);
-      return { id: check.id, ...checkData, ...autoUpdate };
+      const reward = await claimRewardForSuccessfulTransition({
+        transaction, aggregateRef, checkRef, checkData: checkData ?? {}, nextStatus: autoUpdate.status,
+      });
+      const update = { ...autoUpdate, ...(reward ? { reward } : {}) };
+      transaction.update(checkRef, update);
+      return { id: check.id, ...checkData, ...update };
     });
+    reportRewardOutcome(response, familyId, checkId, routineId);
     await recordAuditEvent(db, {
       action: 'submit_proof',
       actorUid: uid,
@@ -3522,9 +3554,14 @@ export const analyzeCheck = onCall({
     if (!check.exists || !isCurrentAnalysisAttempt(checkData, capturedAt)) {
       throw new HttpsError('failed-precondition', 'This check is no longer awaiting this analysis.');
     }
-    transaction.update(checkRef, analysisUpdate);
-    return { id: check.id, ...checkData, ...analysisUpdate };
+    const reward = await claimRewardForSuccessfulTransition({
+      transaction, aggregateRef, checkRef, checkData: checkData ?? {}, nextStatus: analysisUpdate.status,
+    });
+    const update = { ...analysisUpdate, ...(reward ? { reward } : {}) };
+    transaction.update(checkRef, update);
+    return { id: check.id, ...checkData, ...update };
   });
+  reportRewardOutcome(response, familyId, checkId, routineId);
   let reviewDispatch: PushDispatchSummary | undefined;
   if (analysisUpdate.reviewStatus === 'pending') {
     try {
@@ -3711,9 +3748,19 @@ export const reviewCheck = onCall({ region, cors, enforceAppCheck: true }, async
         ].slice(-20),
       };
     }
+    const reward = await claimRewardForSuccessfulTransition({
+      transaction,
+      aggregateRef,
+      checkRef,
+      checkData,
+      nextStatus: String(update.status ?? checkData.status ?? ''),
+      now: new Date(reviewedAt),
+    });
+    if (reward) update.reward = reward;
     transaction.update(checkRef, update);
     return { id: check.id, ...checkData, ...update };
   });
+  reportRewardOutcome(reviewedCheck, familyId, checkId, String(reviewedCheck.routineId ?? DEFAULT_ROUTINE_ID));
   const proofImagePath = reviewedCheck.proofImagePath;
   const finalDecision = reviewedCheck.reviewStatus === 'approved'
     ? 'detected'
@@ -3871,13 +3918,13 @@ export const cleanupStaleOperationalData = onSchedule({
     const aggregateRef = document.ref.parent.parent;
     if (aggregateRef) operations.push((batch) => batch.delete(aggregateRef.collection('quizAnswerKeys').doc(document.id)));
   });
-  if (!operations.length) return;
   const batchSize = 400;
   for (let offset = 0; offset < operations.length; offset += batchSize) {
     const batch = db.batch();
     operations.slice(offset, offset + batchSize).forEach((operation) => operation(batch));
     await batch.commit();
   }
+  await cleanupExpiredRewardSecrets(db, now);
 });
 
 export const deleteAccountData = onCall({ region, cors, enforceAppCheck: true }, async (request) => {

--- a/functions/src/observability.test.ts
+++ b/functions/src/observability.test.ts
@@ -104,3 +104,15 @@ test('truncates operational event errors used for successful fallbacks', () => {
 
   assert.equal(payload.error, 'x'.repeat(240));
 });
+
+test('records reward outcomes without accepting secret detail structures', () => {
+  const payload = operationalEventPayload({
+    kind: 'reward_claim_outcome',
+    familyId: 'participant-1',
+    checkId: 'check-1',
+    routineId: 'routine-1',
+    details: { status: 'claimed', ignoredReward: { value: 'SECRET' } as never },
+  });
+  assert.deepEqual(payload.details, { status: 'claimed' });
+  assert.equal(JSON.stringify(payload).includes('SECRET'), false);
+});

--- a/functions/src/observability.ts
+++ b/functions/src/observability.ts
@@ -14,6 +14,7 @@ type OperationalEventKind =
   | 'push_dispatch_summary'
   | 'scheduler_run_summary'
   | 'analysis_completed'
+  | 'reward_claim_outcome'
   | 'proof_image_fallback'
   | 'synthetic_push_receipt';
 

--- a/functions/src/rewards.integration.ts
+++ b/functions/src/rewards.integration.ts
@@ -1,0 +1,95 @@
+import { strict as assert } from 'node:assert';
+import { after, before, beforeEach, test } from 'node:test';
+import { initializeApp } from 'firebase-admin/app';
+import { getFirestore } from 'firebase-admin/firestore';
+import { cleanupExpiredRewardSecrets, deleteRoutineRewardSecrets, finalizeCheckWithReward } from './rewards.js';
+
+const app = initializeApp({ projectId: 'demo-zadiag-rules' }, 'reward-integration');
+const db = getFirestore(app);
+db.settings({ host: process.env.FIRESTORE_EMULATOR_HOST, ssl: false });
+const aggregateRef = db.collection('participants').doc('reward-participant');
+
+before(async () => {
+  assert.ok(process.env.FIRESTORE_EMULATOR_HOST, 'Firestore emulator is required');
+});
+
+beforeEach(async () => {
+  await db.recursiveDelete(aggregateRef);
+  await aggregateRef.set({ displayName: 'Reward test' });
+});
+
+test('claims exactly one code when concurrent success transitions retry', async () => {
+  const now = new Date('2026-07-24T08:00:00.000Z');
+  const checkRef = aggregateRef.collection('checks').doc('check-1');
+  const policyRef = aggregateRef.collection('rewardPolicies').doc('routine-1');
+  await checkRef.set({ routineId: 'routine-1', status: 'pending' });
+  await policyRef.set({ status: 'active', claimLifetimeHours: 24 });
+  await policyRef.collection('rewardCodes').doc('code-a').set({ status: 'available', value: 'SECRET-A' });
+  await policyRef.collection('rewardCodes').doc('code-b').set({ status: 'available', value: 'SECRET-B' });
+
+  const results = await Promise.all([
+    finalizeCheckWithReward(db, aggregateRef.path, checkRef.id, 'detected', now),
+    finalizeCheckWithReward(db, aggregateRef.path, checkRef.id, 'detected', now),
+  ]);
+  assert.equal(results.every((result) => result?.status === 'claimed'), true);
+  const [check, claim, codes] = await Promise.all([
+    checkRef.get(),
+    aggregateRef.collection('rewardClaims').doc(checkRef.id).get(),
+    policyRef.collection('rewardCodes').get(),
+  ]);
+  assert.equal(check.data()?.reward.status, 'claimed');
+  assert.equal(claim.data()?.value, 'SECRET-A');
+  assert.equal(codes.docs.filter((code) => code.data().status === 'claimed').length, 1);
+  assert.equal(codes.docs.find((code) => code.id === 'code-a')?.data().value, undefined);
+  await policyRef.update({ status: 'revoked' });
+  assert.equal((await finalizeCheckWithReward(db, aggregateRef.path, checkRef.id, 'detected', now))?.status, 'claimed');
+  assert.equal((await checkRef.get()).data()?.status, 'detected');
+});
+
+test('does not claim for non-success and freezes explicit exhaustion, expiry and revocation outcomes', async () => {
+  const now = new Date('2026-07-24T08:00:00.000Z');
+  const policyRef = aggregateRef.collection('rewardPolicies').doc('routine-1');
+  await policyRef.set({ status: 'active' });
+  for (const [checkId, status] of [['failed', 'not_detected'], ['pending', 'pending'], ['uncertain', 'uncertain'], ['expired-check', 'expired'], ['missed', 'missed']] as const) {
+    await aggregateRef.collection('checks').doc(checkId).set({ routineId: 'routine-1', status: 'pending' });
+    assert.equal(await finalizeCheckWithReward(db, aggregateRef.path, checkId, status, now), undefined);
+  }
+  await aggregateRef.collection('checks').doc('exhausted').set({ routineId: 'routine-1', status: 'pending' });
+  assert.equal((await finalizeCheckWithReward(db, aggregateRef.path, 'exhausted', 'detected', now))?.status, 'exhausted');
+  await policyRef.set({ status: 'active', expiresAt: '2026-07-24T07:59:59.000Z' });
+  await aggregateRef.collection('checks').doc('expired').set({ routineId: 'routine-1', status: 'pending' });
+  assert.equal((await finalizeCheckWithReward(db, aggregateRef.path, 'expired', 'detected', now))?.status, 'expired');
+  await policyRef.set({ status: 'revoked' });
+  await aggregateRef.collection('checks').doc('revoked').set({ routineId: 'routine-1', status: 'pending' });
+  assert.equal((await finalizeCheckWithReward(db, aggregateRef.path, 'revoked', 'detected', now))?.status, 'revoked');
+});
+
+test('deletes expired secrets without changing verification history or active claims', async () => {
+  const policyRef = aggregateRef.collection('rewardPolicies').doc('routine-1');
+  await aggregateRef.collection('checks').doc('check-1').set({ status: 'detected', reward: { status: 'claimed' } });
+  await aggregateRef.collection('rewardClaims').doc('expired').set({ value: 'OLD', expiresAt: '2026-07-24T07:00:00.000Z' });
+  await aggregateRef.collection('rewardClaims').doc('active').set({ value: 'CURRENT', expiresAt: '2026-07-24T09:00:00.000Z' });
+  await policyRef.collection('rewardCodes').doc('expired').set({ status: 'available', value: 'OLD-CODE', expiresAt: '2026-07-24T07:00:00.000Z' });
+
+  assert.equal(await cleanupExpiredRewardSecrets(db, new Date('2026-07-24T08:00:00.000Z')), 2);
+  assert.equal((await aggregateRef.collection('rewardClaims').doc('expired').get()).exists, false);
+  assert.equal((await policyRef.collection('rewardCodes').doc('expired').get()).exists, false);
+  assert.equal((await aggregateRef.collection('rewardClaims').doc('active').get()).exists, true);
+  assert.equal((await aggregateRef.collection('checks').doc('check-1').get()).data()?.status, 'detected');
+});
+
+test('deletes the policy, pool, and claims when its routine assignment is deleted', async () => {
+  const policyRef = aggregateRef.collection('rewardPolicies').doc('routine-1');
+  await policyRef.set({ status: 'active' });
+  await policyRef.collection('rewardCodes').doc('code-1').set({ status: 'available', value: 'SECRET' });
+  await aggregateRef.collection('rewardClaims').doc('check-1').set({ routineId: 'routine-1', value: 'CLAIM' });
+  await aggregateRef.collection('rewardClaims').doc('other-check').set({ routineId: 'routine-2', value: 'OTHER' });
+
+  assert.equal(await deleteRoutineRewardSecrets(db, aggregateRef.path, 'routine-1'), 1);
+  assert.equal((await policyRef.get()).exists, false);
+  assert.equal((await policyRef.collection('rewardCodes').doc('code-1').get()).exists, false);
+  assert.equal((await aggregateRef.collection('rewardClaims').doc('check-1').get()).exists, false);
+  assert.equal((await aggregateRef.collection('rewardClaims').doc('other-check').get()).exists, true);
+});
+
+after(async () => db.recursiveDelete(aggregateRef));

--- a/functions/src/rewards.test.ts
+++ b/functions/src/rewards.test.ts
@@ -1,0 +1,12 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { rewardPolicy } from './rewards.js';
+
+test('accepts only bounded active or revoked reward policies', () => {
+  assert.deepEqual(rewardPolicy({ status: 'active' }), { status: 'active', claimLifetimeHours: 24 });
+  assert.deepEqual(rewardPolicy({ status: 'revoked', claimLifetimeHours: 168 }), { status: 'revoked', claimLifetimeHours: 168 });
+  assert.equal(rewardPolicy({ status: 'active', claimLifetimeHours: 0 }), undefined);
+  assert.equal(rewardPolicy({ status: 'active', claimLifetimeHours: 169 }), undefined);
+  assert.equal(rewardPolicy({ status: 'active', expiresAt: 'not-a-date' }), undefined);
+  assert.equal(rewardPolicy({ status: 'paused' }), undefined);
+});

--- a/functions/src/rewards.ts
+++ b/functions/src/rewards.ts
@@ -1,0 +1,198 @@
+import { FieldPath, FieldValue, type DocumentData, type DocumentReference, type Firestore, type Transaction } from 'firebase-admin/firestore';
+import { expiredRewardSecretCutoff } from './cleanup.js';
+
+const finalSuccessStatuses = new Set(['answered', 'detected']);
+const maxRewardCodesPerPolicy = 100;
+const defaultClaimLifetimeHours = 24;
+
+export type RewardOutcomeStatus = 'claimed' | 'exhausted' | 'expired' | 'revoked';
+
+export interface RewardOutcome {
+  status: RewardOutcomeStatus;
+  resolvedAt: string;
+  claimId?: string;
+  expiresAt?: string;
+}
+
+const existingRewardOutcome = (input: unknown): RewardOutcome | undefined => {
+  if (!input || typeof input !== 'object' || Array.isArray(input)) return undefined;
+  const candidate = input as Record<string, unknown>;
+  if (!['claimed', 'exhausted', 'expired', 'revoked'].includes(String(candidate.status ?? ''))
+    || typeof candidate.resolvedAt !== 'string') return undefined;
+  return {
+    status: candidate.status as RewardOutcomeStatus,
+    resolvedAt: candidate.resolvedAt,
+    ...(typeof candidate.claimId === 'string' ? { claimId: candidate.claimId } : {}),
+    ...(typeof candidate.expiresAt === 'string' ? { expiresAt: candidate.expiresAt } : {}),
+  };
+};
+
+interface RewardPolicy {
+  status: 'active' | 'revoked';
+  expiresAt?: string;
+  claimLifetimeHours: number;
+}
+
+export const rewardPolicy = (input: unknown): RewardPolicy | undefined => {
+  if (!input || typeof input !== 'object' || Array.isArray(input)) return undefined;
+  const candidate = input as Record<string, unknown>;
+  if (!['active', 'revoked'].includes(String(candidate.status ?? ''))) return undefined;
+  const claimLifetimeHours = candidate.claimLifetimeHours === undefined
+    ? defaultClaimLifetimeHours
+    : Number(candidate.claimLifetimeHours);
+  if (!Number.isSafeInteger(claimLifetimeHours) || claimLifetimeHours < 1 || claimLifetimeHours > 168) return undefined;
+  if (candidate.expiresAt !== undefined
+    && (typeof candidate.expiresAt !== 'string' || !Number.isFinite(Date.parse(candidate.expiresAt)))) return undefined;
+  const expiresAt = candidate.expiresAt as string | undefined;
+  return {
+    status: candidate.status as RewardPolicy['status'],
+    claimLifetimeHours,
+    ...(expiresAt ? { expiresAt } : {}),
+  };
+};
+
+const availableRewardCode = (
+  documents: FirebaseFirestore.QueryDocumentSnapshot[],
+  now: Date,
+): { document: FirebaseFirestore.QueryDocumentSnapshot; value: string } | { hasExpiredCode: boolean } => {
+  let hasExpiredCode = false;
+  for (const document of documents) {
+    const data = document.data();
+    const value = typeof data.value === 'string' ? data.value.trim() : '';
+    const expiresAt = typeof data.expiresAt === 'string' && Number.isFinite(Date.parse(data.expiresAt))
+      ? data.expiresAt
+      : undefined;
+    if (expiresAt && Date.parse(expiresAt) <= now.getTime()) {
+      hasExpiredCode = true;
+      continue;
+    }
+    if (value && value.length <= 240) return { document, value };
+  }
+  return { hasExpiredCode };
+};
+
+export const claimRewardForSuccessfulTransition = async ({
+  transaction,
+  aggregateRef,
+  checkRef,
+  checkData,
+  nextStatus,
+  now = new Date(),
+}: {
+  transaction: Transaction;
+  aggregateRef: DocumentReference;
+  checkRef: DocumentReference;
+  checkData: DocumentData;
+  nextStatus: string;
+  now?: Date;
+}): Promise<RewardOutcome | undefined> => {
+  if (!finalSuccessStatuses.has(nextStatus) || !checkData.routineId) return undefined;
+  const existingOutcome = existingRewardOutcome(checkData.reward);
+  if (existingOutcome) return existingOutcome;
+  const routineId = String(checkData.routineId);
+  const policyRef = aggregateRef.collection('rewardPolicies').doc(routineId);
+  const claimRef = aggregateRef.collection('rewardClaims').doc(checkRef.id);
+  const [policySnapshot, existingClaim] = await Promise.all([
+    transaction.get(policyRef),
+    transaction.get(claimRef),
+  ]);
+  if (existingClaim.exists) {
+    const data = existingClaim.data() ?? {};
+    return {
+      status: 'claimed',
+      resolvedAt: String(data.claimedAt ?? now.toISOString()),
+      claimId: claimRef.id,
+      ...(typeof data.expiresAt === 'string' ? { expiresAt: data.expiresAt } : {}),
+    };
+  }
+  if (!policySnapshot.exists) return undefined;
+  const policy = rewardPolicy(policySnapshot.data());
+  const resolvedAt = now.toISOString();
+  if (!policy || policy.status === 'revoked') return { status: 'revoked', resolvedAt };
+  if (policy.expiresAt && Date.parse(policy.expiresAt) <= now.getTime()) return { status: 'expired', resolvedAt };
+
+  const availableCodes = await transaction.get(policyRef.collection('rewardCodes')
+    .where('status', '==', 'available')
+    .orderBy(FieldPath.documentId())
+    .limit(maxRewardCodesPerPolicy));
+  const selected = availableRewardCode(availableCodes.docs, now);
+  if ('hasExpiredCode' in selected) {
+    return { status: selected.hasExpiredCode ? 'expired' : 'exhausted', resolvedAt };
+  }
+
+  const expiresAt = new Date(now.getTime() + policy.claimLifetimeHours * 3_600_000).toISOString();
+  transaction.create(claimRef, {
+    checkId: checkRef.id,
+    routineId,
+    codeId: selected.document.id,
+    value: selected.value,
+    claimedAt: resolvedAt,
+    expiresAt,
+  });
+  transaction.update(selected.document.ref, {
+    status: 'claimed',
+    claimedByCheckId: checkRef.id,
+    claimedAt: resolvedAt,
+    value: FieldValue.delete(),
+  });
+  return { status: 'claimed', resolvedAt, claimId: claimRef.id, expiresAt };
+};
+
+export const finalizeCheckWithReward = async (
+  db: Firestore,
+  aggregatePath: string,
+  checkId: string,
+  nextStatus: string,
+  now = new Date(),
+) => db.runTransaction(async (transaction) => {
+  const aggregateRef = db.doc(aggregatePath);
+  const checkRef = aggregateRef.collection('checks').doc(checkId);
+  const check = await transaction.get(checkRef);
+  if (!check.exists) throw new Error('check_not_found');
+  const outcome = await claimRewardForSuccessfulTransition({
+    transaction,
+    aggregateRef,
+    checkRef,
+    checkData: check.data() ?? {},
+    nextStatus,
+    now,
+  });
+  transaction.update(checkRef, {
+    status: nextStatus,
+    ...(outcome ? { reward: outcome } : {}),
+  });
+  return outcome;
+});
+
+export const cleanupExpiredRewardSecrets = async (
+  db: Firestore,
+  now = new Date(),
+  limit = 200,
+) => {
+  const cutoff = expiredRewardSecretCutoff(now);
+  const [claims, codes] = await Promise.all([
+    db.collectionGroup('rewardClaims').where('expiresAt', '<', cutoff).limit(limit).get(),
+    db.collectionGroup('rewardCodes').where('expiresAt', '<', cutoff).limit(limit).get(),
+  ]);
+  const expired = [...claims.docs, ...codes.docs];
+  if (!expired.length) return 0;
+  const batch = db.batch();
+  expired.forEach((document) => batch.delete(document.ref));
+  await batch.commit();
+  return expired.length;
+};
+
+export const deleteRoutineRewardSecrets = async (
+  db: Firestore,
+  aggregatePath: string,
+  routineId: string,
+) => {
+  const aggregateRef = db.doc(aggregatePath);
+  const policyRef = aggregateRef.collection('rewardPolicies').doc(routineId);
+  const claims = await aggregateRef.collection('rewardClaims').where('routineId', '==', routineId).get();
+  await Promise.all([
+    db.recursiveDelete(policyRef),
+    ...claims.docs.map((claim) => claim.ref.delete()),
+  ]);
+  return claims.size;
+};

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zadiag-pwa",
   "private": true,
-  "version": "0.10.23",
+  "version": "0.10.24",
   "type": "module",
   "packageManager": "pnpm@11.7.0",
   "engines": {
@@ -21,7 +21,7 @@
     "icons": "node scripts/generate-icons.mjs",
     "preview": "vite preview --host 0.0.0.0",
     "test": "vitest run",
-    "test:rules": "firebase --project demo-zadiag-rules emulators:exec --only firestore,storage \"vitest run --config vitest.rules.config.ts\"",
+    "test:rules": "firebase --project demo-zadiag-rules emulators:exec --only firestore,storage \"vitest run --config vitest.rules.config.ts && npm --prefix functions run test:reward-integration\"",
     "test:watch": "vitest"
   },
   "dependencies": {

--- a/rules-tests/firestore.rules.test.ts
+++ b/rules-tests/firestore.rules.test.ts
@@ -56,6 +56,9 @@ beforeEach(async () => {
     await setDoc(doc(db, 'participants/participant-1/checks/check-1'), { status: 'pending' });
     await setDoc(doc(db, 'participants/participant-1/quizAnswerKeys/check-1'), { answerKey: [{ correctChoiceId: 'secret' }] });
     await setDoc(doc(db, 'participants/participant-1/quizQuestionReports/report-1'), { checkId: 'check-1' });
+    await setDoc(doc(db, 'participants/participant-1/rewardPolicies/routine-1'), { status: 'active' });
+    await setDoc(doc(db, 'participants/participant-1/rewardPolicies/routine-1/rewardCodes/code-1'), { status: 'available', value: 'PRIVATE-CODE' });
+    await setDoc(doc(db, 'participants/participant-1/rewardClaims/check-1'), { value: 'CLAIMED-CODE' });
     await setDoc(doc(db, 'participants/participant-1/routineAssignments/routine-1'), { status: 'active' });
     await setDoc(doc(db, 'participants/participant-1/routineDrafts/parent-draft'), { ownerId: 'parent', revision: 1 });
     await setDoc(doc(db, 'participants/participant-1/routineDrafts/coparent-draft'), { ownerId: 'coparent', revision: 1 });
@@ -81,6 +84,9 @@ beforeEach(async () => {
     await setDoc(doc(db, 'families/family-1/pushSubscriptions/child'), { endpoint: 'legacy-child-device' });
     await setDoc(doc(db, 'families/family-1/quizAnswerKeys/check-1'), { answerKey: [{ correctChoiceId: 'secret' }] });
     await setDoc(doc(db, 'families/family-1/quizQuestionReports/report-1'), { checkId: 'check-1' });
+    await setDoc(doc(db, 'families/family-1/rewardPolicies/orthodontic-elastics'), { status: 'active' });
+    await setDoc(doc(db, 'families/family-1/rewardPolicies/orthodontic-elastics/rewardCodes/code-1'), { status: 'available', value: 'PRIVATE-LEGACY-CODE' });
+    await setDoc(doc(db, 'families/family-1/rewardClaims/check-1'), { value: 'CLAIMED-LEGACY-CODE' });
   });
 });
 
@@ -163,6 +169,22 @@ describe('participant relationship isolation', () => {
     }
   });
 
+  test('keeps reward policies, unclaimed codes, and claims server-only', async () => {
+    for (const uid of ['parent', 'coparent']) {
+      const memberDb = environment.authenticatedContext(uid).firestore();
+      for (const path of [
+        'participants/participant-1/rewardPolicies/routine-1',
+        'participants/participant-1/rewardPolicies/routine-1/rewardCodes/code-1',
+        'participants/participant-1/rewardClaims/check-1',
+      ]) {
+        await assertFails(getDoc(doc(memberDb, path)));
+        await assertFails(setDoc(doc(memberDb, path), { value: 'TAMPERED' }));
+        await assertFails(deleteDoc(doc(memberDb, path)));
+      }
+      await assertFails(getDocs(collection(memberDb, 'participants/participant-1/rewardClaims')));
+    }
+  });
+
   test('keeps marketplace, registry, share codes, and reports behind callable functions', async () => {
     const parentDb = environment.authenticatedContext('parent').firestore();
     for (const path of [
@@ -216,6 +238,20 @@ describe('family isolation', () => {
     await assertFails(getDoc(doc(outsiderDb, 'families/family-1/routineAssignments/orthodontic-elastics')));
     await assertFails(getDocs(collection(outsiderDb, 'families/family-1/checks')));
     await assertFails(getDoc(doc(parentDb, 'linkCodes/private-hash')));
+  });
+
+  test('keeps legacy-family reward secrets server-only', async () => {
+    const parentDb = environment.authenticatedContext('parent').firestore();
+    const childDb = environment.authenticatedContext('child').firestore();
+    for (const uidDb of [parentDb, childDb]) {
+      for (const path of [
+        'families/family-1/rewardPolicies/orthodontic-elastics',
+        'families/family-1/rewardPolicies/orthodontic-elastics/rewardCodes/code-1',
+        'families/family-1/rewardClaims/check-1',
+      ]) {
+        await assertFails(getDoc(doc(uidDb, path)));
+      }
+    }
   });
 
   test('lets a suspended account see only its own suspension profile', async () => {

--- a/src/domain/models.ts
+++ b/src/domain/models.ts
@@ -25,6 +25,13 @@ export interface ResponsibleAction {
   actorName: string;
 }
 
+export interface RewardOutcome {
+  status: 'claimed' | 'exhausted' | 'expired' | 'revoked';
+  resolvedAt: string;
+  claimId?: string;
+  expiresAt?: string;
+}
+
 export interface TimeWindow {
   id: string;
   start: string;
@@ -251,6 +258,7 @@ export interface VerificationEvent extends RoutineTask {
   reviewedBy?: string;
   reviewReason?: string;
   responsibleActions?: ResponsibleAction[];
+  reward?: RewardOutcome;
 }
 
 const legacyPhotoResponse: RoutineResponseDefinition = { kind: 'photo' };

--- a/src/services/firebaseRepository.ts
+++ b/src/services/firebaseRepository.ts
@@ -145,6 +145,19 @@ const asResponsibleActions = (value: unknown): VerificationEvent['responsibleAct
   return actions.length ? actions : undefined;
 };
 
+const asRewardOutcome = (value: unknown): VerificationEvent['reward'] => {
+  if (!value || typeof value !== 'object') return undefined;
+  const candidate = value as Record<string, unknown>;
+  if (!['claimed', 'exhausted', 'expired', 'revoked'].includes(String(candidate.status))
+    || typeof candidate.resolvedAt !== 'string') return undefined;
+  return {
+    status: candidate.status as NonNullable<VerificationEvent['reward']>['status'],
+    resolvedAt: candidate.resolvedAt,
+    ...(typeof candidate.claimId === 'string' ? { claimId: candidate.claimId } : {}),
+    ...(typeof candidate.expiresAt === 'string' ? { expiresAt: candidate.expiresAt } : {}),
+  };
+};
+
 const asEvent = (id: string, data: DocumentData): VerificationEvent => ({
   id,
   routineId: String(data.routineId ?? DEFAULT_ROUTINE_ID),
@@ -176,6 +189,7 @@ const asEvent = (id: string, data: DocumentData): VerificationEvent => ({
   reviewedBy: data.reviewedBy ? String(data.reviewedBy) : undefined,
   reviewReason: data.reviewReason && data.reviewReason !== 'responsible_review' ? String(data.reviewReason) : undefined,
   responsibleActions: asResponsibleActions(data.responsibleActions),
+  reward: asRewardOutcome(data.reward),
 });
 
 const asRoutineAssignment = (id: string, data: DocumentData): RoutineAssignment => {


### PR DESCRIPTION
## Outcome

- Store reward policies, code pools, and claimed secrets in server-only Firestore collections.
- Atomically and idempotently claim exactly one code when a check first reaches a successful terminal state.
- Preserve only non-sensitive reward metadata in ordinary check history and operational events.
- Report explicit revoked, expired, and exhausted outcomes without exposing plaintext codes.
- Delete expired reward secrets and remove the policy, pool, and claims when a routine is deleted.
- Bump the application version once to `0.10.24`.

## Security and behavior

Firestore rules deny all client reads and writes for reward policies, pools, and claims in both participant and legacy-family aggregates. Transaction-level emulator tests cover concurrency/retries, non-success outcomes, revocation, exhaustion, expiry, and cleanup. Malformed policies fail closed.

## Validation

- `corepack pnpm check:full`
  - 323 client tests passed
  - 129 Functions tests passed
  - 23 Firestore/Storage rules tests passed
  - 4 Firestore reward integration tests passed
  - architecture, design, build, and bundle checks passed
- `git diff --check`

Closes #251
Part of #246
Part of #253