### PR TITLE
Align collective totals and history accents

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zadiag-pwa",
   "private": true,
-  "version": "0.11.8",
+  "version": "0.11.9",
   "type": "module",
   "packageManager": "pnpm@11.7.0",
   "engines": {

--- a/src/components/MultiParticipantOverview.tsx
+++ b/src/components/MultiParticipantOverview.tsx
@@ -1,6 +1,7 @@
 import { useMemo, useState } from 'react';
 import type { Locale, ParticipantNotificationSource, RoutineAssignment, VerificationEvent } from '../domain/models';
 import { profileColorFor } from '../domain/profileColor';
+import { withResolvedEventStatuses } from '../domain/adherence';
 import type { MessageKey } from '../services/i18n';
 import { AdherenceSummaryCard, filterEventsBySummaryRange, type SummaryRange } from './AdherenceSummaryCard';
 import { RoutineHistoryPanel } from './RoutineHistoryPanel';
@@ -43,6 +44,7 @@ export function MultiParticipantOverview({
   sources,
   locale,
   range,
+  now,
   onRangeChange,
   onSelectParticipant,
   t,
@@ -50,20 +52,22 @@ export function MultiParticipantOverview({
   sources: ParticipantNotificationSource[];
   locale: Locale;
   range: SummaryRange;
+  now: number;
   onRangeChange: (range: SummaryRange) => void;
   onSelectParticipant: (participantId: string) => void;
   t: (key: MessageKey) => string;
 }) {
   const { assignments, events, eventContext } = useMemo(() => collectiveDashboardData(sources), [sources]);
+  const resolvedEvents = useMemo(() => withResolvedEventStatuses(events, now), [events, now]);
   const [excludedParticipantIds, setExcludedParticipantIds] = useState<string[]>([]);
   const participants = sources.map((source) => ({
     id: source.participant.id,
     displayName: source.participant.displayName,
     profileColor: profileColorFor(source.participant),
   }));
-  const visibleEvents = useMemo(() => events.filter((event) => (
+  const visibleEvents = useMemo(() => resolvedEvents.filter((event) => (
     !excludedParticipantIds.includes(eventContext.get(event.id)?.participant.id ?? '')
-  )), [eventContext, events, excludedParticipantIds]);
+  )), [eventContext, excludedParticipantIds, resolvedEvents]);
   const visibleAssignments = useMemo(() => assignments.filter((assignment) => (
     !excludedParticipantIds.some((participantId) => assignment.routineId.startsWith(`${participantId}:`))
   )), [assignments, excludedParticipantIds]);
@@ -89,6 +93,7 @@ export function MultiParticipantOverview({
         titleId="collective-history-title"
         participants={participants}
         participantForEvent={participantForEvent}
+        colorForEvent={(event) => eventContext.get(event.id)?.participant.profileColor}
         excludedParticipantIds={excludedParticipantIds}
         onToggleParticipant={(participantId) => setExcludedParticipantIds((current) => (
           current.includes(participantId)

--- a/src/components/RoutineHistoryPanel.tsx
+++ b/src/components/RoutineHistoryPanel.tsx
@@ -57,6 +57,7 @@ export function RoutineHistoryPanel({
   onRequestCheck,
   participants,
   participantForEvent,
+  colorForEvent,
   excludedParticipantIds = [],
   onToggleParticipant,
   t,
@@ -71,6 +72,7 @@ export function RoutineHistoryPanel({
   onRequestCheck?: (routineId: string) => Promise<void>;
   participants?: Array<{ id: string; displayName: string; profileColor: string }>;
   participantForEvent?: (event: VerificationEvent) => { id: string; displayName: string; profileColor: string } | undefined;
+  colorForEvent?: (event: VerificationEvent) => string | undefined;
   excludedParticipantIds?: string[];
   onToggleParticipant?: (participantId: string) => void;
   t: (key: MessageKey) => string;
@@ -199,7 +201,7 @@ export function RoutineHistoryPanel({
           <div className="history-list parent-history-list">
             {filtered.map((event) => {
               const visual = presentationFor(event);
-              const participant = participantForEvent?.(event);
+              const participantColor = colorForEvent?.(event);
               const canRetake = Boolean(onRetake) && canRetakeCapture(event, retryEvents ?? events, new Date());
               const canRequestCheck = Boolean(onRequestCheck)
                 && latestMissedEventIds.has(event.id)
@@ -215,16 +217,11 @@ export function RoutineHistoryPanel({
               return (
                 <ListRow
                   as="section"
-                  className={`card history-row parent-history-row${onOpenEvent ? ' history-row-clickable' : ''}`}
+                  className={`card history-row parent-history-row${participantColor ? ' has-participant-accent' : ''}${onOpenEvent ? ' history-row-clickable' : ''}`}
                   variant="bare"
                   icon={<AppIcon name={routineIconName(visual?.icon)} />}
                   iconClassName="history-icon routine-history-icon"
-                  title={(
-                    <span className="history-row-title">
-                      <span>{visual?.name ?? t('routine')}</span>
-                      {participant ? <span className="history-row-participant" style={{ '--profile-color': participant.profileColor } as CSSProperties}>{participant.displayName}</span> : null}
-                    </span>
-                  )}
+                  title={visual?.name ?? t('routine')}
                   detail={(
                     <>
                       {formatDateTime(event.requestedAt)}
@@ -234,7 +231,7 @@ export function RoutineHistoryPanel({
                       {staleHint ? <span className="history-stale-hint"> · {staleHint}</span> : null}
                     </>
                   )}
-                  style={visual?.style}
+                  style={{ ...visual?.style, ...(participantColor ? { '--history-participant-color': participantColor } : {}) } as CSSProperties}
                   trailing={(
                     <>
                     {onOpenEvent ? <button type="button" className="history-row-open-button" aria-label={`${t('historyDetailTitle')} · ${visual?.name ?? t('routine')} · ${formatDateTime(event.requestedAt)}`} onClick={() => onOpenEvent(event)} /> : null}

--- a/src/screens/ParentDashboard.test.tsx
+++ b/src/screens/ParentDashboard.test.tsx
@@ -39,6 +39,8 @@ describe('ParentDashboard', () => {
       role: 'parent',
       locale: 'en',
       notificationsEnabled: true,
+      activeParticipantId: 'maya',
+      participantAccess: [{ participant: { id: 'maya', displayName: 'Maya', profileColor: 'violet' }, membership: { role: 'owner', status: 'active' } }],
       family: { linked: true, childLinked: false, childName: 'Maya', linkingCode: 'ZD-123456', parentRecoveryCode: '', consented: true },
       routineAssignments: [assignment],
       events: [
@@ -80,12 +82,15 @@ describe('ParentDashboard', () => {
       role: 'parent',
       locale: 'en',
       notificationsEnabled: true,
+      activeParticipantId: 'maya',
+      participantAccess: [{ participant: { id: 'maya', displayName: 'Maya', profileColor: 'violet' }, membership: { role: 'owner', status: 'active' } }],
       family: { linked: true, childLinked: true, childName: 'Maya', linkingCode: '', parentRecoveryCode: '', consented: true },
       routineAssignments: [assignment],
       events: [{ id: 'dashboard-detail', routineId: assignment.routineId, sessionId: 'one', requestedAt, expiresAt: new Date(Date.now() + 60 * 60_000).toISOString(), status: 'detected', reason: 'Visible from dashboard' }],
     };
 
     act(() => root.render(<ParentDashboard state={state} regenerateCode={vi.fn()} requestCheck={vi.fn()} t={(key) => translate('en', key)} />));
+    expect(container.querySelector<HTMLElement>('.parent-history-row')?.style.getPropertyValue('--history-participant-color')).not.toBe('');
     const openDetails = container.querySelector<HTMLButtonElement>('.history-row-open-button');
     act(() => openDetails?.click());
 
@@ -112,7 +117,10 @@ describe('ParentDashboard', () => {
       notificationSources: [
         {
           participant: { id: 'maya', displayName: 'Maya', profileColor: 'violet' }, role: 'parent', assignments: [assignment],
-          events: [{ id: 'maya-ok', routineId: assignment.routineId, sessionId: 'maya', requestedAt: now, expiresAt: now, status: 'detected' }],
+          events: [
+            { id: 'maya-ok', routineId: assignment.routineId, sessionId: 'maya', requestedAt: now, expiresAt: now, status: 'detected' },
+            { id: 'maya-expired', routineId: assignment.routineId, sessionId: 'maya-expired', requestedAt: now, expiresAt: threeDaysAgo, status: 'pending' },
+          ],
         },
         {
           participant: { id: 'leo', displayName: 'Leo', profileColor: 'teal' }, role: 'parent', assignments: [assignment],
@@ -131,25 +139,25 @@ describe('ParentDashboard', () => {
     expect(container.querySelector('.history-filter-card')).not.toBeNull();
     expect(Array.from(container.querySelectorAll('.filter-group > span')).map((label) => label.textContent)).toEqual(['Participant', 'Routine', 'Status']);
     expect(container.textContent).toContain('Results');
-    expect(container.querySelectorAll('.parent-history-row')).toHaveLength(1);
+    expect(container.querySelectorAll('.parent-history-row')).toHaveLength(2);
     const weekRange = Array.from(container.querySelectorAll<HTMLButtonElement>('.summary-range-toggle button'))
       .find((button) => button.textContent === '7 days');
     act(() => weekRange?.click());
-    expect(container.querySelectorAll('.parent-history-row')).toHaveLength(2);
-    expect(container.querySelector('.progress-ring')?.textContent).toBe('50%');
-    const collectiveTitles = Array.from(container.querySelectorAll('.history-row-title')).map((title) => title.textContent).join(' ');
-    expect(collectiveTitles).toContain('Maya');
-    expect(collectiveTitles).toContain('Leo');
+    expect(container.querySelectorAll('.parent-history-row')).toHaveLength(3);
+    expect(container.querySelector('.progress-ring')?.textContent).toBe('33%');
+    const collectiveTitles = Array.from(container.querySelectorAll('.parent-history-row strong')).map((title) => title.textContent).join(' ');
+    expect(collectiveTitles).not.toContain('Maya');
+    expect(collectiveTitles).not.toContain('Leo');
     const participantChips = Array.from(container.querySelectorAll<HTMLElement>('.participant-filter-chip'));
     expect(participantChips.every((chip) => chip.style.getPropertyValue('--profile-color').length > 0)).toBe(true);
-    expect(new Set(Array.from(container.querySelectorAll<HTMLElement>('.history-row-participant')).map((name) => name.style.getPropertyValue('--profile-color'))).size).toBe(2);
+    expect(new Set(Array.from(container.querySelectorAll<HTMLElement>('.has-participant-accent')).map((row) => row.style.getPropertyValue('--history-participant-color'))).size).toBe(2);
     expect(container.textContent).toContain('Detailed report');
 
     const leoFilter = Array.from(container.querySelectorAll<HTMLButtonElement>('.filter-group:first-child button'))
       .find((button) => button.textContent === 'Leo');
     act(() => leoFilter?.click());
-    expect(container.querySelectorAll('.parent-history-row')).toHaveLength(1);
-    expect(container.querySelector('.progress-ring')?.textContent).toBe('100%');
+    expect(container.querySelectorAll('.parent-history-row')).toHaveLength(2);
+    expect(container.querySelector('.progress-ring')?.textContent).toBe('50%');
 
     act(() => container.querySelector<HTMLButtonElement>('.history-row-open-button')?.click());
     expect(selectParticipant).toHaveBeenCalledWith('maya');

--- a/src/screens/ParentDashboard.tsx
+++ b/src/screens/ParentDashboard.tsx
@@ -7,6 +7,7 @@ import { RoutineHistoryPanel } from '../components/RoutineHistoryPanel';
 import { AdherenceSummaryCard, filterEventsBySummaryRange, type SummaryRange } from '../components/AdherenceSummaryCard';
 import { UpcomingChecksSection } from '../components/UpcomingChecksSection';
 import { presentRoutine } from '../domain/routinePresentation';
+import { profileColorFor } from '../domain/profileColor';
 import { eventWindowLabel } from '../domain/taskTimeLabel';
 import { isReviewableVerification, withResolvedEventStatuses } from '../domain/adherence';
 import { EmptyState } from '../components/ui';
@@ -314,7 +315,7 @@ export function ParentDashboard({
       </div>
 
       {showParticipantOverview ? (
-        <MultiParticipantOverview sources={notificationSources} locale={state.locale} range={summaryRange} onRangeChange={setSummaryRange} onSelectParticipant={selectParticipant} t={t} />
+        <MultiParticipantOverview sources={notificationSources} locale={state.locale} range={summaryRange} now={now} onRangeChange={setSummaryRange} onSelectParticipant={selectParticipant} t={t} />
       ) : <>
       <section className="today-section participant-history-section dashboard-summary-section parent-dashboard-overview-section" aria-labelledby="responsible-summary-title">
         <h2 id="responsible-summary-title">{t('overview')}</h2>
@@ -643,7 +644,7 @@ export function ParentDashboard({
       ) : null}
 
       <section className="today-section participant-history-section parent-history-section">
-        <RoutineHistoryPanel assignments={state.routineAssignments} events={rangedRawEvents} locale={state.locale} titleId="responsible-history-title" onRequestCheck={requestCheck} onOpenEvent={(event) => setDetailEventId(event.id)} t={t} />
+        <RoutineHistoryPanel assignments={state.routineAssignments} events={rangedRawEvents} locale={state.locale} titleId="responsible-history-title" colorForEvent={activeParticipantAccess ? () => profileColorFor(activeParticipantAccess.participant) : undefined} onRequestCheck={requestCheck} onOpenEvent={(event) => setDetailEventId(event.id)} t={t} />
       </section>
       {detailEvent ? <VerificationEventDetailDialog event={detailEvent} locale={state.locale} proofUrl={proofUrls[detailEvent.id]} getProofImageUrl={getProofImageUrl} reviewCheck={reviewCheck} requestCheck={requestCheck} onClose={() => setDetailEventId(undefined)} t={t} /> : null}
       </>}

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -1009,9 +1009,7 @@ button:disabled { cursor: not-allowed; }
 .participant-switcher-option-avatar { width: 32px; height: 32px; display: grid; place-items: center; border-radius: 10px; background: #eef5f3; color: var(--profile-color, var(--color-primary)); font-size: 13px; font-weight: 900; }
 .participant-switcher-overview-avatar .svg-icon { font-size: 18px; }
 .participant-switcher-menu button.active .participant-switcher-option-avatar { background: var(--color-surface-solid); }
-.history-row-title { display: flex; min-width: 0; align-items: baseline; gap: 7px; }
-.history-row-title > span:first-child { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-.history-row-participant { flex: 0 0 auto; color: var(--profile-color); font-size: 10px; font-weight: 850; }
+.parent-history-row.has-participant-accent { border-inline-start: 4px solid var(--history-participant-color); }
 .filter-chips .participant-filter-chip { border-color: color-mix(in srgb, var(--profile-color) 24%, var(--color-border)); background: color-mix(in srgb, var(--profile-color) 7%, var(--color-surface-solid)); color: var(--profile-color); }
 .filter-chips .participant-filter-chip.active { border-color: var(--profile-color); background: var(--profile-color); color: var(--color-surface-solid); }
 .participant-switcher-static .profile-context-card { cursor: default; }


### PR DESCRIPTION
## Summary

- resolve expired pending checks before computing collective adherence totals
- align collective successful/total counts with the individual dashboard model
- remove participant names from collective history row titles
- add a participant-colored left accent to collective history rows
- apply the active participant color accent to individual history rows as well
- bump the application version to `0.11.9`

## Validation

- `corepack pnpm exec vitest run src/screens/ParentDashboard.test.tsx src/App.test.ts src/components/PullToUpdate.test.tsx` — 45 passed
- `corepack pnpm exec tsc -b --pretty false`
- `corepack pnpm check:architecture`
- `corepack pnpm check:design`
- `git diff --check`