### PR TITLE
Keep collective participant filters available

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zadiag-pwa",
   "private": true,
-  "version": "0.11.25",
+  "version": "0.11.26",
   "type": "module",
   "packageManager": "pnpm@11.7.0",
   "engines": {

--- a/src/components/RoutineHistoryPanel.tsx
+++ b/src/components/RoutineHistoryPanel.tsx
@@ -208,7 +208,7 @@ export function RoutineHistoryPanel({
     }
   };
 
-  if (!sortedEvents.length) {
+  if (!sortedEvents.length && !participants?.length) {
     return (
       <section className="routine-history-panel" aria-label={t('recentHistory')}>
         <EmptyState icon="time" title={t('noHistoryYet')} detail={t('noHistoryYetHint')} />

--- a/src/screens/ParentDashboard.test.tsx
+++ b/src/screens/ParentDashboard.test.tsx
@@ -189,8 +189,20 @@ describe('ParentDashboard', () => {
     expect(container.querySelectorAll('.parent-history-row')).toHaveLength(2);
     expect(container.querySelector('.progress-ring')?.textContent).toBe('50%');
 
+    const mayaFilter = Array.from(container.querySelectorAll<HTMLButtonElement>('.participant-history-filter-card button'))
+      .find((button) => button.textContent === 'Maya');
+    act(() => mayaFilter?.click());
+    expect(container.querySelector('.participant-history-filter-card')).not.toBeNull();
+    expect(Array.from(container.querySelectorAll<HTMLButtonElement>('.participant-filter-chip')).every((button) => button.getAttribute('aria-pressed') === 'false')).toBe(true);
+    expect(container.querySelectorAll('.parent-history-row')).toHaveLength(0);
+    expect(container.querySelector('.history-results-heading span')?.textContent).toBe('0');
+
+    act(() => leoFilter?.click());
+    expect(container.querySelector('.participant-history-filter-card')).not.toBeNull();
+    expect(container.querySelectorAll('.parent-history-row')).toHaveLength(1);
+
     act(() => container.querySelector<HTMLButtonElement>('.history-row-open-button')?.click());
-    expect(selectParticipant).toHaveBeenCalledWith('maya');
+    expect(selectParticipant).toHaveBeenCalledWith('leo');
   });
 
   it('requests a collective active check for its owning participant', async () => {


### PR DESCRIPTION
## Summary
- keep the collective participant filter card visible when every participant is deselected
- show all participant chips in their inactive state and keep the result count at zero
- allow any participant to be selected again without leaving or refreshing the collective dashboard
- add a regression test covering deselect-all and reselect
- bump the application version to 0.11.26

## Validation
- ParentDashboard tests passed (24)
- TypeScript passed
- design check passed
- diff check passed
- full GitHub verification required before merge because the combined local check was terminated by the environment with code 143