### PR TITLE
Polish collective dashboard flow

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zadiag-pwa",
   "private": true,
-  "version": "0.11.6",
+  "version": "0.11.7",
   "type": "module",
   "packageManager": "pnpm@11.7.0",
   "engines": {

--- a/src/components/MultiParticipantOverview.tsx
+++ b/src/components/MultiParticipantOverview.tsx
@@ -1,12 +1,12 @@
 import { useMemo } from 'react';
 import type { Locale, ParticipantNotificationSource, RoutineAssignment, VerificationEvent } from '../domain/models';
+import { profileColorFor } from '../domain/profileColor';
 import type { MessageKey } from '../services/i18n';
-import { AdherenceSummaryCard, type SummaryRange } from './AdherenceSummaryCard';
+import { AdherenceSummaryCard, filterEventsBySummaryRange, type SummaryRange } from './AdherenceSummaryCard';
 import { RoutineHistoryPanel } from './RoutineHistoryPanel';
 
-type CollectiveEventContext = {
-  participant: { id: string; displayName: string };
-};
+type CollectiveParticipant = { id: string; displayName: string; profileColor: string };
+type CollectiveEventContext = { participant: CollectiveParticipant };
 
 const collectiveDashboardData = (sources: ParticipantNotificationSource[]) => {
   const assignments: RoutineAssignment[] = [];
@@ -31,6 +31,7 @@ const collectiveDashboardData = (sources: ParticipantNotificationSource[]) => {
         participant: {
           id: source.participant.id,
           displayName: source.participant.displayName,
+          profileColor: profileColorFor(source.participant),
         },
       });
     });
