### PR TITLE
Group individual summary filters and history

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zadiag-pwa",
   "private": true,
-  "version": "0.11.18",
+  "version": "0.11.19",
   "type": "module",
   "packageManager": "pnpm@11.7.0",
   "engines": {

--- a/src/components/RoutineHistoryPanel.tsx
+++ b/src/components/RoutineHistoryPanel.tsx
@@ -161,7 +161,6 @@ export function RoutineHistoryPanel({
 
   return (
     <section className="routine-history-panel" aria-labelledby={titleId}>
-      <div className="section-heading parent-history-heading"><h2 id={titleId}>{t('recentHistory')}</h2></div>
       {sortedEvents.length ? (
         <>
           <section className="card history-filter-card" aria-label={t('historyFilters')}>
@@ -197,6 +196,7 @@ export function RoutineHistoryPanel({
             </div>
           </section>
 
+          <div className="section-heading parent-history-heading"><h2 id={titleId}>{t('recentHistory')}</h2></div>
           <div className="section-heading history-results-heading"><h2>{t('historyResults')}</h2><span>{filtered.length}</span></div>
           <div className="history-list parent-history-list">
             {filtered.map((event) => {
@@ -261,7 +261,10 @@ export function RoutineHistoryPanel({
           </div>
         </>
       ) : (
-        <EmptyState icon="time" title={t('noHistoryYet')} detail={t('noHistoryYetHint')} />
+        <>
+          <div className="section-heading parent-history-heading"><h2 id={titleId}>{t('recentHistory')}</h2></div>
+          <EmptyState icon="time" title={t('noHistoryYet')} detail={t('noHistoryYetHint')} />
+        </>
       )}
     </section>
   );

--- a/src/screens/ParentDashboard.test.tsx
+++ b/src/screens/ParentDashboard.test.tsx
@@ -63,6 +63,15 @@ describe('ParentDashboard', () => {
     expect(container.textContent).not.toContain('StatusAll');
     expect(container.textContent).not.toContain('Monitoring plan');
     expect(container.textContent).not.toContain('Needs attention');
+    const coreDashboard = container.querySelector('.parent-dashboard-overview-section');
+    const summaryCard = coreDashboard?.querySelector('.adherence-summary-card');
+    const filterCard = coreDashboard?.querySelector('.history-filter-card');
+    const historyHeading = coreDashboard?.querySelector('.parent-history-heading');
+    expect(summaryCard).not.toBeNull();
+    expect(filterCard).not.toBeNull();
+    expect(historyHeading).not.toBeNull();
+    expect(Boolean(summaryCard!.compareDocumentPosition(filterCard!) & Node.DOCUMENT_POSITION_FOLLOWING)).toBe(true);
+    expect(Boolean(filterCard!.compareDocumentPosition(historyHeading!) & Node.DOCUMENT_POSITION_FOLLOWING)).toBe(true);
     const detailedReport = container.querySelector<HTMLDetailsElement>('.detailed-reporting');
     expect(detailedReport?.open).toBe(false);
     expect(detailedReport?.querySelector('summary')?.textContent).toBe('Detailed report');

--- a/src/screens/ParentDashboard.tsx
+++ b/src/screens/ParentDashboard.tsx
@@ -319,6 +319,7 @@ export function ParentDashboard({
       <section className="today-section participant-history-section dashboard-summary-section parent-dashboard-overview-section" aria-labelledby="responsible-summary-title">
         <h2 id="responsible-summary-title">{t('overview')}</h2>
         <AdherenceSummaryCard events={displayEvents} assignments={state.routineAssignments} locale={state.locale} subjectName={reportSubjectName} range={summaryRange} onRangeChange={setSummaryRange} detailedReportOpenSignal={weeklyReportOpenSignal} t={t} />
+        <RoutineHistoryPanel assignments={state.routineAssignments} events={rangedRawEvents} locale={state.locale} titleId="responsible-history-title" colorForEvent={activeParticipantAccess ? () => profileColorFor(activeParticipantAccess.participant) : undefined} onRequestCheck={requestCheck} onOpenEvent={(event) => setDetailEventId(event.id)} t={t} />
       </section>
       {setupStep ? (
         <section className="card parent-onboarding-card" aria-labelledby="parent-onboarding-title">
@@ -642,9 +643,6 @@ export function ParentDashboard({
         />
       ) : null}
 
-      <section className="today-section participant-history-section parent-history-section">
-        <RoutineHistoryPanel assignments={state.routineAssignments} events={rangedRawEvents} locale={state.locale} titleId="responsible-history-title" colorForEvent={activeParticipantAccess ? () => profileColorFor(activeParticipantAccess.participant) : undefined} onRequestCheck={requestCheck} onOpenEvent={(event) => setDetailEventId(event.id)} t={t} />
-      </section>
       {detailEvent ? <VerificationEventDetailDialog event={detailEvent} locale={state.locale} proofUrl={proofUrls[detailEvent.id]} getProofImageUrl={getProofImageUrl} reviewCheck={reviewCheck} requestCheck={requestCheck} onClose={() => setDetailEventId(undefined)} t={t} /> : null}
       </>}
     </div>


### PR DESCRIPTION
## Résumé
- regroupe la synthèse, les filtres et l’historique dans le Dashboard individuel
- place les filtres immédiatement après la synthèse et son bilan détaillé
- place l’historique juste après les filtres
- conserve les cartes opérationnelles sous ce bloc principal
- passe l’application en version 0.11.19

## Validation
- `pnpm check`
- 332 tests application réussis
- 131 tests fonctions réussis
- architecture, design, build et bundle validés