### PR TITLE
Compact weekly insight card

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zadiag-pwa",
   "private": true,
-  "version": "0.11.27",
+  "version": "0.11.28",
   "type": "module",
   "packageManager": "pnpm@11.7.0",
   "engines": {

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -962,11 +962,11 @@ button:disabled { cursor: not-allowed; }
 .planning-recommendation > button { justify-self: start; min-height: var(--height-action); padding: 8px 12px; border: 0; border-radius: 12px; background: var(--color-primary); color: var(--color-surface-solid); font-size: 11px; font-weight: 850; }
 .planning-recommendation .request-feedback { margin: 0; }
 .weekly-insight-card { padding: 0; }
-.weekly-insight-heading { display: grid; grid-template-columns: minmax(0, 1fr) auto auto; align-items: start; gap: 7px; padding: 8px var(--block-padding-sm); }
-.weekly-insight-heading .eyebrow { padding: 0; background: transparent; color: var(--color-primary); font-size: 10px; }
-.weekly-insight-heading h2 { margin: 2px 0 0; font-size: 15px; line-height: 1.15; }
-.weekly-insight-rate { flex: 0 0 auto; display: flex; min-height: 32px; align-items: center; color: var(--color-primary); }
-.weekly-insight-rate strong { font-size: 20px; line-height: 1; }
+.weekly-insight-heading { display: grid; grid-template-columns: minmax(0, 1fr) auto auto; align-items: center; gap: 7px; padding: 5px var(--block-padding-sm); }
+.weekly-insight-heading .eyebrow { padding: 0; background: transparent; color: var(--color-primary); font-size: 9px; line-height: 1; }
+.weekly-insight-heading h2 { margin: 1px 0 0; font-size: 13px; line-height: 1.1; }
+.weekly-insight-rate { flex: 0 0 auto; display: flex; min-height: 28px; align-items: center; color: var(--color-primary); }
+.weekly-insight-rate strong { font-size: 18px; line-height: 1; }
 .weekly-insight-content { display: grid; gap: 10px; padding: 0 var(--block-padding) var(--block-padding); }
 .weekly-insight-empty { margin: 0; color: var(--color-text-muted); }
 .weekly-insight-evolution { margin: 0; color: var(--color-text-muted); font-size: 12px; font-weight: 750; }


### PR DESCRIPTION
## What changed
- Reduce the weekly insight title, eyebrow, and completion-rate typography.
- Tighten the heading’s vertical padding and alignment while preserving the existing disclosure control size.
- Bump the application version to 0.11.28.

## Why
The collapsed “La semaine en un coup d’œil” card occupied more vertical space than needed, especially when the French title wrapped on narrow screens.

## Impact
The weekly summary remains fully accessible and behaves identically, but its collapsed header is shorter and visually lighter. Other disclosure cards are unchanged.

## Validation
- `./node_modules/.bin/vitest run src/screens/ParentDashboard.test.tsx` (24 tests)
- `npm run check:design`
- `corepack pnpm check` (335 frontend tests, 131 backend tests, production build, architecture and bundle checks)
- `git diff --check`