### PR TITLE
Restore collective swipe after selection

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zadiag-pwa",
   "private": true,
-  "version": "0.11.9",
+  "version": "0.11.10",
   "type": "module",
   "packageManager": "pnpm@11.7.0",
   "engines": {

--- a/src/App.test.ts
+++ b/src/App.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { DEFAULT_ROUTINE_ID, type AppState, type VerificationEvent } from './domain/models';
-import { appBadgeCountForState, documentLanguageForLocale, isParticipantInvitationCode, participantIdForNotificationLaunch, resetNoticeMessageKey, resolveNotificationLaunch, setupCompletionTransition, shouldShowParticipantOverviewAfterSwipe, syncStatusFor, syncStatusIsVisible } from './App';
+import { appBadgeCountForState, documentLanguageForLocale, hasMultipleParticipantsForSwipe, isParticipantInvitationCode, participantIdForNotificationLaunch, resetNoticeMessageKey, resolveNotificationLaunch, setupCompletionTransition, shouldShowParticipantOverviewAfterSwipe, syncStatusFor, syncStatusIsVisible } from './App';
 
 describe('shouldShowParticipantOverviewAfterSwipe', () => {
   it('uses the first left swipe from an individual responsible dashboard for the collective overview', () => {
@@ -9,6 +9,14 @@ describe('shouldShowParticipantOverviewAfterSwipe', () => {
     expect(shouldShowParticipantOverviewAfterSwipe('parent', 'home', 'right', true, false)).toBe(false);
     expect(shouldShowParticipantOverviewAfterSwipe('child', 'home', 'left', true, false)).toBe(false);
     expect(shouldShowParticipantOverviewAfterSwipe('parent', 'home', 'left', false, false)).toBe(false);
+  });
+});
+
+describe('hasMultipleParticipantsForSwipe', () => {
+  it('keeps the collective destination available while either relationship source is synchronizing', () => {
+    expect(hasMultipleParticipantsForSwipe(2, 0)).toBe(true);
+    expect(hasMultipleParticipantsForSwipe(0, 2)).toBe(true);
+    expect(hasMultipleParticipantsForSwipe(1, 1)).toBe(false);
   });
 });
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -91,6 +91,11 @@ export const shouldShowParticipantOverviewAfterSwipe = (
   && hasMultipleParticipants
   && !participantOverview;
 
+export const hasMultipleParticipantsForSwipe = (
+  activeAccessCount: number,
+  notificationSourceCount: number,
+) => Math.max(activeAccessCount, notificationSourceCount) > 1;
+
 export const isParticipantInvitationCode = (code: string) => /^ZI-\d{6}$/.test(code.trim().toUpperCase());
 
 export const documentLanguageForLocale = (locale: Locale) => documentLanguage(locale);
@@ -465,6 +470,11 @@ export function App() {
   ) => action ? withRepositorySync(action) : undefined;
   const syncLocale = withRepositorySync(repository.setLocale);
   const selectActiveParticipant = withOptionalRepositorySync(repository.selectActiveParticipant);
+  const selectParticipantContext = selectActiveParticipant ? async (participantId: string) => {
+    setParticipantOverview(false);
+    writeUiStorageString(PARTICIPANT_OVERVIEW_STORAGE_KEY, 'individual');
+    await selectActiveParticipant(participantId);
+  } : undefined;
   const selectRole = async (role: Role) => {
     await repository.selectRole(role);
     sync();
@@ -760,7 +770,7 @@ export function App() {
             onExportRoutinePackage={canManageRoutines ? bindOptionalRepository(repository.exportRoutinePackage) : undefined}
             onImportRoutinePackage={canManageRoutines ? bindOptionalRepository(repository.importRoutinePackage) : undefined}
             onRevokeSharedRoutine={canManageRoutines ? bindOptionalRepository(repository.revokeSharedRoutine) : undefined}
-            onSelectParticipant={selectActiveParticipant}
+            onSelectParticipant={selectParticipantContext}
             onSaveMonitoringPlan={canManageRoutines ? async (routineId, plan, validationMode) => {
               setSavingRoutineId(routineId);
               try {
@@ -812,7 +822,7 @@ export function App() {
             updateAccountProfile={withOptionalRepositorySync(repository.updateAccountProfile)}
             renameParticipant={withOptionalRepositorySync(repository.renameParticipant)}
             updateParticipantColor={withOptionalRepositorySync(repository.updateParticipantColor)}
-            selectParticipant={selectActiveParticipant}
+            selectParticipant={selectParticipantContext}
             createParticipant={withOptionalRepositorySync(repository.createParticipant)}
             inviteParticipantMember={bindOptionalRepository(repository.inviteParticipantMember)}
             acceptParticipantInvitation={withOptionalRepositorySync(repository.acceptParticipantInvitation)}
@@ -855,7 +865,7 @@ export function App() {
               } : undefined}
               summaryRange={dashboardSummaryRange}
               onSummaryRangeChange={setDashboardSummaryRange}
-              onSelectParticipant={selectActiveParticipant}
+              onSelectParticipant={selectParticipantContext}
               onOpenNotificationEvent={(participantId, event) => { void openNotificationEvent(participantId, event); }}
               notificationEventId={focusedDashboardEventId}
               onNotificationEventConsumed={() => setFocusedDashboardEventId(undefined)}
@@ -877,7 +887,10 @@ export function App() {
     content = (
       <PullToUpdate
         onHorizontalSwipe={(direction) => {
-          const hasMultipleParticipants = (state.participantAccess?.filter((entry) => entry.membership.status === 'active').length ?? 0) > 1;
+          const hasMultipleParticipants = hasMultipleParticipantsForSwipe(
+            state.participantAccess?.filter((entry) => entry.membership.status === 'active').length ?? 0,
+            state.notificationSources?.length ?? 0,
+          );
           if (shouldShowParticipantOverviewAfterSwipe(role, tab, direction, hasMultipleParticipants, participantOverview)) {
             setParticipantOverview(true);
             writeUiStorageString(PARTICIPANT_OVERVIEW_STORAGE_KEY, 'overview');

--- a/src/screens/ParentDashboard.test.tsx
+++ b/src/screens/ParentDashboard.test.tsx
@@ -161,7 +161,6 @@ describe('ParentDashboard', () => {
 
     act(() => container.querySelector<HTMLButtonElement>('.history-row-open-button')?.click());
     expect(selectParticipant).toHaveBeenCalledWith('maya');
-    expect(setParticipantOverview).toHaveBeenCalledWith(false);
   });
 
   it('shows an actionable repeated-failure trend and keeps it dismissed until a new failure', async () => {

--- a/src/screens/ParentDashboard.tsx
+++ b/src/screens/ParentDashboard.tsx
@@ -256,7 +256,6 @@ export function ParentDashboard({
   const hasMultipleParticipants = notificationSources.length > 1;
   const showParticipantOverview = hasMultipleParticipants && participantOverview;
   const selectParticipant = (participantId: string) => {
-    onParticipantOverviewChange?.(false);
     onSelectParticipant?.(participantId);
   };
   useEffect(() => {


### PR DESCRIPTION
## Résumé
- centralise la sélection d’un participant afin de quitter correctement la vue collective avant le chargement du profil
- détecte la présence de plusieurs participants depuis les accès actifs ou les sources de notification
- préserve ainsi la destination « Tous les participants » pendant la synchronisation des relations
- passe l’application en version 0.11.10

## Validation
- tests ciblés App, ParentDashboard et PullToUpdate : 46 réussis
- `tsc -b`
- `pnpm check:architecture`
- `pnpm check:design`
- `git diff --check`