### PR TITLE
Remediate vulnerable transitive dependencies

### DIFF
--- a/functions/package-lock.json
+++ b/functions/package-lock.json
@@ -3019,9 +3019,9 @@
       }
     },
     "node_modules/protobufjs": {
-      "version": "7.6.4",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.4.tgz",
-      "integrity": "sha512-RJJPTTpvFfHcWLkIa2JFWK4XvtSzS0yEWDmunqHXli1h3JlkbcQZXDZdcWxv+JK3Xsl5/UFDPZ0iGm7DAengYw==",
+      "version": "7.6.5",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.5.tgz",
+      "integrity": "sha512-/FPD0nUc9jH6rfFjji9IBqOz4pcSE3CsT1m7Ep6Mdb0LxSUMj8hgl6GomOvZzpNpAqqGaXA0P3VSrZLFzIhQrw==",
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
       "dependencies": {

--- a/functions/package.json
+++ b/functions/package.json
@@ -22,6 +22,7 @@
     "typescript": "^7.0.2"
   },
   "overrides": {
+    "protobufjs": "7.6.5",
     "uuid": "11.1.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zadiag-pwa",
   "private": true,
-  "version": "0.11.1",
+  "version": "0.11.2",
   "type": "module",
   "packageManager": "pnpm@11.7.0",
   "engines": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,7 +5,9 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
+  '@hono/node-server': 2.0.11
   '@opentelemetry/core@<2.8.0': 2.8.0
+  fast-uri: 3.1.4
   uuid@<11.1.1: 11.1.1
 
 importers:
@@ -940,9 +942,9 @@ packages:
     engines: {node: '>=6'}
     hasBin: true
 
-  '@hono/node-server@1.19.14':
-    resolution: {integrity: sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==}
-    engines: {node: '>=18.14.1'}
+  '@hono/node-server@2.0.11':
+    resolution: {integrity: sha512-bjD221KPLoJTWUwso1J6fGKiTXEUFedG/s0visavY4zakFPkeGURMRNly+FhBHs7T8Dz4qHaZIMX9ZoJHSJtKA==}
+    engines: {node: '>=20'}
     peerDependencies:
       hono: ^4
 
@@ -2601,8 +2603,8 @@ packages:
   fast-json-stable-stringify@2.1.0:
     resolution: {integrity: sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==}
 
-  fast-uri@3.1.3:
-    resolution: {integrity: sha512-i70LwGWUduXqzicKXWshooq+sWL1K3WUU5rKZNG/0i3a1OSoX3HqhH5WbWwTmqWfor4urUakGPiRQcleRZTwOg==}
+  fast-uri@3.1.4:
+    resolution: {integrity: sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==}
 
   faye-websocket@0.11.4:
     resolution: {integrity: sha512-CzbClwlXAuiRQAlUyfqPgvPoNKTckTPGfwZV4ZdAhVcP2lh9KUxJg2b5GkE7XbjKQ3YJnQ9z6D9ntLAlB+tP8g==}
@@ -6029,7 +6031,7 @@ snapshots:
       protobufjs: 7.6.5
       yargs: 17.7.3
 
-  '@hono/node-server@1.19.14(hono@4.12.31)':
+  '@hono/node-server@2.0.11(hono@4.12.31)':
     dependencies:
       hono: 4.12.31
 
@@ -6309,7 +6311,7 @@ snapshots:
 
   '@modelcontextprotocol/sdk@1.29.0(zod@4.4.3)':
     dependencies:
-      '@hono/node-server': 1.19.14(hono@4.12.31)
+      '@hono/node-server': 2.0.11(hono@4.12.31)
       ajv: 8.20.0
       ajv-formats: 3.0.1(ajv@8.20.0)
       content-type: 1.0.5
@@ -6716,7 +6718,7 @@ snapshots:
   ajv@8.20.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.3
+      fast-uri: 3.1.4
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -7612,7 +7614,7 @@ snapshots:
 
   fast-json-stable-stringify@2.1.0: {}
 
-  fast-uri@3.1.3: {}
+  fast-uri@3.1.4: {}
 
   faye-websocket@0.11.4:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,7 +2,9 @@ packages:
   - .
 
 overrides:
+  '@hono/node-server': 2.0.11
   '@opentelemetry/core@<2.8.0': 2.8.0
+  'fast-uri': 3.1.4
   'uuid@<11.1.1': 11.1.1
 
 allowBuilds:


### PR DESCRIPTION
## Outcome

Remediates all three open Dependabot alerts currently reported on `main`:

- pins `fast-uri` to 3.1.4 for the web development toolchain;
- pins `@hono/node-server` to 2.0.11 behind Firebase CLI's MCP dependency;
- pins `protobufjs` to 7.6.5 in the Functions runtime tree;
- bumps the application version once to 0.11.2.

## Root cause

The affected packages are transitive dependencies. The current upstream `@modelcontextprotocol/sdk` still constrains `@hono/node-server` to the vulnerable 1.x line, so the corrected Hono release requires a centralized pnpm override until upstream adopts 2.x.

## Validation

- `corepack pnpm why fast-uri` → 3.1.4 only
- `corepack pnpm why @hono/node-server` → 2.0.11 only
- `npm --prefix functions ls protobufjs` → 7.6.5 only
- `corepack pnpm exec firebase --version` → 15.24.0
- `corepack pnpm check` → 326 web tests and 131 Functions tests passed; build, bundle, architecture, and design checks passed
- `corepack pnpm check:security` → zero known web vulnerabilities and zero Functions vulnerabilities
- `git diff --check`