### PR TITLE
Remove redundant recent history heading

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zadiag-pwa",
   "private": true,
-  "version": "0.11.23",
+  "version": "0.11.24",
   "type": "module",
   "packageManager": "pnpm@11.7.0",
   "engines": {

--- a/src/components/RoutineHistoryPanel.tsx
+++ b/src/components/RoutineHistoryPanel.tsx
@@ -168,7 +168,7 @@ export function RoutineHistoryPanel({
   }
 
   return (
-    <section className="routine-history-panel" aria-labelledby={titleId}>
+    <section className="routine-history-panel" aria-label={t('recentHistory')}>
       <section className="card history-filter-card" aria-label={t('historyFilters')}>
             {participants?.length && onToggleParticipant ? (
               <div className="filter-group">
@@ -202,7 +202,6 @@ export function RoutineHistoryPanel({
             </div>
       </section>
 
-        <div className="section-heading parent-history-heading"><h2 id={titleId}>{t('recentHistory')}</h2></div>
         <div className="section-heading history-results-heading"><h2>{t('historyResults')}</h2><span>{filtered.length}</span></div>
       <div className="history-list parent-history-list">
             {filtered.map((event) => {

--- a/src/screens/ParentDashboard.test.tsx
+++ b/src/screens/ParentDashboard.test.tsx
@@ -58,7 +58,8 @@ describe('ParentDashboard', () => {
     expect(setupSteps[1]?.classList.contains('active')).toBe(true);
     expect(container.textContent).toContain('Participant phone not linked');
     expect(container.textContent).toContain('Participant linking code');
-    expect(container.textContent).toContain('Recent history');
+    expect(container.textContent).not.toContain('Recent history');
+    expect(container.textContent).toContain('Results');
     expect(container.textContent).toContain('Status');
     expect(container.textContent).not.toContain('StatusAll');
     expect(container.textContent).not.toContain('Monitoring plan');
@@ -67,14 +68,14 @@ describe('ParentDashboard', () => {
     const operationalCards = container.querySelector('.parent-onboarding-card');
     const summaryCard = coreDashboard?.querySelector('.adherence-summary-card');
     const filterCard = coreDashboard?.querySelector('.history-filter-card');
-    const historyHeading = coreDashboard?.querySelector('.parent-history-heading');
+    const resultsHeading = coreDashboard?.querySelector('.history-results-heading');
     expect(summaryCard).not.toBeNull();
     expect(filterCard).not.toBeNull();
-    expect(historyHeading).not.toBeNull();
+    expect(resultsHeading).not.toBeNull();
     expect(operationalCards).not.toBeNull();
     expect(Boolean(operationalCards!.compareDocumentPosition(coreDashboard!) & Node.DOCUMENT_POSITION_FOLLOWING)).toBe(true);
     expect(Boolean(summaryCard!.compareDocumentPosition(filterCard!) & Node.DOCUMENT_POSITION_FOLLOWING)).toBe(true);
-    expect(Boolean(filterCard!.compareDocumentPosition(historyHeading!) & Node.DOCUMENT_POSITION_FOLLOWING)).toBe(true);
+    expect(Boolean(filterCard!.compareDocumentPosition(resultsHeading!) & Node.DOCUMENT_POSITION_FOLLOWING)).toBe(true);
     const detailedReport = container.querySelector<HTMLDetailsElement>('.detailed-reporting');
     expect(detailedReport?.open).toBe(false);
     expect(detailedReport?.querySelector('summary')?.textContent).toBe('Detailed report');

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -770,7 +770,6 @@ button:disabled { cursor: not-allowed; }
 .parent-empty-history-card > .settings-row-icon { width: 42px; height: 42px; display: grid; place-items: center; border-radius: 13px; background: #e9f5f2; color: var(--color-primary); box-shadow: inset 0 1px rgba(255,255,255,.8); }
 .parent-empty-history-card > .app-icon,
 .parent-empty-history-card > .settings-row-icon { font-size: 24px; }
-.parent-history-heading { margin-top: 0; margin-bottom: 0; }
 .parent-empty-history-card { display: grid; grid-template-columns: 42px minmax(0, 1fr); align-items: center; gap: 12px; padding: var(--row-padding-y) var(--row-padding-x); }
 .parent-empty-history-card h2 { font-size: 16px; }
 .parent-empty-history-card p { margin: 3px 0 0; font-size: 12px; line-height: 1.35; }


### PR DESCRIPTION
## Summary
- remove the redundant Recent history heading above dashboard results
- keep Results and its count as the single list heading
- remove the superseded heading style
- bump the application version to 0.11.24

## Validation
- ParentDashboard tests passed (24)
- TypeScript passed
- design check passed
- diff check passed