### PR TITLE
Compact history filter chips

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zadiag-pwa",
   "private": true,
-  "version": "0.11.14",
+  "version": "0.11.15",
   "type": "module",
   "packageManager": "pnpm@11.7.0",
   "engines": {

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -748,7 +748,7 @@ button:disabled { cursor: not-allowed; }
 .filter-group > span { color: var(--color-text-muted); font-size: 12px; font-weight: 900; letter-spacing: .08em; text-transform: uppercase; }
 .filter-chips { display: flex; flex-wrap: wrap; gap: 7px; overflow: visible; padding-bottom: 0; scrollbar-width: none; }
 .filter-chips::-webkit-scrollbar { display: none; }
-.filter-chips button { flex: 0 1 auto; min-height: var(--height-action); max-width: 100%; padding: 6px 12px; border: 1px solid transparent; border-radius: 11px; background: var(--color-control-surface); color: var(--color-text-muted); font-size: 12px; font-weight: 800; line-height: 1.05; white-space: normal; }
+.filter-chips button { flex: 0 1 auto; min-height: 32px; max-width: 100%; padding: 3px 12px; border: 1px solid transparent; border-radius: 11px; background: var(--color-control-surface); color: var(--color-text-muted); font-size: 12px; font-weight: 800; line-height: 1.05; white-space: normal; }
 .filter-chips button.active { background: var(--color-text); color: var(--color-surface-solid); box-shadow: 0 4px 12px rgba(16,42,67,.16); }
 .filter-chips .filter-status-detected,
 .filter-chips .filter-status-answered { background: var(--color-primary-soft); color: var(--color-primary); }
@@ -2159,10 +2159,15 @@ button:disabled { cursor: not-allowed; }
 }
 .settings-locale-toggle button,
 .summary-range-toggle button,
-.filter-chips button,
 .routine-tabs button {
   min-height: var(--height-action);
   padding: 5px 8px;
+  font-size: 11px;
+  font-weight: 700;
+}
+.filter-chips button {
+  min-height: 32px;
+  padding: 3px 8px;
   font-size: 11px;
   font-weight: 700;
 }


### PR DESCRIPTION
## Résumé
- réduit la hauteur minimale des chips de filtre de 36 à 32 px
- réduit leur padding vertical de 6 à 3 px
- conserve un rendu compact cohérent sur mobile
- passe l’application en version 0.11.15

## Validation
- `pnpm check`
- 332 tests application réussis
- 131 tests fonctions réussis
- architecture, design, build et bundle validés