### PR TITLE
Hide empty recent history heading

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zadiag-pwa",
   "private": true,
-  "version": "0.11.22",
+  "version": "0.11.23",
   "type": "module",
   "packageManager": "pnpm@11.7.0",
   "engines": {

--- a/src/components/RoutineHistoryPanel.tsx
+++ b/src/components/RoutineHistoryPanel.tsx
@@ -159,11 +159,17 @@ export function RoutineHistoryPanel({
     }
   };
 
+  if (!sortedEvents.length) {
+    return (
+      <section className="routine-history-panel" aria-label={t('recentHistory')}>
+        <EmptyState icon="time" title={t('noHistoryYet')} detail={t('noHistoryYetHint')} />
+      </section>
+    );
+  }
+
   return (
     <section className="routine-history-panel" aria-labelledby={titleId}>
-      {sortedEvents.length ? (
-        <>
-          <section className="card history-filter-card" aria-label={t('historyFilters')}>
+      <section className="card history-filter-card" aria-label={t('historyFilters')}>
             {participants?.length && onToggleParticipant ? (
               <div className="filter-group">
                 <span>{t('filterByParticipant')}</span>
@@ -194,11 +200,11 @@ export function RoutineHistoryPanel({
                 })}
               </div>
             </div>
-          </section>
+      </section>
 
-          <div className="section-heading parent-history-heading"><h2 id={titleId}>{t('recentHistory')}</h2></div>
-          <div className="section-heading history-results-heading"><h2>{t('historyResults')}</h2><span>{filtered.length}</span></div>
-          <div className="history-list parent-history-list">
+        <div className="section-heading parent-history-heading"><h2 id={titleId}>{t('recentHistory')}</h2></div>
+        <div className="section-heading history-results-heading"><h2>{t('historyResults')}</h2><span>{filtered.length}</span></div>
+      <div className="history-list parent-history-list">
             {filtered.map((event) => {
               const visual = presentationFor(event);
               const participantColor = colorForEvent?.(event);
@@ -258,14 +264,7 @@ export function RoutineHistoryPanel({
               );
             })}
             {!filtered.length && <p className="empty-state">{t('noHistoryMatches')}</p>}
-          </div>
-        </>
-      ) : (
-        <>
-          <div className="section-heading parent-history-heading"><h2 id={titleId}>{t('recentHistory')}</h2></div>
-          <EmptyState icon="time" title={t('noHistoryYet')} detail={t('noHistoryYetHint')} />
-        </>
-      )}
+      </div>
     </section>
   );
 }

--- a/src/screens/ParentDashboard.test.tsx
+++ b/src/screens/ParentDashboard.test.tsx
@@ -498,6 +498,7 @@ describe('ParentDashboard', () => {
     expect(container.querySelectorAll('.responsible-state-card')).toHaveLength(1);
     expect(container.querySelector('.weekly-insight-card')).not.toBeNull();
     expect(container.textContent).toContain('No history yet');
+    expect(container.textContent).not.toContain('Recent history');
     expect(container.textContent).not.toContain('StatusAll');
     act(() => Array.from(container.querySelectorAll('button')).find((button) => button.textContent === 'Choose a routine')?.dispatchEvent(new MouseEvent('click', { bubbles: true })));
     expect(openRoutines).toHaveBeenCalled();


### PR DESCRIPTION
## Summary
- hide the Recent history heading when there are no history results
- preserve the dedicated empty-state message for context and accessibility
- bump the application version to 0.11.23

## Validation
- ParentDashboard tests passed (24)
- TypeScript passed
- design check passed
- diff check passed
- full verification delegated to the required GitHub check after the local combined process was terminated by the environment with code 143