### PR TITLE
Show operational cards before dashboard summary

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zadiag-pwa",
   "private": true,
-  "version": "0.11.19",
+  "version": "0.11.20",
   "type": "module",
   "packageManager": "pnpm@11.7.0",
   "engines": {

--- a/src/screens/ParentDashboard.test.tsx
+++ b/src/screens/ParentDashboard.test.tsx
@@ -64,12 +64,15 @@ describe('ParentDashboard', () => {
     expect(container.textContent).not.toContain('Monitoring plan');
     expect(container.textContent).not.toContain('Needs attention');
     const coreDashboard = container.querySelector('.parent-dashboard-overview-section');
+    const operationalCards = container.querySelector('.parent-onboarding-card');
     const summaryCard = coreDashboard?.querySelector('.adherence-summary-card');
     const filterCard = coreDashboard?.querySelector('.history-filter-card');
     const historyHeading = coreDashboard?.querySelector('.parent-history-heading');
     expect(summaryCard).not.toBeNull();
     expect(filterCard).not.toBeNull();
     expect(historyHeading).not.toBeNull();
+    expect(operationalCards).not.toBeNull();
+    expect(Boolean(operationalCards!.compareDocumentPosition(coreDashboard!) & Node.DOCUMENT_POSITION_FOLLOWING)).toBe(true);
     expect(Boolean(summaryCard!.compareDocumentPosition(filterCard!) & Node.DOCUMENT_POSITION_FOLLOWING)).toBe(true);
     expect(Boolean(filterCard!.compareDocumentPosition(historyHeading!) & Node.DOCUMENT_POSITION_FOLLOWING)).toBe(true);
     const detailedReport = container.querySelector<HTMLDetailsElement>('.detailed-reporting');

--- a/src/screens/ParentDashboard.tsx
+++ b/src/screens/ParentDashboard.tsx
@@ -316,11 +316,6 @@ export function ParentDashboard({
       {showParticipantOverview ? (
         <MultiParticipantOverview sources={notificationSources} locale={state.locale} range={summaryRange} now={now} onRangeChange={setSummaryRange} onSelectParticipant={selectParticipant} t={t} />
       ) : <>
-      <section className="today-section participant-history-section dashboard-summary-section parent-dashboard-overview-section" aria-labelledby="responsible-summary-title">
-        <h2 id="responsible-summary-title">{t('overview')}</h2>
-        <AdherenceSummaryCard events={displayEvents} assignments={state.routineAssignments} locale={state.locale} subjectName={reportSubjectName} range={summaryRange} onRangeChange={setSummaryRange} detailedReportOpenSignal={weeklyReportOpenSignal} t={t} />
-        <RoutineHistoryPanel assignments={state.routineAssignments} events={rangedRawEvents} locale={state.locale} titleId="responsible-history-title" colorForEvent={activeParticipantAccess ? () => profileColorFor(activeParticipantAccess.participant) : undefined} onRequestCheck={requestCheck} onOpenEvent={(event) => setDetailEventId(event.id)} t={t} />
-      </section>
       {setupStep ? (
         <section className="card parent-onboarding-card" aria-labelledby="parent-onboarding-title">
           <div className="parent-onboarding-heading">
@@ -642,6 +637,12 @@ export function ParentDashboard({
           )}
         />
       ) : null}
+
+      <section className="today-section participant-history-section dashboard-summary-section parent-dashboard-overview-section" aria-labelledby="responsible-summary-title">
+        <h2 id="responsible-summary-title">{t('overview')}</h2>
+        <AdherenceSummaryCard events={displayEvents} assignments={state.routineAssignments} locale={state.locale} subjectName={reportSubjectName} range={summaryRange} onRangeChange={setSummaryRange} detailedReportOpenSignal={weeklyReportOpenSignal} t={t} />
+        <RoutineHistoryPanel assignments={state.routineAssignments} events={rangedRawEvents} locale={state.locale} titleId="responsible-history-title" colorForEvent={activeParticipantAccess ? () => profileColorFor(activeParticipantAccess.participant) : undefined} onRequestCheck={requestCheck} onOpenEvent={(event) => setDetailEventId(event.id)} t={t} />
+      </section>
 
       {detailEvent ? <VerificationEventDetailDialog event={detailEvent} locale={state.locale} proofUrl={proofUrls[detailEvent.id]} getProofImageUrl={getProofImageUrl} reviewCheck={reviewCheck} requestCheck={requestCheck} onClose={() => setDetailEventId(undefined)} t={t} /> : null}
       </>}


### PR DESCRIPTION
## Résumé
- place les cartes opérationnelles avant le bloc principal du Dashboard individuel
- conserve ensuite l’ordre synthèse, filtres, historique
- laisse la vue collective inchangée
- passe l’application en version 0.11.20

## Validation
- `pnpm check`
- 332 tests application réussis
- 131 tests fonctions réussis
- architecture, design, build et bundle validés