@@ -57,7 +58,9 @@ export function MultiParticipantOverview({
   const participants = sources.map((source) => ({
     id: source.participant.id,
     displayName: source.participant.displayName,
+    profileColor: profileColorFor(source.participant),
   }));
+  const rangedEvents = useMemo(() => filterEventsBySummaryRange(events, range), [events, range]);
   const participantForEvent = (event: VerificationEvent) => eventContext.get(event.id)?.participant;
 
   return (
@@ -74,7 +77,7 @@ export function MultiParticipantOverview({
       />
       <RoutineHistoryPanel
         assignments={assignments}
-        events={events}
+        events={rangedEvents}
         locale={locale}
         titleId="collective-history-title"
         participants={participants}

--- a/src/components/PullToUpdate.test.tsx
+++ b/src/components/PullToUpdate.test.tsx
@@ -109,4 +109,16 @@ describe('PullToUpdate', () => {
 
     expect(onHorizontalSwipe).not.toHaveBeenCalled();
   });
+
+  it('keeps horizontal navigation available from a full-row history opener', () => {
+    const onHorizontalSwipe = vi.fn();
+    const page = renderPullToUpdate(async () => false, onHorizontalSwipe);
+    page.innerHTML = '<section class="history-row"><button type="button" class="history-row-open-button">Open result</button></section>';
+    const historyRowOpener = page.querySelector('.history-row-open-button') as HTMLButtonElement;
+
+    dispatchTouch(historyRowOpener, 'touchstart', 120, 80);
+    dispatchTouch(historyRowOpener, 'touchend', 30, 82);
+
+    expect(onHorizontalSwipe).toHaveBeenCalledWith('left');
+  });
 });

--- a/src/components/PullToUpdate.tsx
+++ b/src/components/PullToUpdate.tsx
@@ -6,7 +6,7 @@ const PULL_THRESHOLD = 72;
 const MAX_PULL_DISTANCE = 110;
 const HORIZONTAL_SWIPE_THRESHOLD = 64;
 const HORIZONTAL_SWIPE_DOMINANCE = 1.35;
-const SWIPE_NAVIGATION_EXCLUSION_SELECTOR = 'button, a, input, select, textarea, summary, [role="button"], dialog, .parent-review-card, [data-swipe-navigation="ignore"]';
+const SWIPE_NAVIGATION_EXCLUSION_SELECTOR = 'button:not(.history-row-open-button), a, input, select, textarea, summary, [role="button"], dialog, .parent-review-card, [data-swipe-navigation="ignore"]';
 
 type PullGesture = {
   startX: number;

--- a/src/components/RoutineHistoryPanel.tsx
+++ b/src/components/RoutineHistoryPanel.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useState, type CSSProperties } from 'react';
 import type { Locale, RoutineAssignment, VerificationEvent, VerificationStatus } from '../domain/models';
 import type { MessageKey } from '../services/i18n';
 import { presentRoutine } from '../domain/routinePresentation';
@@ -68,8 +68,8 @@ export function RoutineHistoryPanel({
   onRetake?: (event: VerificationEvent) => void;
   onOpenEvent?: (event: VerificationEvent) => void;
   onRequestCheck?: (routineId: string) => Promise<void>;
-  participants?: Array<{ id: string; displayName: string }>;
-  participantForEvent?: (event: VerificationEvent) => { id: string; displayName: string } | undefined;
+  participants?: Array<{ id: string; displayName: string; profileColor: string }>;
+  participantForEvent?: (event: VerificationEvent) => { id: string; displayName: string; profileColor: string } | undefined;
   t: (key: MessageKey) => string;
 }) {
   const [excludedStatuses, setExcludedStatuses] = useState<VerificationStatus[]>(() => readStoredFilters(titleId).statuses);
@@ -176,7 +176,7 @@ export function RoutineHistoryPanel({
                 <div className="filter-chips">
                   {participants.map((participant) => {
                     const active = !excludedParticipantIds.includes(participant.id);
-                    return <button type="button" key={participant.id} aria-pressed={active} className={active ? 'active' : ''} onClick={() => toggleParticipantFilter(participant.id)}>{participant.displayName}</button>;
+                    return <button type="button" key={participant.id} aria-pressed={active} className={`participant-filter-chip${active ? ' active' : ''}`} style={{ '--profile-color': participant.profileColor } as CSSProperties} onClick={() => toggleParticipantFilter(participant.id)}>{participant.displayName}</button>;
                   })}
                 </div>
               </div>
@@ -229,7 +229,7 @@ export function RoutineHistoryPanel({
                   title={(
                     <span className="history-row-title">
                       <span>{visual?.name ?? t('routine')}</span>
-                      {participant ? <span className="history-row-participant">{participant.displayName}</span> : null}
+                      {participant ? <span className="history-row-participant" style={{ '--profile-color': participant.profileColor } as CSSProperties}>{participant.displayName}</span> : null}
                     </span>
                   )}
                   detail={(

--- a/src/screens/ParentDashboard.test.tsx
+++ b/src/screens/ParentDashboard.test.tsx
@@ -99,23 +99,24 @@ describe('ParentDashboard', () => {
 
   it('reuses the individual dashboard with participant filters and context labels', () => {
     const now = new Date().toISOString();
+    const threeDaysAgo = new Date(Date.now() - 3 * 86_400_000).toISOString();
     const assignment = createDefaultRoutineAssignment(now);
     const selectParticipant = vi.fn();
     const state: AppState = {
       role: 'parent', locale: 'en', notificationsEnabled: true, activeParticipantId: 'maya',
       family: { linked: true, childLinked: true, childName: 'Maya', linkingCode: '', parentRecoveryCode: '', consented: true },
       participantAccess: [
-        { participant: { id: 'maya', displayName: 'Maya' }, membership: { role: 'owner', status: 'active' } },
-        { participant: { id: 'leo', displayName: 'Leo' }, membership: { role: 'caregiver', status: 'active' } },
+        { participant: { id: 'maya', displayName: 'Maya', profileColor: 'violet' }, membership: { role: 'owner', status: 'active' } },
+        { participant: { id: 'leo', displayName: 'Leo', profileColor: 'teal' }, membership: { role: 'caregiver', status: 'active' } },
       ],
       notificationSources: [
         {
-          participant: { id: 'maya', displayName: 'Maya' }, role: 'parent', assignments: [assignment],
+          participant: { id: 'maya', displayName: 'Maya', profileColor: 'violet' }, role: 'parent', assignments: [assignment],
           events: [{ id: 'maya-ok', routineId: assignment.routineId, sessionId: 'maya', requestedAt: now, expiresAt: now, status: 'detected' }],
         },
         {
-          participant: { id: 'leo', displayName: 'Leo' }, role: 'parent', assignments: [assignment],
-          events: [{ id: 'leo-review', routineId: assignment.routineId, sessionId: 'leo', requestedAt: now, expiresAt: now, status: 'uncertain' }],
+          participant: { id: 'leo', displayName: 'Leo', profileColor: 'teal' }, role: 'parent', assignments: [assignment],
+          events: [{ id: 'leo-review', routineId: assignment.routineId, sessionId: 'leo', requestedAt: threeDaysAgo, expiresAt: threeDaysAgo, status: 'uncertain' }],
         },
       ],
       routineAssignments: [assignment],
@@ -130,10 +131,17 @@ describe('ParentDashboard', () => {
     expect(container.querySelector('.history-filter-card')).not.toBeNull();
     expect(Array.from(container.querySelectorAll('.filter-group > span')).map((label) => label.textContent)).toEqual(['Participant', 'Routine', 'Status']);
     expect(container.textContent).toContain('Results');
+    expect(container.querySelectorAll('.parent-history-row')).toHaveLength(1);
+    const weekRange = Array.from(container.querySelectorAll<HTMLButtonElement>('.summary-range-toggle button'))
+      .find((button) => button.textContent === '7 days');
+    act(() => weekRange?.click());
     expect(container.querySelectorAll('.parent-history-row')).toHaveLength(2);
     const collectiveTitles = Array.from(container.querySelectorAll('.history-row-title')).map((title) => title.textContent).join(' ');
     expect(collectiveTitles).toContain('Maya');
     expect(collectiveTitles).toContain('Leo');
+    const participantChips = Array.from(container.querySelectorAll<HTMLElement>('.participant-filter-chip'));
+    expect(participantChips.every((chip) => chip.style.getPropertyValue('--profile-color').length > 0)).toBe(true);
+    expect(new Set(Array.from(container.querySelectorAll<HTMLElement>('.history-row-participant')).map((name) => name.style.getPropertyValue('--profile-color'))).size).toBe(2);
     expect(container.textContent).toContain('Detailed report');
 
     const leoFilter = Array.from(container.querySelectorAll<HTMLButtonElement>('.filter-group:first-child button'))

--- a/src/screens/ParentDashboard.tsx
+++ b/src/screens/ParentDashboard.tsx
@@ -316,6 +316,10 @@ export function ParentDashboard({
       {showParticipantOverview ? (
         <MultiParticipantOverview sources={notificationSources} locale={state.locale} range={summaryRange} onRangeChange={setSummaryRange} onSelectParticipant={selectParticipant} t={t} />
       ) : <>
+      <section className="today-section participant-history-section dashboard-summary-section parent-dashboard-overview-section" aria-labelledby="responsible-summary-title">
+        <h2 id="responsible-summary-title">{t('overview')}</h2>
+        <AdherenceSummaryCard events={displayEvents} assignments={state.routineAssignments} locale={state.locale} subjectName={reportSubjectName} range={summaryRange} onRangeChange={setSummaryRange} detailedReportOpenSignal={weeklyReportOpenSignal} t={t} />
+      </section>
       {setupStep ? (
         <section className="card parent-onboarding-card" aria-labelledby="parent-onboarding-title">
           <div className="parent-onboarding-heading">
@@ -638,9 +642,7 @@ export function ParentDashboard({
         />
       ) : null}
 
-      <section className="today-section participant-history-section parent-history-section dashboard-summary-section" aria-labelledby="responsible-summary-title">
-        <h2 id="responsible-summary-title">{t('overview')}</h2>
-        <AdherenceSummaryCard events={displayEvents} assignments={state.routineAssignments} locale={state.locale} subjectName={reportSubjectName} range={summaryRange} onRangeChange={setSummaryRange} detailedReportOpenSignal={weeklyReportOpenSignal} t={t} />
+      <section className="today-section participant-history-section parent-history-section">
         <RoutineHistoryPanel assignments={state.routineAssignments} events={rangedRawEvents} locale={state.locale} titleId="responsible-history-title" onRequestCheck={requestCheck} onOpenEvent={(event) => setDetailEventId(event.id)} t={t} />
       </section>
       {detailEvent ? <VerificationEventDetailDialog event={detailEvent} locale={state.locale} proofUrl={proofUrls[detailEvent.id]} getProofImageUrl={getProofImageUrl} reviewCheck={reviewCheck} requestCheck={requestCheck} onClose={() => setDetailEventId(undefined)} t={t} /> : null}

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -1011,7 +1011,9 @@ button:disabled { cursor: not-allowed; }
 .participant-switcher-menu button.active .participant-switcher-option-avatar { background: var(--color-surface-solid); }
 .history-row-title { display: flex; min-width: 0; align-items: baseline; gap: 7px; }
 .history-row-title > span:first-child { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-.history-row-participant { flex: 0 0 auto; color: var(--color-text-muted); font-size: 10px; font-weight: 750; }
+.history-row-participant { flex: 0 0 auto; color: var(--profile-color); font-size: 10px; font-weight: 850; }
+.participant-filter-chip { color: var(--profile-color); }
+.participant-filter-chip.active { border-color: color-mix(in srgb, var(--profile-color) 32%, var(--color-border)); background: color-mix(in srgb, var(--profile-color) 12%, var(--color-surface-solid)); color: var(--profile-color); }
 .participant-switcher-static .profile-context-card { cursor: default; }
 .relationship-manager-card { display: grid; padding: 0; overflow: hidden; }
 .profile-context-card { width: 100%; min-height: 68px; display: grid; grid-template-columns: 40px minmax(0, 1fr) 38px; align-items: center; gap: 11px; padding: 12px 14px; border: 0; background: linear-gradient(135deg, rgba(255,255,255,.98), rgba(241,248,246,.94)); color: var(--color-text); text-align: left; }


### PR DESCRIPTION
## Summary

- move the individual adherence overview directly below the participant selector
- apply the selected collective summary period to collective history results
- show each participant’s profile color in participant filter chips and history labels
- keep horizontal swipe navigation available from full-row history openers
- preserve swipe exclusions for visible controls and proof-review cards
- bump the application version to `0.11.7`

## Validation

- `corepack pnpm exec vitest run src/components/PullToUpdate.test.tsx src/screens/ParentDashboard.test.tsx src/App.test.ts` — 44 passed
- `corepack pnpm exec tsc -b --pretty false`
- `corepack pnpm check:architecture`
- `corepack pnpm check:design`
- `git diff --check`