### PR TITLE
Add collective operational actions

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zadiag-pwa",
   "private": true,
-  "version": "0.11.20",
+  "version": "0.11.21",
   "type": "module",
   "packageManager": "pnpm@11.7.0",
   "engines": {

--- a/src/App.test.ts
+++ b/src/App.test.ts
@@ -1,6 +1,6 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { DEFAULT_ROUTINE_ID, type AppState, type VerificationEvent } from './domain/models';
-import { appBadgeCountForState, documentLanguageForLocale, hasMultipleParticipantsForSwipe, isParticipantInvitationCode, participantIdForNotificationLaunch, resetNoticeMessageKey, resolveNotificationLaunch, setupCompletionTransition, shouldShowParticipantOverviewAfterSwipe, syncStatusFor, syncStatusIsVisible } from './App';
+import { appBadgeCountForState, documentLanguageForLocale, hasMultipleParticipantsForSwipe, isParticipantInvitationCode, participantIdForNotificationLaunch, resetNoticeMessageKey, resolveNotificationLaunch, runParticipantAction, setupCompletionTransition, shouldShowParticipantOverviewAfterSwipe, syncStatusFor, syncStatusIsVisible } from './App';
 
 describe('shouldShowParticipantOverviewAfterSwipe', () => {
   it('uses the first left swipe from an individual responsible dashboard for the collective overview', () => {
@@ -17,6 +17,41 @@ describe('hasMultipleParticipantsForSwipe', () => {
     expect(hasMultipleParticipantsForSwipe(2, 0)).toBe(true);
     expect(hasMultipleParticipantsForSwipe(0, 2)).toBe(true);
     expect(hasMultipleParticipantsForSwipe(1, 1)).toBe(false);
+  });
+});
+
+describe('runParticipantAction', () => {
+  it('targets the requested participant and restores the previous context after success', async () => {
+    const selections: string[] = [];
+    let activeParticipantId = 'maya';
+    const selectParticipant = async (participantId: string) => {
+      selections.push(participantId);
+      activeParticipantId = participantId;
+    };
+    const settled = vi.fn();
+
+    const result = await runParticipantAction('leo', 'maya', selectParticipant, async () => activeParticipantId, settled);
+
+    expect(result).toBe('leo');
+    expect(selections).toEqual(['leo', 'maya']);
+    expect(activeParticipantId).toBe('maya');
+    expect(settled).toHaveBeenCalledOnce();
+  });
+
+  it('restores the previous context when the participant action fails', async () => {
+    const selections: string[] = [];
+    const settled = vi.fn();
+
+    await expect(runParticipantAction(
+      'leo',
+      'maya',
+      async (participantId) => { selections.push(participantId); },
+      async () => { throw new Error('action_failed'); },
+      settled,
+    )).rejects.toThrow('action_failed');
+
+    expect(selections).toEqual(['leo', 'maya']);
+    expect(settled).toHaveBeenCalledOnce();
   });
 });
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -79,6 +79,27 @@ export const appBadgeCountForState = (
 export const resetNoticeMessageKey = (role: Role | undefined): MessageKey =>
   role === 'parent' ? 'resetNoticeParent' : 'resetNoticeChild';
 
+export const runParticipantAction = async <TResult,>(
+  participantId: string,
+  previousParticipantId: string | undefined,
+  selectParticipant: (participantId: string) => Promise<void>,
+  action: () => Promise<TResult>,
+  onSettled: () => void,
+): Promise<TResult> => {
+  if (previousParticipantId !== participantId) await selectParticipant(participantId);
+  try {
+    return await action();
+  } finally {
+    try {
+      if (previousParticipantId && previousParticipantId !== participantId) {
+        await selectParticipant(previousParticipantId);
+      }
+    } finally {
+      onSettled();
+    }
+  }
+};
+
 export const shouldShowParticipantOverviewAfterSwipe = (
   role: Role,
   tab: Tab,
@@ -475,6 +496,19 @@ export function App() {
     writeUiStorageString(PARTICIPANT_OVERVIEW_STORAGE_KEY, 'individual');
     await selectActiveParticipant(participantId);
   } : undefined;
+  const runInParticipantContext = async <TResult,>(
+    participantId: string,
+    action: () => Promise<TResult>,
+  ): Promise<TResult> => {
+    if (!repository.selectActiveParticipant) throw new Error('participant_selection_unavailable');
+    return runParticipantAction(
+      participantId,
+      state.activeParticipantId,
+      repository.selectActiveParticipant,
+      action,
+      sync,
+    );
+  };
   const selectRole = async (role: Role) => {
     await repository.selectRole(role);
     sync();
@@ -854,6 +888,15 @@ export function App() {
               getProofImageUrl={(eventId) => repository.getProofImageUrl(eventId)}
               reviewCheck={canReviewProofs ? withRepositorySyncVoid(repository.reviewCheck) : undefined}
               requestCheck={canRequestChecks ? withRepositorySync(repository.requestCheckNow) : undefined}
+              reviewParticipantCheck={repository.selectActiveParticipant
+                ? (participantId, eventId, decision) => runInParticipantContext(participantId, () => repository.reviewCheck(eventId, decision)).then(() => undefined)
+                : undefined}
+              requestParticipantCheck={repository.selectActiveParticipant
+                ? (participantId, routineId) => runInParticipantContext(participantId, () => repository.requestCheckNow(routineId))
+                : undefined}
+              getParticipantProofImageUrl={repository.selectActiveParticipant
+                ? (participantId, eventId) => runInParticipantContext(participantId, () => repository.getProofImageUrl(eventId))
+                : undefined}
               updateRoutine={canManageRoutines ? async (routineId, plan) => {
                 setSavingRoutineId(routineId);
                 try {

--- a/src/components/MultiParticipantOverview.tsx
+++ b/src/components/MultiParticipantOverview.tsx
@@ -1,10 +1,18 @@
-import { useMemo, useState } from 'react';
-import type { Locale, ParticipantNotificationSource, RoutineAssignment, VerificationEvent } from '../domain/models';
+import { useEffect, useMemo, useState } from 'react';
+import type { Locale, ParticipantAccess, ParticipantNotificationSource, ReviewCheckDecision, RoutineAssignment, VerificationEvent } from '../domain/models';
 import { profileColorFor } from '../domain/profileColor';
-import { withResolvedEventStatuses } from '../domain/adherence';
+import { isReviewableVerification, withResolvedEventStatuses } from '../domain/adherence';
 import type { MessageKey } from '../services/i18n';
 import { AdherenceSummaryCard, filterEventsBySummaryRange, type SummaryRange } from './AdherenceSummaryCard';
 import { RoutineHistoryPanel } from './RoutineHistoryPanel';
+import { DashboardStatusSummary } from './DashboardStatusSummary';
+import { activePendingEvents, presentedAwaitingRoutineChecks, presentedUpcomingRoutineChecks } from '../domain/dashboardChecks';
+import { participantAccessCan } from '../domain/participantAccess';
+import { presentRoutine } from '../domain/routinePresentation';
+import { AppIcon, routineIconName } from './Icon';
+import { plannedWindowLabel } from '../domain/taskTimeLabel';
+import { languageTag } from '../services/locale';
+import { WeeklyInsightCard } from './WeeklyInsightCard';
 
 type CollectiveParticipant = { id: string; displayName: string; profileColor: string };
 type CollectiveEventContext = { participant: CollectiveParticipant };
@@ -47,6 +55,10 @@ export function MultiParticipantOverview({
   now,
   onRangeChange,
   onSelectParticipant,
+  participantAccess,
+  requestParticipantCheck,
+  reviewParticipantCheck,
+  getParticipantProofImageUrl,
   t,
 }: {
   sources: ParticipantNotificationSource[];
@@ -55,11 +67,21 @@ export function MultiParticipantOverview({
   now: number;
   onRangeChange: (range: SummaryRange) => void;
   onSelectParticipant: (participantId: string) => void;
+  participantAccess?: ParticipantAccess[];
+  requestParticipantCheck?: (participantId: string, routineId: string) => Promise<void>;
+  reviewParticipantCheck?: (participantId: string, eventId: string, decision: ReviewCheckDecision) => Promise<void>;
+  getParticipantProofImageUrl?: (participantId: string, eventId: string) => Promise<string>;
   t: (key: MessageKey) => string;
 }) {
   const { assignments, events, eventContext } = useMemo(() => collectiveDashboardData(sources), [sources]);
   const resolvedEvents = useMemo(() => withResolvedEventStatuses(events, now), [events, now]);
   const [excludedParticipantIds, setExcludedParticipantIds] = useState<string[]>([]);
+  const [expandedStatus, setExpandedStatus] = useState<'active' | 'review' | 'next'>();
+  const [requestingKey, setRequestingKey] = useState<string>();
+  const [reviewingKey, setReviewingKey] = useState<string>();
+  const [actionError, setActionError] = useState<'request' | 'review'>();
+  const [proofUrls, setProofUrls] = useState<Record<string, string>>({});
+  const [proofErrors, setProofErrors] = useState<Record<string, boolean>>({});
   const participants = sources.map((source) => ({
     id: source.participant.id,
     displayName: source.participant.displayName,
@@ -73,10 +95,170 @@ export function MultiParticipantOverview({
   )), [assignments, excludedParticipantIds]);
   const rangedEvents = useMemo(() => filterEventsBySummaryRange(visibleEvents, range), [range, visibleEvents]);
   const participantForEvent = (event: VerificationEvent) => eventContext.get(event.id)?.participant;
+  const operationalSources = useMemo(() => sources.map((source) => {
+    const access = participantAccess?.find((entry) => entry.participant.id === source.participant.id);
+    const participant = {
+      id: source.participant.id,
+      displayName: source.participant.displayName,
+      profileColor: profileColorFor(source.participant),
+    };
+    const presentationFor = (routineId: string) => {
+      const assignment = source.assignments.find((item) => item.routineId === routineId);
+      return assignment ? presentRoutine(assignment.routine, locale) : { name: t('routine'), icon: undefined, style: {} };
+    };
+    return {
+      participant,
+      canRequest: Boolean(requestParticipantCheck && participantAccessCan(access, 'requestChecks')),
+      canReview: Boolean(reviewParticipantCheck && participantAccessCan(access, 'reviewProofs')),
+      active: activePendingEvents(source.events, now).map((event) => ({
+        event,
+        presentation: presentationFor(event.routineId),
+      })),
+      awaiting: presentedAwaitingRoutineChecks(source.assignments, source.events, locale, new Date(now)),
+      review: source.events.filter(isReviewableVerification)
+        .sort((left, right) => Date.parse(right.capturedAt ?? right.requestedAt) - Date.parse(left.capturedAt ?? left.requestedAt)),
+      upcoming: presentedUpcomingRoutineChecks(source.assignments, locale, new Date(now)),
+      presentationFor,
+    };
+  }), [locale, now, participantAccess, requestParticipantCheck, reviewParticipantCheck, sources, t]);
+  const activeCount = operationalSources.reduce((count, source) => count + source.active.length + source.awaiting.length, 0);
+  const reviewCount = operationalSources.reduce((count, source) => count + source.review.length, 0);
+  const upcomingCount = operationalSources.reduce((count, source) => count + source.upcoming.length, 0);
+  useEffect(() => {
+    if (expandedStatus !== 'review' || !getParticipantProofImageUrl) return;
+    let cancelled = false;
+    const loadProofs = async () => {
+      for (const source of operationalSources) {
+        for (const event of source.review) {
+          const key = `${source.participant.id}:${event.id}`;
+          if (proofUrls[key] || proofErrors[key]) continue;
+          try {
+            const url = await getParticipantProofImageUrl(source.participant.id, event.id);
+            if (!cancelled) setProofUrls((current) => ({ ...current, [key]: url }));
+          } catch (error) {
+            console.error(error);
+            if (!cancelled) setProofErrors((current) => ({ ...current, [key]: true }));
+          }
+        }
+      }
+    };
+    void loadProofs();
+    return () => { cancelled = true; };
+  }, [expandedStatus, getParticipantProofImageUrl, operationalSources, proofErrors, proofUrls]);
+  const request = async (participantId: string, routineId: string) => {
+    if (!requestParticipantCheck || requestingKey) return;
+    const key = `${participantId}:${routineId}`;
+    setRequestingKey(key);
+    setActionError(undefined);
+    try {
+      await requestParticipantCheck(participantId, routineId);
+    } catch (error) {
+      console.error(error);
+      setActionError('request');
+    } finally {
+      setRequestingKey(undefined);
+    }
+  };
+  const review = async (participantId: string, eventId: string, decision: ReviewCheckDecision) => {
+    if (!reviewParticipantCheck || reviewingKey) return;
+    const key = `${participantId}:${eventId}`;
+    setReviewingKey(key);
+    setActionError(undefined);
+    try {
+      await reviewParticipantCheck(participantId, eventId, decision);
+    } catch (error) {
+      console.error(error);
+      setActionError('review');
+    } finally {
+      setReviewingKey(undefined);
+    }
+  };
 
   return (
     <section className="today-section participant-history-section parent-history-section dashboard-summary-section multi-participant-overview" aria-labelledby="collective-summary-title">
       <h2 id="collective-summary-title">{t('overview')}</h2>
+      <DashboardStatusSummary
+        label={t('dashboardStatusSummary')}
+        items={[
+          { id: 'active', label: t('dashboardActive'), value: activeCount },
+          { id: 'review', label: t('dashboardReview'), value: reviewCount, tone: 'attention' },
+          { id: 'next', label: t('dashboardNext'), value: upcomingCount },
+        ]}
+        selectedId={expandedStatus}
+        onSelect={(id) => setExpandedStatus((current) => current === id ? undefined : id as typeof current)}
+      />
+      {expandedStatus === 'active' && activeCount ? (
+        <section className="settings-section collective-operational-section" aria-label={t('dashboardActive')}>
+          <div className="today-task-list">
+            {operationalSources.flatMap((source) => [
+              ...source.active.map(({ event, presentation }) => (
+                <article className="today-task today-routine-card parent-active-check-card actionable" style={presentation.style} key={`${source.participant.id}:${event.id}`}>
+                  <div className="today-task-copy">
+                    <span className="settings-row-icon today-task-icon" aria-hidden="true"><AppIcon name={routineIconName(presentation.icon)} /></span>
+                    <div><h3>{presentation.name}</h3><p>{source.participant.displayName}</p></div>
+                  </div>
+                  {source.canRequest ? <button type="button" className="primary-action-button parent-remind-button" disabled={Boolean(requestingKey)} onClick={() => { void request(source.participant.id, event.routineId); }}>{requestingKey === `${source.participant.id}:${event.routineId}` ? t('requestingCheck') : t('requestCheckShort')}</button> : null}
+                </article>
+              )),
+              ...source.awaiting.map((item) => (
+                <article className="today-task today-routine-card parent-active-check-card actionable" style={item.presentation.style} key={`${source.participant.id}:awaiting:${item.id}`}>
+                  <div className="today-task-copy">
+                    <span className="settings-row-icon today-task-icon" aria-hidden="true"><AppIcon name={routineIconName(item.presentation.icon)} /></span>
+                    <div><h3>{item.presentation.name}</h3><p>{source.participant.displayName}</p></div>
+                  </div>
+                  {source.canRequest ? <button type="button" className="primary-action-button parent-remind-button" disabled={Boolean(requestingKey)} onClick={() => { void request(source.participant.id, item.routineId); }}>{requestingKey === `${source.participant.id}:${item.routineId}` ? t('requestingCheck') : t('requestCheckShort')}</button> : null}
+                </article>
+              )),
+            ])}
+            {actionError === 'request' ? <span className="request-feedback error" role="alert">{t('requestCheckError')}</span> : null}
+          </div>
+        </section>
+      ) : null}
+      {expandedStatus === 'review' && reviewCount ? (
+        <section className="settings-section parent-review-section collective-operational-section" aria-label={t('dashboardReview')}>
+          <div className="parent-review-list">
+            {operationalSources.flatMap((source) => source.review.map((event) => {
+              const presentation = source.presentationFor(event.routineId);
+              const key = `${source.participant.id}:${event.id}`;
+              return (
+                <article className="card parent-review-card" key={key}>
+                  <div className="parent-review-main">
+                    {getParticipantProofImageUrl ? <div className="parent-review-image">{proofUrls[key]
+                      ? <img src={proofUrls[key]} alt={t('responsibleReviewImageAlt')} />
+                      : <div role="status">{proofErrors[key] ? t('responsibleReviewImageError') : t('loadingProofImage')}</div>}</div> : null}
+                    <div className="parent-review-copy"><strong>{presentation.name}</strong><small>{source.participant.displayName}</small>{event.reason ? <p>{event.reason}</p> : null}</div>
+                    <div className="parent-review-actions">
+                      {source.canReview ? <button type="button" className="parent-review-button reject" aria-label={t('responsibleReviewReject')} disabled={Boolean(reviewingKey)} onClick={() => { void review(source.participant.id, event.id, 'not_detected'); }}><AppIcon name="close" /></button> : null}
+                      {source.canReview ? <button type="button" className="parent-review-button approve" aria-label={t('responsibleReviewApprove')} disabled={Boolean(reviewingKey)} onClick={() => { void review(source.participant.id, event.id, 'detected'); }}><AppIcon name="check" /></button> : null}
+                    </div>
+                  </div>
+                </article>
+              );
+            }))}
+            {actionError === 'review' ? <p className="request-feedback error" role="alert">{t('responsibleReviewError')}</p> : null}
+          </div>
+        </section>
+      ) : null}
+      {expandedStatus === 'next' && upcomingCount ? (
+        <section className="today-section upcoming-checks-section collective-operational-section" aria-label={t('dashboardNext')}>
+          <div className="upcoming-checks-list">
+            {operationalSources.flatMap((source) => source.upcoming.map((item) => (
+              <article className="upcoming-check-card" style={item.presentation.style} key={`${source.participant.id}:${item.id}`}>
+                <span className="settings-row-icon today-task-icon" aria-hidden="true"><AppIcon name={routineIconName(item.presentation.icon)} /></span>
+                <div><h3>{item.presentation.name}</h3><p>{source.participant.displayName} · {plannedWindowLabel(item.planned.start, item.planned.end, new Date(now), languageTag(locale), t)}</p></div>
+              </article>
+            )))}
+          </div>
+        </section>
+      ) : null}
+      <WeeklyInsightCard
+        assignments={assignments}
+        events={resolvedEvents}
+        locale={locale}
+        now={now}
+        onOpenReport={() => onRangeChange('week')}
+        t={t}
+      />
       <AdherenceSummaryCard
         events={visibleEvents}
         assignments={visibleAssignments}

--- a/src/components/WeeklyInsightCard.tsx
+++ b/src/components/WeeklyInsightCard.tsx
@@ -1,0 +1,70 @@
+import { useMemo, useState } from 'react';
+import type { Locale, RoutineAssignment, VerificationEvent } from '../domain/models';
+import { weeklyInsight } from '../domain/reporting';
+import { presentRoutine } from '../domain/routinePresentation';
+import type { MessageKey } from '../services/i18n';
+import { DisclosureToggle } from './DisclosureToggle';
+import { AppIcon } from './Icon';
+
+export function WeeklyInsightCard({
+  assignments,
+  events,
+  locale,
+  now,
+  onOpenReport,
+  t,
+}: {
+  assignments: RoutineAssignment[];
+  events: VerificationEvent[];
+  locale: Locale;
+  now: number;
+  onOpenReport: () => void;
+  t: (key: MessageKey) => string;
+}) {
+  const [open, setOpen] = useState(false);
+  const insight = useMemo(() => weeklyInsight(assignments, events, now), [assignments, events, now]);
+  const routineNames = useMemo(() => new Map(assignments.map((assignment) => [
+    assignment.routineId,
+    presentRoutine(assignment.routine, locale).name,
+  ])), [assignments, locale]);
+  const priorityKey: MessageKey | undefined = insight ? {
+    adjust_schedule: 'weeklyPriorityAdjustSchedule',
+    review_proofs: 'weeklyPriorityReviewProofs',
+    support_consistency: 'weeklyPrioritySupportConsistency',
+    keep_course: 'weeklyPriorityKeepCourse',
+  }[insight.priority] as MessageKey : undefined;
+
+  return (
+    <section className="card weekly-insight-card" aria-labelledby="weekly-insight-title">
+      <div className="weekly-insight-heading">
+        <div><span className="eyebrow">{t('weeklyInsightEyebrow')}</span><h2 id="weekly-insight-title">{t('weeklyInsightTitle')}</h2></div>
+        <span className="weekly-insight-rate"><strong>{insight ? `${Math.round(insight.rate * 100)}%` : '—'}</strong></span>
+        <DisclosureToggle
+          expanded={open}
+          showLabel={t('weeklyInsightShow')}
+          hideLabel={t('weeklyInsightHide')}
+          onToggle={() => setOpen((current) => !current)}
+        />
+      </div>
+      {open ? <div className="weekly-insight-content">
+        {insight && priorityKey ? (
+          <>
+            <p className="weekly-insight-evolution">{insight.rateDelta === undefined
+              ? t('summaryNoPreviousBaseline')
+              : insight.rateDelta === 0
+                ? t('summaryComparedStable')
+                : `${t(insight.rateDelta > 0 ? 'weeklyInsightUp' : 'weeklyInsightDown')} ${Math.abs(Math.round(insight.rateDelta * 100))} ${t('summaryPoints')}`}</p>
+            <div className="weekly-insight-metrics">
+              {insight.strongestRoutineId && insight.strongestRoutineId !== insight.watchRoutineId ? <span><small>{t('weeklyInsightStrongest')}</small><strong>{routineNames.get(insight.strongestRoutineId) ?? t('routine')}</strong></span> : null}
+              {insight.watchRoutineId ? <span><small>{t('weeklyInsightWatch')}</small><strong>{routineNames.get(insight.watchRoutineId) ?? t('routine')}</strong></span> : null}
+              {insight.bestWindow ? <span><small>{t('weeklyInsightBestWindow')}</small><strong>{insight.bestWindow.start}–{insight.bestWindow.end}</strong></span> : null}
+              <span><small>{t('weeklyInsightResponsibleActions')}</small><strong>{insight.responsibleActions.length ? insight.responsibleActions.map((actor) => `${actor.actorName} · ${actor.count}`).join(', ') : insight.responsibleActionCount}</strong></span>
+            </div>
+            <div className="weekly-insight-priority"><AppIcon name="sparkles" /><p><small>{t('weeklyInsightPriority')}</small><strong>{t(priorityKey)}</strong></p></div>
+            <button type="button" onClick={onOpenReport}>{t('weeklyInsightOpenReport')}</button>
+          </>
+        ) : <p className="weekly-insight-empty">{t('weeklyInsightEmpty')}</p>}
+      </div> : null}
+    </section>
+  );
+}

--- a/src/screens/ParentDashboard.test.tsx
+++ b/src/screens/ParentDashboard.test.tsx
@@ -114,11 +114,12 @@ describe('ParentDashboard', () => {
     expect(container.querySelector('.screen-header h1')?.textContent).toBe('Activity');
   });
 
-  it('reuses the individual dashboard with participant filters and context labels', () => {
+  it('reuses the individual dashboard with participant filters and context labels', async () => {
     const now = new Date().toISOString();
     const threeDaysAgo = new Date(Date.now() - 3 * 86_400_000).toISOString();
     const assignment = createDefaultRoutineAssignment(now);
     const selectParticipant = vi.fn();
+    const reviewParticipantCheck = vi.fn().mockResolvedValue(undefined);
     const state: AppState = {
       role: 'parent', locale: 'en', notificationsEnabled: true, activeParticipantId: 'maya',
       family: { linked: true, childLinked: true, childName: 'Maya', linkingCode: '', parentRecoveryCode: '', consented: true },
@@ -144,11 +145,16 @@ describe('ParentDashboard', () => {
     };
 
     const setParticipantOverview = vi.fn();
-    act(() => root.render(<ParentDashboard state={state} participantOverview onParticipantOverviewChange={setParticipantOverview} onSelectParticipant={selectParticipant} t={(key) => translate('en', key)} />));
+    act(() => root.render(<ParentDashboard state={state} participantOverview onParticipantOverviewChange={setParticipantOverview} onSelectParticipant={selectParticipant} reviewParticipantCheck={reviewParticipantCheck} t={(key) => translate('en', key)} />));
 
     expect(container.querySelector('.multi-participant-overview')).not.toBeNull();
     expect(container.querySelector('.adherence-summary-card')).not.toBeNull();
     expect(container.querySelector('.history-filter-card')).not.toBeNull();
+    const collectiveStatus = container.querySelector('.dashboard-status-summary');
+    const collectiveWeekly = container.querySelector('.weekly-insight-card');
+    const collectiveSummary = container.querySelector('.adherence-summary-card');
+    expect(Boolean(collectiveStatus!.compareDocumentPosition(collectiveWeekly!) & Node.DOCUMENT_POSITION_FOLLOWING)).toBe(true);
+    expect(Boolean(collectiveWeekly!.compareDocumentPosition(collectiveSummary!) & Node.DOCUMENT_POSITION_FOLLOWING)).toBe(true);
     expect(Array.from(container.querySelectorAll('.filter-group > span')).map((label) => label.textContent)).toEqual(['Participant', 'Routine', 'Status']);
     expect(container.textContent).toContain('Results');
     expect(container.querySelectorAll('.parent-history-row')).toHaveLength(2);
@@ -164,6 +170,15 @@ describe('ParentDashboard', () => {
     expect(participantChips.every((chip) => chip.style.getPropertyValue('--profile-color').length > 0)).toBe(true);
     expect(new Set(Array.from(container.querySelectorAll<HTMLElement>('.has-participant-accent')).map((row) => row.style.getPropertyValue('--history-participant-color'))).size).toBe(2);
     expect(container.textContent).toContain('Detailed report');
+    const reviewStatus = Array.from(container.querySelectorAll<HTMLButtonElement>('.dashboard-status-summary button'))
+      .find((button) => button.textContent?.includes('To review'));
+    act(() => reviewStatus?.click());
+    const collectiveReview = container.querySelector('.collective-operational-section');
+    expect(Boolean(collectiveReview?.compareDocumentPosition(collectiveWeekly!) & Node.DOCUMENT_POSITION_FOLLOWING)).toBe(true);
+    await act(async () => {
+      container.querySelector<HTMLButtonElement>('.collective-operational-section .parent-review-button.approve')?.click();
+    });
+    expect(reviewParticipantCheck).toHaveBeenCalledWith('leo', 'leo-review', 'detected');
 
     const leoFilter = Array.from(container.querySelectorAll<HTMLButtonElement>('.filter-group:first-child button'))
       .find((button) => button.textContent === 'Leo');
@@ -173,6 +188,41 @@ describe('ParentDashboard', () => {
 
     act(() => container.querySelector<HTMLButtonElement>('.history-row-open-button')?.click());
     expect(selectParticipant).toHaveBeenCalledWith('maya');
+  });
+
+  it('requests a collective active check for its owning participant', async () => {
+    const now = new Date().toISOString();
+    const assignment = createDefaultRoutineAssignment(now);
+    const requestParticipantCheck = vi.fn().mockResolvedValue(undefined);
+    const state: AppState = {
+      role: 'parent', locale: 'en', notificationsEnabled: true, activeParticipantId: 'maya',
+      family: { linked: true, childLinked: true, childName: 'Maya', linkingCode: '', parentRecoveryCode: '', consented: true },
+      participantAccess: [
+        { participant: { id: 'maya', displayName: 'Maya', profileColor: 'violet' }, membership: { role: 'owner', status: 'active' } },
+        { participant: { id: 'leo', displayName: 'Leo', profileColor: 'teal' }, membership: { role: 'caregiver', status: 'active' } },
+      ],
+      notificationSources: [
+        { participant: { id: 'maya', displayName: 'Maya', profileColor: 'violet' }, role: 'parent', assignments: [assignment], events: [] },
+        {
+          participant: { id: 'leo', displayName: 'Leo', profileColor: 'teal' }, role: 'parent', assignments: [assignment],
+          events: [{ id: 'leo-active', routineId: assignment.routineId, sessionId: 'leo', requestedAt: now, expiresAt: new Date(Date.now() + 3_600_000).toISOString(), status: 'pending' }],
+        },
+      ],
+      routineAssignments: [assignment],
+      events: [],
+    };
+
+    act(() => root.render(<ParentDashboard state={state} participantOverview requestParticipantCheck={requestParticipantCheck} t={(key) => translate('en', key)} />));
+    const activeStatus = Array.from(container.querySelectorAll<HTMLButtonElement>('.dashboard-status-summary button'))
+      .find((button) => button.textContent?.includes('Active'));
+    act(() => activeStatus?.click());
+    const leoCard = Array.from(container.querySelectorAll<HTMLElement>('.collective-operational-section .parent-active-check-card'))
+      .find((card) => card.textContent?.includes('Leo'));
+    await act(async () => {
+      leoCard?.querySelector<HTMLButtonElement>('button')?.click();
+    });
+
+    expect(requestParticipantCheck).toHaveBeenCalledWith('leo', assignment.routineId);
   });
 
   it('shows an actionable repeated-failure trend and keeps it dismissed until a new failure', async () => {
@@ -774,7 +824,10 @@ describe('ParentDashboard', () => {
     expect(container.textContent).toContain('Checks to verify');
     expect(Array.from(container.querySelectorAll('.dashboard-status-summary strong')).map((item) => item.textContent)).toEqual(['0', '1', '1']);
     const reviewSection = container.querySelector('.parent-review-section');
+    const weeklyInsight = container.querySelector('.weekly-insight-card');
     expect(reviewSection).not.toBeNull();
+    expect(weeklyInsight).not.toBeNull();
+    expect(Boolean(reviewSection!.compareDocumentPosition(weeklyInsight!) & Node.DOCUMENT_POSITION_FOLLOWING)).toBe(true);
     expect(container.querySelector('.upcoming-checks-section')).toBeNull();
     expect(container.textContent).toContain('Expected proof: Mouth photo');
     expect(container.textContent).toContain('Source: AI');

--- a/src/screens/ParentDashboard.tsx
+++ b/src/screens/ParentDashboard.tsx
@@ -21,9 +21,9 @@ import { NotificationCenter } from '../components/NotificationCenter';
 import { AwaitingCheckCards } from '../components/AwaitingCheckCards';
 import { useCurrentTime } from '../hooks/useCurrentTime';
 import { VerificationEventDetailDialog } from '../components/VerificationEventDetailDialog';
-import { planningRecommendation, routineAnomalies, weeklyInsight } from '../domain/reporting';
-import { DisclosureToggle } from '../components/DisclosureToggle';
+import { planningRecommendation, routineAnomalies } from '../domain/reporting';
 import { MultiParticipantOverview } from '../components/MultiParticipantOverview';
+import { WeeklyInsightCard } from '../components/WeeklyInsightCard';
 
 export function ParentDashboard({
   state,
@@ -34,6 +34,9 @@ export function ParentDashboard({
   getProofImageUrl,
   reviewCheck,
   requestCheck,
+  reviewParticipantCheck,
+  requestParticipantCheck,
+  getParticipantProofImageUrl,
   updateRoutine,
   summaryRange: controlledSummaryRange,
   onSummaryRangeChange,
@@ -51,6 +54,9 @@ export function ParentDashboard({
   getProofImageUrl?: (eventId: string) => Promise<string>;
   reviewCheck?: (eventId: string, decision: ReviewCheckDecision) => Promise<void>;
   requestCheck?: (routineId: string) => Promise<void>;
+  reviewParticipantCheck?: (participantId: string, eventId: string, decision: ReviewCheckDecision) => Promise<void>;
+  requestParticipantCheck?: (participantId: string, routineId: string) => Promise<void>;
+  getParticipantProofImageUrl?: (participantId: string, eventId: string) => Promise<string>;
   updateRoutine?: (routineId: string, plan: MonitoringPlan) => Promise<void>;
   summaryRange?: SummaryRange;
   onSummaryRangeChange?: (range: SummaryRange) => void;
@@ -76,7 +82,6 @@ export function ParentDashboard({
   const [planningRecommendationOpen, setPlanningRecommendationOpen] = useState(false);
   const [planningRecommendationStatus, setPlanningRecommendationStatus] = useState<'saving' | 'saved' | 'error'>();
   const [weeklyReportOpenSignal, setWeeklyReportOpenSignal] = useState(0);
-  const [weeklyInsightOpen, setWeeklyInsightOpen] = useState(false);
   const swipeStartRef = useRef<{ eventId: string; x: number; y: number } | undefined>(undefined);
   const swipeDecisionRef = useRef(false);
   const handledNotificationEventIdRef = useRef<string | undefined>(undefined);
@@ -121,13 +126,6 @@ export function ParentDashboard({
     && localStorage.getItem(anomalyStorageKey) !== anomalyFingerprint ? anomaly : undefined;
   const anomalyAssignment = visibleAnomaly ? state.routineAssignments.find((assignment) => assignment.routineId === visibleAnomaly.routineId) : undefined;
   const recommendedPlan = anomalyAssignment ? planningRecommendation(anomalyAssignment, displayEvents, now) : undefined;
-  const weekly = useMemo(() => weeklyInsight(state.routineAssignments, displayEvents, now), [displayEvents, now, state.routineAssignments]);
-  const weeklyPriorityKey: MessageKey | undefined = weekly ? {
-    adjust_schedule: 'weeklyPriorityAdjustSchedule',
-    review_proofs: 'weeklyPriorityReviewProofs',
-    support_consistency: 'weeklyPrioritySupportConsistency',
-    keep_course: 'weeklyPriorityKeepCourse',
-  }[weekly.priority] as MessageKey : undefined;
   const responsibleEmptyState = !state.family.childLinked
     ? { icon: 'link' as const, title: t('responsibleEmptyParticipantNotLinkedTitle'), hint: t('responsibleEmptyParticipantNotLinkedHint') }
     : !state.routineAssignments.length
@@ -263,7 +261,6 @@ export function ParentDashboard({
     setDismissedAnomaly(undefined);
     setPlanningRecommendationOpen(false);
     setPlanningRecommendationStatus(undefined);
-    setWeeklyInsightOpen(false);
   }, [state.activeParticipantId]);
   useEffect(() => {
     if (!notificationEventId) {
@@ -314,7 +311,19 @@ export function ParentDashboard({
       </div>
 
       {showParticipantOverview ? (
-        <MultiParticipantOverview sources={notificationSources} locale={state.locale} range={summaryRange} now={now} onRangeChange={setSummaryRange} onSelectParticipant={selectParticipant} t={t} />
+        <MultiParticipantOverview
+          sources={notificationSources}
+          locale={state.locale}
+          range={summaryRange}
+          now={now}
+          onRangeChange={setSummaryRange}
+          onSelectParticipant={selectParticipant}
+          participantAccess={state.participantAccess}
+          reviewParticipantCheck={reviewParticipantCheck}
+          requestParticipantCheck={requestParticipantCheck}
+          getParticipantProofImageUrl={getParticipantProofImageUrl}
+          t={t}
+        />
       ) : <>
       {setupStep ? (
         <section className="card parent-onboarding-card" aria-labelledby="parent-onboarding-title">
@@ -487,40 +496,6 @@ export function ParentDashboard({
         </section>
       ) : null}
 
-      {state.family.childLinked ? (
-        <section className="card weekly-insight-card" aria-labelledby="weekly-insight-title">
-          <div className="weekly-insight-heading">
-            <div><span className="eyebrow">{t('weeklyInsightEyebrow')}</span><h2 id="weekly-insight-title">{t('weeklyInsightTitle')}</h2></div>
-            <span className="weekly-insight-rate"><strong>{weekly ? `${Math.round(weekly.rate * 100)}%` : '—'}</strong></span>
-            <DisclosureToggle
-              expanded={weeklyInsightOpen}
-              showLabel={t('weeklyInsightShow')}
-              hideLabel={t('weeklyInsightHide')}
-              onToggle={() => setWeeklyInsightOpen((open) => !open)}
-            />
-          </div>
-          {weeklyInsightOpen ? <div className="weekly-insight-content">
-            {weekly && weeklyPriorityKey ? (
-              <>
-                <p className="weekly-insight-evolution">{weekly.rateDelta === undefined
-                  ? t('summaryNoPreviousBaseline')
-                  : weekly.rateDelta === 0
-                    ? t('summaryComparedStable')
-                    : `${t(weekly.rateDelta > 0 ? 'weeklyInsightUp' : 'weeklyInsightDown')} ${Math.abs(Math.round(weekly.rateDelta * 100))} ${t('summaryPoints')}`}</p>
-                <div className="weekly-insight-metrics">
-                  {weekly.strongestRoutineId && weekly.strongestRoutineId !== weekly.watchRoutineId ? <span><small>{t('weeklyInsightStrongest')}</small><strong>{routinePresentationsById.get(weekly.strongestRoutineId)?.name ?? t('routine')}</strong></span> : null}
-                  {weekly.watchRoutineId ? <span><small>{t('weeklyInsightWatch')}</small><strong>{routinePresentationsById.get(weekly.watchRoutineId)?.name ?? t('routine')}</strong></span> : null}
-                  {weekly.bestWindow ? <span><small>{t('weeklyInsightBestWindow')}</small><strong>{weekly.bestWindow.start}–{weekly.bestWindow.end}</strong></span> : null}
-                  <span><small>{t('weeklyInsightResponsibleActions')}</small><strong>{weekly.responsibleActions.length ? weekly.responsibleActions.map((actor) => `${actor.actorName} · ${actor.count}`).join(', ') : weekly.responsibleActionCount}</strong></span>
-                </div>
-                <div className="weekly-insight-priority"><AppIcon name="sparkles" /><p><small>{t('weeklyInsightPriority')}</small><strong>{t(weeklyPriorityKey)}</strong></p></div>
-                <button type="button" onClick={() => { setSummaryRange('week'); setWeeklyReportOpenSignal((current) => current + 1); }}>{t('weeklyInsightOpenReport')}</button>
-              </>
-            ) : <p className="weekly-insight-empty">{t('weeklyInsightEmpty')}</p>}
-          </div> : null}
-        </section>
-      ) : null}
-
       {expandedStatus === 'review' && reviewEvents.length ? (
         <section className="settings-section parent-review-section" aria-labelledby="parent-review-title">
           <div className="section-heading parent-review-heading">
@@ -621,6 +596,17 @@ export function ParentDashboard({
 
       {expandedStatus === 'next' && state.family.childLinked && state.routineAssignments.length && upcomingChecks.length ? (
         <UpcomingChecksSection checks={upcomingChecks} now={nowDate} locale={locale} titleId="responsible-upcoming-checks-title" t={t} />
+      ) : null}
+
+      {state.family.childLinked ? (
+        <WeeklyInsightCard
+          assignments={state.routineAssignments}
+          events={displayEvents}
+          locale={state.locale}
+          now={now}
+          onOpenReport={() => { setSummaryRange('week'); setWeeklyReportOpenSignal((current) => current + 1); }}
+          t={t}
+        />
       ) : null}
 
       {enlargedProof ? (


### PR DESCRIPTION
## Summary
- add the Active, To review, and Next operational blocks to the collective dashboard
- allow collective actions to target the correct participant while restoring the selected participant context
- place operational blocks before the weekly insight in collective and individual dashboards
- share the weekly insight card between both dashboard modes
- bump the application version to 0.11.21

## Validation
- `pnpm check`
- 335 application tests passed
- 131 functions tests passed
- targeted dashboard and participant-context tests passed
- TypeScript, architecture, design, build, and bundle checks passed