### PR TITLE
Prioritize actionable history cards

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zadiag-pwa",
   "private": true,
-  "version": "0.11.28",
+  "version": "0.11.29",
   "type": "module",
   "packageManager": "pnpm@11.7.0",
   "engines": {

--- a/src/components/RoutineHistoryPanel.test.ts
+++ b/src/components/RoutineHistoryPanel.test.ts
@@ -1,11 +1,47 @@
 import { describe, expect, it } from 'vitest';
-import { groupedVerificationStatuses } from './RoutineHistoryPanel';
+import type { VerificationEvent, VerificationStatus } from '../domain/models';
+import { compareHistoryEvents, groupedVerificationStatuses } from './RoutineHistoryPanel';
+
+const event = (id: string, status: VerificationStatus, requestedAt: string): VerificationEvent => ({
+  id,
+  routineId: 'routine',
+  sessionId: id,
+  requestedAt,
+  expiresAt: requestedAt,
+  status,
+});
 
 describe('groupedVerificationStatuses', () => {
   it('offers one validated filter for photo and structured-response successes', () => {
     expect(groupedVerificationStatuses(['detected', 'answered', 'missed'])).toEqual([
       { status: 'detected', eventStatuses: ['detected', 'answered'] },
       { status: 'missed', eventStatuses: ['missed'] },
+    ]);
+  });
+
+  it('puts items to review or follow before completed and exceeded items', () => {
+    const older = '2026-07-25T08:00:00.000Z';
+    const newer = '2026-07-26T08:00:00.000Z';
+    const events = [
+      event('expired', 'expired', newer),
+      event('validated', 'detected', newer),
+      event('pending', 'pending', older),
+      event('review', 'uncertain', older),
+      event('missed', 'missed', newer),
+      event('analyzing', 'analyzing', newer),
+      event('rejected', 'not_detected', newer),
+      event('answered', 'answered', older),
+    ];
+
+    expect(events.sort(compareHistoryEvents).map(({ id }) => id)).toEqual([
+      'rejected',
+      'review',
+      'analyzing',
+      'pending',
+      'validated',
+      'answered',
+      'expired',
+      'missed',
     ]);
   });
 });

--- a/src/components/RoutineHistoryPanel.tsx
+++ b/src/components/RoutineHistoryPanel.tsx
@@ -13,6 +13,21 @@ import { languageTag } from '../services/locale';
 const eventTimestamp = (event: VerificationEvent) =>
   Date.parse(event.submittedAt ?? event.capturedAt ?? event.requestedAt);
 
+const historyStatusPriority: Record<VerificationStatus, number> = {
+  uncertain: 0,
+  not_detected: 0,
+  pending: 1,
+  analyzing: 1,
+  detected: 2,
+  answered: 2,
+  missed: 3,
+  expired: 3,
+};
+
+export const compareHistoryEvents = (left: VerificationEvent, right: VerificationEvent) =>
+  historyStatusPriority[left.status] - historyStatusPriority[right.status]
+  || eventTimestamp(right) - eventTimestamp(left);
+
 const hiddenReasonCodes = new Set(['analysis_unavailable', 'self_validated']);
 
 const displayReason = (reason?: string) =>
@@ -169,7 +184,7 @@ export function RoutineHistoryPanel({
     presentRoutine(assignment.routine, locale),
   ])), [assignments, locale]);
   const sortedEvents = useMemo(
-    () => [...displayEvents].sort((a, b) => eventTimestamp(b) - eventTimestamp(a)),
+    () => [...displayEvents].sort(compareHistoryEvents),
     [displayEvents],
   );
   const latestMissedEventIds = useMemo(() => {


### PR DESCRIPTION
## Summary
- sort history cards by operational priority before chronology
- show review-required items first, followed by pending and analyzing items
- place completed items after active follow-up work and expired or missed items last
- preserve newest-first ordering within each priority group
- add focused coverage for every verification status
- bump the application version to 0.11.29

## Validation
- `npm run check`
- 336 frontend tests passed
- production build and bundle checks passed
- architecture and design checks passed
- functions test suites passed