### PR TITLE
Refine participant accents in history

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zadiag-pwa",
   "private": true,
-  "version": "0.11.10",
+  "version": "0.11.11",
   "type": "module",
   "packageManager": "pnpm@11.7.0",
   "engines": {

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -1009,7 +1009,18 @@ button:disabled { cursor: not-allowed; }
 .participant-switcher-option-avatar { width: 32px; height: 32px; display: grid; place-items: center; border-radius: 10px; background: #eef5f3; color: var(--profile-color, var(--color-primary)); font-size: 13px; font-weight: 900; }
 .participant-switcher-overview-avatar .svg-icon { font-size: 18px; }
 .participant-switcher-menu button.active .participant-switcher-option-avatar { background: var(--color-surface-solid); }
-.parent-history-row.has-participant-accent { border-inline-start: 4px solid var(--history-participant-color); }
+.parent-history-row.has-participant-accent {
+  position: relative;
+}
+.parent-history-row.has-participant-accent::before {
+  content: "";
+  position: absolute;
+  inset-block: 12px;
+  inset-inline-start: 0;
+  width: 3px;
+  border-radius: 0 2px 2px 0;
+  background: var(--history-participant-color);
+}
 .filter-chips .participant-filter-chip { border-color: color-mix(in srgb, var(--profile-color) 24%, var(--color-border)); background: color-mix(in srgb, var(--profile-color) 7%, var(--color-surface-solid)); color: var(--profile-color); }
 .filter-chips .participant-filter-chip.active { border-color: var(--profile-color); background: var(--profile-color); color: var(--color-surface-solid); }
 .participant-switcher-static .profile-context-card { cursor: default; }


### PR DESCRIPTION
## Résumé
- remplace la bordure colorée arrondie des cartes d’historique par un trait vertical intérieur plus fin
- détache l’accent du haut et du bas de la carte pour préserver sa silhouette
- conserve la couleur du participant comme repère contextuel
- passe l’application en version 0.11.11

## Cause
Le liseré utilisait directement la bordure gauche de la carte et suivait donc fortement ses coins arrondis.

## Validation
- `pnpm check`
- 332 tests application réussis
- 131 tests fonctions réussis
- architecture, design, build et bundle validés