### PR TITLE
Unify collective filters and swipe

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zadiag-pwa",
   "private": true,
-  "version": "0.11.7",
+  "version": "0.11.8",
   "type": "module",
   "packageManager": "pnpm@11.7.0",
   "engines": {

--- a/src/components/MultiParticipantOverview.tsx
+++ b/src/components/MultiParticipantOverview.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from 'react';
+import { useMemo, useState } from 'react';
 import type { Locale, ParticipantNotificationSource, RoutineAssignment, VerificationEvent } from '../domain/models';
 import { profileColorFor } from '../domain/profileColor';
 import type { MessageKey } from '../services/i18n';
@@ -55,20 +55,27 @@ export function MultiParticipantOverview({
   t: (key: MessageKey) => string;
 }) {
   const { assignments, events, eventContext } = useMemo(() => collectiveDashboardData(sources), [sources]);
+  const [excludedParticipantIds, setExcludedParticipantIds] = useState<string[]>([]);
   const participants = sources.map((source) => ({
     id: source.participant.id,
     displayName: source.participant.displayName,
     profileColor: profileColorFor(source.participant),
   }));
-  const rangedEvents = useMemo(() => filterEventsBySummaryRange(events, range), [events, range]);
+  const visibleEvents = useMemo(() => events.filter((event) => (
+    !excludedParticipantIds.includes(eventContext.get(event.id)?.participant.id ?? '')
+  )), [eventContext, events, excludedParticipantIds]);
+  const visibleAssignments = useMemo(() => assignments.filter((assignment) => (
+    !excludedParticipantIds.some((participantId) => assignment.routineId.startsWith(`${participantId}:`))
+  )), [assignments, excludedParticipantIds]);
+  const rangedEvents = useMemo(() => filterEventsBySummaryRange(visibleEvents, range), [range, visibleEvents]);
   const participantForEvent = (event: VerificationEvent) => eventContext.get(event.id)?.participant;
 
   return (
     <section className="today-section participant-history-section parent-history-section dashboard-summary-section multi-participant-overview" aria-labelledby="collective-summary-title">
       <h2 id="collective-summary-title">{t('overview')}</h2>
       <AdherenceSummaryCard
-        events={events}
-        assignments={assignments}
+        events={visibleEvents}
+        assignments={visibleAssignments}
         locale={locale}
         subjectName={t('allParticipants')}
         range={range}
@@ -76,12 +83,18 @@ export function MultiParticipantOverview({
         t={t}
       />
       <RoutineHistoryPanel
-        assignments={assignments}
+        assignments={visibleAssignments}
         events={rangedEvents}
         locale={locale}
         titleId="collective-history-title"
         participants={participants}
         participantForEvent={participantForEvent}
+        excludedParticipantIds={excludedParticipantIds}
+        onToggleParticipant={(participantId) => setExcludedParticipantIds((current) => (
+          current.includes(participantId)
+            ? current.filter((item) => item !== participantId)
+            : [...current, participantId]
+        ))}
         onOpenEvent={(event) => {
           const context = eventContext.get(event.id);
           if (context) onSelectParticipant(context.participant.id);

--- a/src/components/PullToUpdate.test.tsx
+++ b/src/components/PullToUpdate.test.tsx
@@ -121,4 +121,16 @@ describe('PullToUpdate', () => {
 
     expect(onHorizontalSwipe).toHaveBeenCalledWith('left');
   });
+
+  it('allows a dashboard to opt its controls into swipe navigation', () => {
+    const onHorizontalSwipe = vi.fn();
+    const page = renderPullToUpdate(async () => false, onHorizontalSwipe);
+    page.innerHTML = '<main data-swipe-navigation="allow"><button type="button">Dashboard filter</button></main>';
+    const dashboardFilter = page.querySelector('button') as HTMLButtonElement;
+
+    dispatchTouch(dashboardFilter, 'touchstart', 120, 80);
+    dispatchTouch(dashboardFilter, 'touchend', 45, 82);
+
+    expect(onHorizontalSwipe).toHaveBeenCalledWith('left');
+  });
 });

--- a/src/components/PullToUpdate.tsx
+++ b/src/components/PullToUpdate.tsx
@@ -4,9 +4,10 @@ import type { MessageKey } from '../services/i18n';
 
 const PULL_THRESHOLD = 72;
 const MAX_PULL_DISTANCE = 110;
-const HORIZONTAL_SWIPE_THRESHOLD = 64;
-const HORIZONTAL_SWIPE_DOMINANCE = 1.35;
-const SWIPE_NAVIGATION_EXCLUSION_SELECTOR = 'button:not(.history-row-open-button), a, input, select, textarea, summary, [role="button"], dialog, .parent-review-card, [data-swipe-navigation="ignore"]';
+const HORIZONTAL_SWIPE_THRESHOLD = 56;
+const HORIZONTAL_SWIPE_DOMINANCE = 1.2;
+const SWIPE_NAVIGATION_CONTROL_SELECTOR = 'button:not(.history-row-open-button), a, input, select, textarea, summary, [role="button"]';
+const SWIPE_NAVIGATION_HARD_EXCLUSION_SELECTOR = 'dialog, .parent-review-card, [data-swipe-navigation="ignore"]';
 
 type PullGesture = {
   startX: number;
@@ -46,7 +47,10 @@ export function PullToUpdate({
     if (event.touches.length !== 1) return;
     const target = event.target instanceof Element ? event.target : undefined;
     const touch = event.touches[0];
-    swipeGestureRef.current = onHorizontalSwipe && !target?.closest(SWIPE_NAVIGATION_EXCLUSION_SELECTOR)
+    const hardExcluded = target?.closest(SWIPE_NAVIGATION_HARD_EXCLUSION_SELECTOR);
+    const controlExcluded = target?.closest(SWIPE_NAVIGATION_CONTROL_SELECTOR);
+    const explicitlyAllowed = target?.closest('[data-swipe-navigation="allow"]');
+    swipeGestureRef.current = onHorizontalSwipe && !hardExcluded && (!controlExcluded || explicitlyAllowed)
       ? { startX: touch.clientX, startY: touch.clientY }
       : undefined;
     if (updating) return;

--- a/src/components/RoutineHistoryPanel.tsx
+++ b/src/components/RoutineHistoryPanel.tsx
@@ -21,13 +21,12 @@ const displayReason = (reason?: string) =>
 const historyFilterStorageKey = (titleId: string) => `zadiag.historyFilters.${titleId}`;
 
 const readStoredFilters = (titleId: string) => {
-  const empty = { statuses: [] as VerificationStatus[], routineIds: [] as string[], participantIds: [] as string[] };
+  const empty = { statuses: [] as VerificationStatus[], routineIds: [] as string[] };
   return readUiStorageJson(historyFilterStorageKey(titleId), empty, (value) => {
-    const parsed = value as Partial<{ statuses: VerificationStatus[]; routineIds: string[]; participantIds: string[] }>;
+    const parsed = value as Partial<{ statuses: VerificationStatus[]; routineIds: string[] }>;
     return {
       statuses: Array.isArray(parsed.statuses) ? parsed.statuses : [],
       routineIds: Array.isArray(parsed.routineIds) ? parsed.routineIds : [],
-      participantIds: Array.isArray(parsed.participantIds) ? parsed.participantIds : [],
     };
   });
 };
@@ -58,6 +57,8 @@ export function RoutineHistoryPanel({
   onRequestCheck,
   participants,
   participantForEvent,
+  excludedParticipantIds = [],
+  onToggleParticipant,
   t,
 }: {
   assignments: RoutineAssignment[];
@@ -70,11 +71,12 @@ export function RoutineHistoryPanel({
   onRequestCheck?: (routineId: string) => Promise<void>;
   participants?: Array<{ id: string; displayName: string; profileColor: string }>;
   participantForEvent?: (event: VerificationEvent) => { id: string; displayName: string; profileColor: string } | undefined;
+  excludedParticipantIds?: string[];
+  onToggleParticipant?: (participantId: string) => void;
   t: (key: MessageKey) => string;
 }) {
   const [excludedStatuses, setExcludedStatuses] = useState<VerificationStatus[]>(() => readStoredFilters(titleId).statuses);
   const [excludedRoutineIds, setExcludedRoutineIds] = useState<string[]>(() => readStoredFilters(titleId).routineIds);
-  const [excludedParticipantIds, setExcludedParticipantIds] = useState<string[]>(() => readStoredFilters(titleId).participantIds);
   const [requestingEventId, setRequestingEventId] = useState<string>();
   const [hiddenRequestEventIds, setHiddenRequestEventIds] = useState<Record<string, string>>({});
   const formatterLocale = languageTag(locale);
@@ -111,14 +113,12 @@ export function RoutineHistoryPanel({
   );
   const excludedStatusSet = useMemo(() => new Set(excludedStatuses), [excludedStatuses]);
   const excludedRoutineIdSet = useMemo(() => new Set(excludedRoutineIds), [excludedRoutineIds]);
-  const excludedParticipantIdSet = useMemo(() => new Set(excludedParticipantIds), [excludedParticipantIds]);
   useEffect(() => {
     writeUiStorageString(historyFilterStorageKey(titleId), JSON.stringify({
       statuses: excludedStatuses,
       routineIds: excludedRoutineIds,
-      participantIds: excludedParticipantIds,
     }));
-  }, [excludedParticipantIds, excludedRoutineIds, excludedStatuses, titleId]);
+  }, [excludedRoutineIds, excludedStatuses, titleId]);
   const toggleRoutineFilter = (routineId: string) => {
     setExcludedRoutineIds((current) =>
       current.includes(routineId)
@@ -133,17 +133,10 @@ export function RoutineHistoryPanel({
         : current.filter((status) => !eventStatuses.includes(status));
     });
   };
-  const toggleParticipantFilter = (participantId: string) => {
-    setExcludedParticipantIds((current) =>
-      current.includes(participantId)
-        ? current.filter((item) => item !== participantId)
-        : [...current, participantId]);
-  };
   const filtered = useMemo(() => sortedEvents.filter((event) =>
     !excludedStatusSet.has(event.status)
     && !excludedRoutineIdSet.has(event.routineId)
-    && !excludedParticipantIdSet.has(participantForEvent?.(event)?.id ?? '')
-  ), [excludedParticipantIdSet, excludedRoutineIdSet, excludedStatusSet, participantForEvent, sortedEvents]);
+  ), [excludedRoutineIdSet, excludedStatusSet, sortedEvents]);
   const presentationFor = (event: VerificationEvent) => routinePresentationsById.get(event.routineId);
   const requestCheck = async (event: VerificationEvent) => {
     if (!onRequestCheck || requestingEventId) return;
@@ -170,13 +163,13 @@ export function RoutineHistoryPanel({
       {sortedEvents.length ? (
         <>
           <section className="card history-filter-card" aria-label={t('historyFilters')}>
-            {participants?.length ? (
+            {participants?.length && onToggleParticipant ? (
               <div className="filter-group">
                 <span>{t('filterByParticipant')}</span>
                 <div className="filter-chips">
                   {participants.map((participant) => {
                     const active = !excludedParticipantIds.includes(participant.id);
-                    return <button type="button" key={participant.id} aria-pressed={active} className={`participant-filter-chip${active ? ' active' : ''}`} style={{ '--profile-color': participant.profileColor } as CSSProperties} onClick={() => toggleParticipantFilter(participant.id)}>{participant.displayName}</button>;
+                    return <button type="button" key={participant.id} aria-pressed={active} className={`participant-filter-chip${active ? ' active' : ''}`} style={{ '--profile-color': participant.profileColor } as CSSProperties} onClick={() => onToggleParticipant(participant.id)}>{participant.displayName}</button>;
                   })}
                 </div>
               </div>

--- a/src/screens/ParentDashboard.test.tsx
+++ b/src/screens/ParentDashboard.test.tsx
@@ -136,6 +136,7 @@ describe('ParentDashboard', () => {
       .find((button) => button.textContent === '7 days');
     act(() => weekRange?.click());
     expect(container.querySelectorAll('.parent-history-row')).toHaveLength(2);
+    expect(container.querySelector('.progress-ring')?.textContent).toBe('50%');
     const collectiveTitles = Array.from(container.querySelectorAll('.history-row-title')).map((title) => title.textContent).join(' ');
     expect(collectiveTitles).toContain('Maya');
     expect(collectiveTitles).toContain('Leo');
@@ -148,6 +149,7 @@ describe('ParentDashboard', () => {
       .find((button) => button.textContent === 'Leo');
     act(() => leoFilter?.click());
     expect(container.querySelectorAll('.parent-history-row')).toHaveLength(1);
+    expect(container.querySelector('.progress-ring')?.textContent).toBe('100%');
 
     act(() => container.querySelector<HTMLButtonElement>('.history-row-open-button')?.click());
     expect(selectParticipant).toHaveBeenCalledWith('maya');

--- a/src/screens/ParentDashboard.tsx
+++ b/src/screens/ParentDashboard.tsx
@@ -282,7 +282,7 @@ export function ParentDashboard({
     onNotificationEventConsumed?.();
   }, [notificationEventId, now, onNotificationEventConsumed, state.events]);
   return (
-    <div className="content-screen child-home parent-overview-screen">
+    <div className="content-screen child-home parent-overview-screen" data-swipe-navigation="allow">
       <div className="page-context-top parent-context-top">
         <header className="screen-header page-context-heading">
           <div><h1>{t('activity')}</h1></div>

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -1012,8 +1012,8 @@ button:disabled { cursor: not-allowed; }
 .history-row-title { display: flex; min-width: 0; align-items: baseline; gap: 7px; }
 .history-row-title > span:first-child { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .history-row-participant { flex: 0 0 auto; color: var(--profile-color); font-size: 10px; font-weight: 850; }
-.participant-filter-chip { color: var(--profile-color); }
-.participant-filter-chip.active { border-color: color-mix(in srgb, var(--profile-color) 32%, var(--color-border)); background: color-mix(in srgb, var(--profile-color) 12%, var(--color-surface-solid)); color: var(--profile-color); }
+.filter-chips .participant-filter-chip { border-color: color-mix(in srgb, var(--profile-color) 24%, var(--color-border)); background: color-mix(in srgb, var(--profile-color) 7%, var(--color-surface-solid)); color: var(--profile-color); }
+.filter-chips .participant-filter-chip.active { border-color: var(--profile-color); background: var(--profile-color); color: var(--color-surface-solid); }
 .participant-switcher-static .profile-context-card { cursor: default; }
 .relationship-manager-card { display: grid; padding: 0; overflow: hidden; }
 .profile-context-card { width: 100%; min-height: 68px; display: grid; grid-template-columns: 40px minmax(0, 1fr) 38px; align-items: center; gap: 11px; padding: 12px 14px; border: 0; background: linear-gradient(135deg, rgba(255,255,255,.98), rgba(241,248,246,.94)); color: var(--color-text); text-align: left; }


### PR DESCRIPTION
## Summary

- make the collective participant filter drive the overview, detailed report, and history together
- start each collective visit with all participants included
- preserve participant colors on active and inactive filter chips
- allow left-swipe navigation from controls across the responsible dashboard
- use a more forgiving swipe threshold while continuing to exclude review cards and dialogs
- bump the application version to `0.11.8`

## Validation

- `corepack pnpm exec vitest run src/components/PullToUpdate.test.tsx src/screens/ParentDashboard.test.tsx src/App.test.ts` — 45 passed
- `corepack pnpm exec tsc -b --pretty false`
- `corepack pnpm check:architecture`
- `corepack pnpm check:design`
- `git diff --check`